### PR TITLE
Enable nothunk tests by setting check-tvar-invariant flag for strict-stm

### DIFF
--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - yogeshs/3001-check-tvar-invariant
 
 
 jobs:

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -1,0 +1,39 @@
+name: Stricct NoThunk test
+on:
+  push:
+    branches:
+      - master
+
+
+jobs:
+  build-test:
+    name: "Build and Test with Strict Check TVar Invariant Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.3.1
+        with:
+          repository: input-output-hk/ouroboros-network
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Prepare nix
+        uses: cachix/install-nix-action@v17
+        with:
+          extra_nix_config: |
+            trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+            substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
+      - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2.1.5
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: |
+            cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
+          restore-keys: |
+            cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
+
+      - name: "Build and Test"
+        run: |
+          nix-build -A tvar-invariant-checks.tests

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -1,8 +1,9 @@
-name: Strict NoThunk test
+name: Strict nothunk test
 on:
   push:
     branches:
       - master
+      # Comment out this and also add schedules
       - yogeshs/3001-check-tvar-invariant
 
 
@@ -11,9 +12,11 @@ jobs:
     name: "Build and Test with Strict Check TVar Invariant Check"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2.3.1
+      - uses: actions/checkout@v3
         with:
           repository: input-output-hk/ouroboros-network
+          # Run on the pull request or the current branch
+          # TODO: Yogesh: Remove this once PR is approved as this action would run on the default branch
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
@@ -21,20 +24,8 @@ jobs:
         uses: cachix/install-nix-action@v17
         with:
           extra_nix_config: |
-            trusted-public-keys = iohk.cachix.org-1:DpRUyj7h7V830dp/i6Nti+NEO2/nhblbov/8MW7Rqoo= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-            substituters = https://cache.nixos.org https://hydra.iohk.io https://iohk.cachix.org
-      - name: Github cache ~/.cabal/packages, ~/.cabal/store and dist-newstyle
-        uses: actions/cache@v2.1.5
-        with:
-          path: |
-            ~/.cabal/packages
-            ~/.cabal/store
-            dist-newstyle
-          key: |
-            cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
-          restore-keys: |
-            cabal-${{ runner.os }}-${{ hashFiles('cabal.project', 'default.nix', 'shell.nix') }}
-
+            trusted-public-keys =  cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.nixos.org https://cache.iog.io https://iohk.cachix.org
       - name: "Build and Test"
         run: |
-          nix-build -A tvar-invariant-checks.tests
+          nix-build -A tvar-invariant-checks.tests --keep-going

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -1,11 +1,12 @@
 name: Strict nothunk test
 on:
+  schedule:
+    # Run the test every Wednesday at midnight
+    - cron: "0 0 * * 3"
   push:
     branches:
-      - master
-      # Comment out this and also add schedules
+      # TODO: Yogesh: For testing only, remove this before the merge
       - yogeshs/3001-check-tvar-invariant
-
 
 jobs:
   build-test:

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -3,10 +3,6 @@ on:
   schedule:
     # Run the test every Wednesday at midnight
     - cron: "0 0 * * 3"
-  push:
-    branches:
-      # TODO: Yogesh: For testing only, remove this before the merge
-      - yogeshs/3001-check-tvar-invariant
 
 jobs:
   build-test:
@@ -16,9 +12,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           repository: input-output-hk/ouroboros-network
-          # Run on the pull request or the current branch
-          # TODO: Yogesh: Remove this once PR is approved as this action would run on the default branch
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
           fetch-depth: 0
 
       - name: Prepare nix

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -1,4 +1,4 @@
-name: Stricct NoThunk test
+name: Strict NoThunk test
 on:
   push:
     branches:

--- a/.github/workflows/check-invariant-test.yml
+++ b/.github/workflows/check-invariant-test.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           extra_nix_config: |
             trusted-public-keys =  cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-            substituters = https://cache.nixos.org https://cache.iog.io https://iohk.cachix.org
+            substituters = https://cache.nixos.org https://cache.iog.io
       - name: "Build and Test"
         run: |
           nix-build -A tvar-invariant-checks.tests --keep-going

--- a/default.nix
+++ b/default.nix
@@ -68,9 +68,9 @@ let
         haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
     };
 
-    tvar-invariant-checks = {
+    tvar-invariant-checks = recurseIntoAttrs {
       inherit haskellPackagesWithTVarCheck;
-      tests = collectComponents' "tests" haskellPackagesWithTVarCheck;
+      tests = collectChecks' haskellPackagesWithTVarCheck;
     };
 
     shell = import ./shell.nix {

--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,9 @@ let
 
   coveredProject = ouroborosNetworkHaskellPackages.appendModule { coverage = true; };
 
+  haskellPackagesWithTVarCheck = recRecurseIntoAttrs
+    (selectProjectPackages ouroborosNetworkHaskellPackagesWithTVarCheck);
+
   validate-mainnet = import ./nix/validate-mainnet.nix {
     inherit pkgs;
     byron-db-converter =
@@ -63,6 +66,11 @@ let
         haskellPackages.ouroboros-consensus-cardano-test.components.tests.test;
       Shelley =
         haskellPackages.ouroboros-consensus-shelley-test.components.tests.test;
+    };
+
+    tvar-invariant-checks = {
+      inherit haskellPackagesWithTVarCheck;
+      tests = collectComponents' "tests" haskellPackagesWithTVarCheck;
     };
 
     shell = import ./shell.nix {

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -47,7 +47,7 @@ let
       }
       {   
         packages.strict-stm.components.library.configureFlags =
-          lib.mkForce (if checkTVarInvariant then ["-f checktvarinvariant"] else []);
+          lib.mkIf checkTVarInvariant (lib.mkForce ["-f checktvarinvariant"]);
       }
       {
         # Apply profiling arg to all library components in the build:

--- a/nix/ouroboros-network.nix
+++ b/nix/ouroboros-network.nix
@@ -4,7 +4,9 @@
 { lib, stdenv, pkgs, haskell-nix, buildPackages, config ? { }
   # Enable profiling
 , profiling ? config.haskellNix.profiling or false
-, libsodium-vrf ? pkgs.libsodium-vrf }:
+, libsodium-vrf ? pkgs.libsodium-vrf 
+  # Enable strict TVar invariant check flag in strict-stm
+, checkTVarInvariant ? false }:
 let
   compiler-nix-name = pkgs.localConfig.ghcVersion;
   src = haskell-nix.haskellLib.cleanGit {
@@ -42,6 +44,10 @@ let
           # and test suites.
           doCoverage = config.coverage;
         });
+      }
+      {   
+        packages.strict-stm.components.library.configureFlags =
+          lib.mkForce (if checkTVarInvariant then ["-f checktvarinvariant"] else []);
       }
       {
         # Apply profiling arg to all library components in the build:

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -5,6 +5,11 @@ with pkgs; {
     inherit config pkgs lib stdenv haskell-nix buildPackages;
   };
 
+  ouroborosNetworkHaskellPackagesWithTVarCheck = import ./ouroboros-network.nix {
+    inherit config pkgs lib stdenv haskell-nix buildPackages;
+    checkTVarInvariant = true;
+  };
+
   network-docs = callPackage ./network-docs.nix { };
   consensus-docs = callPackage ./consensus-docs.nix { };
 


### PR DESCRIPTION
# Description

* Add a flag checkTVarInvariant to ./nix/ouroboros-network.nix
* `haskellPackagesWithTVarCheck` points to `strict-stm` package with "checktvarinvariant" flag enabled.
* `nix-build -A tvar-invariant-checks.tests` runs the tests with "checktvarinvariant" flag turned on
* Github action "Strict NoThunk Test" should run the tests with above flag turned on

Closes input-output-hk/ouroboros-consensus#604 

# Checklist

- Branch
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If this branch changes Consensus and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../ouroboros-consensus/docs/interface-CHANGELOG.md)
    - [ ] If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
