### PR TITLE
WIP Timed

### DIFF
--- a/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
+++ b/ouroboros-consensus-test/src/Test/ThreadNet/Network.hs
@@ -953,7 +953,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             ledgerState <$> ChainDB.getCurrentLedger chainDB
         , hfbtLedgerConfig   = configLedger pInfoConfig
         , hfbtRegistry       = registry
-        , hfbtSystemTime     = OracularClock.finiteSystemTime clock
+        , hfbtSystemTime     = systemTime
         , hfbtTracer         =
             contramap
               -- We don't really have a SystemStart in the tests
@@ -968,6 +968,7 @@ runThreadNetwork systemTime ThreadNetworkArgs
             { tracers
             , registry
             , cfg                     = pInfoConfig
+            , systemTime
             , btime
             , chainDB
             , initChainDB             = nodeInitChainDB

--- a/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
+++ b/ouroboros-consensus-test/test-consensus/Test/Consensus/MiniProtocol/ChainSync/Client.hs
@@ -285,7 +285,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
               WithFingerprint (const Nothing) (Fingerprint 0)
           }
 
-        client :: StrictTVar m (AnchoredFragment (Header TestBlock))
+        client :: StrictTVar m (AnchoredFragment (Timed (Header TestBlock)))
                -> Consensus ChainSyncClientPipelined
                     TestBlock
                     m
@@ -293,6 +293,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
                    (pipelineDecisionLowHighMark 10 20)
                    chainSyncTracer
                    nodeCfg
+                   (LogicalClock.mockSystemTime clock)
                    chainDbView
                    maxBound
                    (return Continue)
@@ -380,7 +381,7 @@ runChainSync securityParam (ClientUpdates clientUpdates)
       mbResult      <- readTVar varClientResult
       return ChainSyncOutcome {
           finalServerChain = testHeader <$> finalServerChain
-        , syncedFragment   = AF.mapAnchoredFragment testHeader candidateFragment
+        , syncedFragment   = AF.mapAnchoredFragment (testHeader . getTimed) candidateFragment
         , ..
         }
   where

--- a/ouroboros-consensus/ouroboros-consensus.cabal
+++ b/ouroboros-consensus/ouroboros-consensus.cabal
@@ -38,6 +38,7 @@ library
                        Ouroboros.Consensus.Block.NestedContent
                        Ouroboros.Consensus.Block.RealPoint
                        Ouroboros.Consensus.Block.SupportsProtocol
+                       Ouroboros.Consensus.Block.Timed
                        Ouroboros.Consensus.BlockchainTime
                        Ouroboros.Consensus.BlockchainTime.API
                        Ouroboros.Consensus.BlockchainTime.WallClock.Default

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block.hs
@@ -9,3 +9,4 @@ import           Ouroboros.Consensus.Block.Forging as X
 import           Ouroboros.Consensus.Block.NestedContent as X
 import           Ouroboros.Consensus.Block.RealPoint as X
 import           Ouroboros.Consensus.Block.SupportsProtocol as X
+import           Ouroboros.Consensus.Block.Timed as X

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Block/Timed.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Block/Timed.hs
@@ -1,0 +1,49 @@
+{-# LANGUAGE DeriveAnyClass        #-}
+{-# LANGUAGE DeriveFunctor         #-}
+{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE TypeFamilies          #-}
+module Ouroboros.Consensus.Block.Timed (
+    Timed (..)
+  , TimeReceived (..)
+  ) where
+
+import           GHC.Generics (Generic)
+import           NoThunks.Class (NoThunks)
+
+import           Ouroboros.Network.Block
+import           Ouroboros.Network.ReceiveDelay
+
+import           Ouroboros.Consensus.BlockchainTime.WallClock.Types
+
+data TimeReceived =
+    ReceivedAt !RelativeTime
+  | ReadFromDisk
+  deriving (Show, Eq, Generic, NoThunks)
+
+-- | A block or header together with time-related information.
+data Timed a = Timed {
+      getTimed     :: !a
+      -- | The time at which the block or header was forged. I.e., the time
+      -- corresponding to the slot.
+      --
+      -- NOTE: because of hard forks, converting a slot to a time is not so
+      -- simple. As the slot length can change with each hard fork
+    , timeProduced :: !RelativeTime
+    , timeReceived :: !TimeReceived
+    }
+  deriving (Show, Eq, Functor, Generic, NoThunks)
+
+type instance HeaderHash (Timed a) = HeaderHash a
+
+instance StandardHash a => StandardHash (Timed a)
+
+instance HasHeader a => HasHeader (Timed a) where
+  getHeaderFields = castHeaderFields . getHeaderFields . getTimed
+
+instance HasReceiveDelay (Timed a) where
+  receiveDelay Timed { timeProduced, timeReceived } =
+      case timeReceived of
+        ReadFromDisk          -> Nothing
+        ReceivedAt receivedAt -> Just $ receivedAt `diffRelTime` timeProduced

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Network/NodeToNode.hs
@@ -101,7 +101,7 @@ data Handlers m peer blk = Handlers {
       hChainSyncClient
         :: NodeToNodeVersion
         -> ControlMessageSTM m
-        -> StrictTVar m (AnchoredFragment (Header blk))
+        -> StrictTVar m (AnchoredFragment (Timed (Header blk)))
         -> ChainSyncClientPipelined (Header blk) (Point blk) (Tip blk) m ChainSyncClientResult
         -- TODO: we should consider either bundling these context parameters
         -- into a record, or extending the protocol handler representation
@@ -162,7 +162,7 @@ mkHandlers
   -> NodeKernel     m remotePeer localPeer blk
   -> Handlers       m remotePeer           blk
 mkHandlers
-      NodeKernelArgs {keepAliveRng, miniProtocolParameters}
+      NodeKernelArgs {keepAliveRng, miniProtocolParameters, systemTime}
       NodeKernel {getChainDB, getMempool, getTopLevelConfig, getTracers = tracers} =
     Handlers {
         hChainSyncClient =
@@ -172,6 +172,7 @@ mkHandlers
               (chainSyncPipeliningHighMark miniProtocolParameters))
             (Node.chainSyncClientTracer tracers)
             getTopLevelConfig
+            systemTime
             (defaultChainDbView getChainDB)
       , hChainSyncServer =
           chainSyncHeadersServer

--- a/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
+++ b/ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
@@ -285,6 +285,7 @@ runWith RunNodeArgs{..} LowLevelRunNodeArgs{..} =
             cfg
             blockForging
             rnTraceConsensus
+            systemTime
             btime
             chainDB
       nodeKernel <- initNodeKernel nodeKernelArgs
@@ -477,6 +478,7 @@ mkNodeKernelArgs
   -> TopLevelConfig blk
   -> m [BlockForging m blk]
   -> Tracers m (ConnectionId addrNTN) (ConnectionId addrNTC) blk
+  -> SystemTime m
   -> BlockchainTime m
   -> ChainDB m blk
   -> m (NodeKernelArgs m (ConnectionId addrNTN) (ConnectionId addrNTC) blk)
@@ -487,6 +489,7 @@ mkNodeKernelArgs
   cfg
   initBlockForging
   tracers
+  systemTime
   btime
   chainDB
   = do
@@ -495,6 +498,7 @@ mkNodeKernelArgs
       { tracers
       , registry
       , cfg
+      , systemTime
       , btime
       , chainDB
       , blockForging

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -60,6 +60,7 @@ library
                        Ouroboros.Network.NodeToNode.Version
                        Ouroboros.Network.NodeToClient
                        Ouroboros.Network.NodeToClient.Version
+                       Ouroboros.Network.ReceiveDelay
                        Ouroboros.Network.Tracers
                        Ouroboros.Network.Point
                        Ouroboros.Network.PeerSelection.Types
@@ -152,6 +153,7 @@ library
                        serialise         >=0.2 && <0.3,
                        random,
                        stm               >=2.4 && <2.6,
+                       time              >=1.6 && <1.11,
 
                        cardano-binary,
                        cardano-prelude,

--- a/ouroboros-network/src/Ouroboros/Network/ReceiveDelay.hs
+++ b/ouroboros-network/src/Ouroboros/Network/ReceiveDelay.hs
@@ -1,0 +1,16 @@
+module Ouroboros.Network.ReceiveDelay (
+    HasReceiveDelay (..)
+  ) where
+
+import           Data.Time (NominalDiffTime)
+
+class HasReceiveDelay a where
+  -- | The time between production and reception via the network.
+  --
+  -- For example, the difference between the time at which a block was produced
+  -- (derived from its slot number) and the time at which we received the block
+  -- or its header via the network.
+  --
+  -- When a block or header was read from disk and we no longer know when we
+  -- received it over the network, 'Nothing' is returned.
+  receiveDelay :: a -> Maybe NominalDiffTime


### PR DESCRIPTION
Fixes #2801.

Rough plan:

* `HasReceiveDelay` class in the network layer: this is what the network team
  will use to get the `receiveDelay` of a header.
* `Timed` data type (better name welcome) in consensus implementing this class.
* The ChainSyncClient will track candidates containing `Timed (Header blk)`.
  Its candidate map is exposed to the network layer.