### PR TITLE
Add the eval-time GC roots to release.nix so they're cached.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,6 +59,10 @@ let
       inherit pkgs;
       withHoogle = true;
     };
+
+    # so that eval time gc roots are cached (nix-tools stuff)
+    inherit (ouroborosNetworkHaskellPackages) roots;
+    inherit (haskellPackages.ouroboros-network.project) plan-nix;
   };
 in
 self

--- a/release.nix
+++ b/release.nix
@@ -77,7 +77,7 @@ let
       # as well as exes:
       exesPaths = path: [ ([ "exes" ] ++ path) ([ "haskellPackages" (head path) "components" "exes" ] ++ (tail path)) ];
     in
-    [ [ "shell" ] ]
+    [ [ "shell" ] [ "roots" ] ]
     ++ (optionals (!withProblematicWindowsTests) (
       (checksPaths [ "ouroboros-network" "test" ])
       ++ (checksPaths [ "Win32-network" "test" ])


### PR DESCRIPTION
 Otherwise they'll get GCd very quickly, which means people will need to
 build a lot to even open the shell.