### PR TITLE
RawBearer API

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Renamed `requestOutboundConnection` to `acquireOutboundConnection` and
   `unregister{Inbound,Outbound}Connection` to `release{Inbound,Outbound}Connection`.
   `AssertionLocation` constructors were renamed as well.
+* Added `RawBearer` API (see https://github.com/IntersectMBO/ouroboros-network/pull/4395)
 
 ### Non-breaking changes
 
@@ -43,6 +44,7 @@
 * `Ouroboros.Network.ConnectionManager.Core` must be imported qualified.
 * `ConnectionManagerTrace` moved from `Ouroboros.Network.ConnectionManager.Types`
   to the `Core` module & renamed as `Trace`.
+* RawBearer API (typeclass and instances) added.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-framework/changelog.d/20230224_094922_tdammers_raw_bearer.rst
+++ b/ouroboros-network-framework/changelog.d/20230224_094922_tdammers_raw_bearer.rst
@@ -1,6 +1,0 @@
-Added
------
-
-- RawBearer API
-- ToRawBearer typeclass
-- ToRawBearer instances for `Socket`, `LocalSocket`, and `Simulation.Network.Snocket.FD`

--- a/ouroboros-network-framework/changelog.d/20230224_094922_tdammers_raw_bearer.rst
+++ b/ouroboros-network-framework/changelog.d/20230224_094922_tdammers_raw_bearer.rst
@@ -1,0 +1,6 @@
+Added
+-----
+
+- RawBearer API
+- ToRawBearer typeclass
+- ToRawBearer instances for `Socket`, `LocalSocket`, and `Simulation.Network.Snocket.FD`

--- a/ouroboros-network-framework/io-tests/Main.hs
+++ b/ouroboros-network-framework/io-tests/Main.hs
@@ -4,6 +4,7 @@ import Main.Utf8 (withUtf8)
 import Test.Tasty
 
 import Test.Ouroboros.Network.Driver qualified as Driver
+import Test.Ouroboros.Network.RawBearer qualified as RawBearer
 import Test.Ouroboros.Network.Server2.IO qualified as Server2
 import Test.Ouroboros.Network.Socket qualified as Socket
 import Test.Ouroboros.Network.Subscription qualified as Subscription
@@ -18,6 +19,7 @@ tests =
   , Server2.tests
   , Socket.tests
   , Subscription.tests
+  , RawBearer.tests
   ]
 
 

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/RawBearer.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE CPP                        #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+module Test.Ouroboros.Network.RawBearer where
+
+import Ouroboros.Network.IOManager
+import Ouroboros.Network.RawBearer
+import Ouroboros.Network.RawBearer.Test.Utils
+import Ouroboros.Network.Snocket
+
+import Control.Concurrent.Class.MonadMVar
+import Control.Monad.Class.MonadThrow (catchJust, finally)
+import Control.Tracer (Tracer (..), nullTracer)
+import Data.Word (Word32)
+import Network.Socket qualified as Socket
+import System.Directory (removeFile)
+import System.IO.Error (ioeGetErrorType, isDoesNotExistErrorType)
+import System.IO.Unsafe
+
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.RawBearer"
+  [ testProperty "raw bearer send receive inet socket" prop_raw_bearer_send_and_receive_inet
+#if !defined(mingw32_HOST_OS)
+  , testProperty "raw bearer send receive local socket" prop_raw_bearer_send_and_receive_local
+  , testProperty "raw bearer send receive unix socket" prop_raw_bearer_send_and_receive_unix
+#endif
+  ]
+
+ioTracer :: Tracer IO String
+ioTracer = nullTracer
+
+{-# NOINLINE nextPort #-}
+nextPort :: MVar IO Int
+nextPort = unsafePerformIO $ newMVar 7000
+
+prop_raw_bearer_send_and_receive_inet :: Message -> Property
+prop_raw_bearer_send_and_receive_inet msg =
+  ioProperty $ withIOManager $ \iomgr -> do
+    serverPort <- modifyMVar nextPort (\i -> return (succ i, succ i))
+    let serverAddr = Socket.SockAddrInet (fromIntegral serverPort) localhost
+    rawBearerSendAndReceive
+      ioTracer
+      (socketSnocket iomgr)
+      makeSocketRawBearer
+      serverAddr
+      Nothing
+      msg
+
+newtype ArbPosInt = ArbPosInt { unArbPosInt :: Int }
+  deriving newtype (Show, Eq, Ord)
+
+instance Arbitrary ArbPosInt where
+  shrink _ = []
+  arbitrary = ArbPosInt . getPositive <$> arbitrary
+
+prop_raw_bearer_send_and_receive_local :: ArbPosInt -> ArbPosInt -> Message -> Property
+prop_raw_bearer_send_and_receive_local serverInt clientInt msg =
+  ioProperty $ withIOManager $ \iomgr -> do
+#if defined(mingw32_HOST_OS)
+    let serverName = "\\\\.\\pipe\\local_socket_server.test" ++ show serverInt
+    let clientName = "\\\\.\\pipe\\local_socket_client.test" ++ show clientInt
+#else
+    let serverName = "local_socket_server.test" ++ show serverInt
+    let clientName = "local_socket_client.test" ++ show clientInt
+#endif
+    cleanUp serverName
+    cleanUp clientName
+    let serverAddr = localAddressFromPath serverName
+    let clientAddr = localAddressFromPath clientName
+    rawBearerSendAndReceive
+      ioTracer
+      (localSnocket iomgr)
+      makeLocalRawBearer
+      serverAddr
+      (Just clientAddr)
+      msg `finally` do
+        cleanUp serverName
+        cleanUp clientName
+  where
+#if defined(mingw32_HOST_OS)
+    cleanUp _ = return ()
+#else
+    cleanUp name = do
+        catchJust (\e -> if isDoesNotExistErrorType (ioeGetErrorType e) then Just () else Nothing)
+                  (removeFile name)
+                  (\_ -> return ())
+#endif
+
+
+localhost :: Word32
+localhost = Socket.tupleToHostAddress (127, 0, 0, 1)
+
+prop_raw_bearer_send_and_receive_unix :: Int -> Int -> Message -> Property
+prop_raw_bearer_send_and_receive_unix serverInt clientInt msg =
+  ioProperty $ withIOManager $ \iomgr -> do
+    let serverName = "unix_socket_server.test"++ show serverInt
+    let clientName = "unix_socket_client.test"++ show clientInt
+    cleanUp serverName
+    cleanUp clientName
+    let serverAddr = Socket.SockAddrUnix serverName
+    let clientAddr = Socket.SockAddrUnix clientName
+    rawBearerSendAndReceive
+      ioTracer
+      (socketSnocket iomgr)
+      makeSocketRawBearer
+      serverAddr
+      (Just clientAddr)
+      msg `finally` do
+        cleanUp serverName
+  where
+    cleanUp name = do
+        catchJust (\e -> if isDoesNotExistErrorType (ioeGetErrorType e) then Just () else Nothing)
+                  (removeFile name)
+                  (\_ -> return ())

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -38,10 +38,10 @@ library
     Ouroboros.Network.Driver.Simple
     Ouroboros.Network.Driver.Stateful
     Ouroboros.Network.ErrorPolicy
-    Ouroboros.Network.IOManager
     Ouroboros.Network.InboundGovernor
     Ouroboros.Network.InboundGovernor.Event
     Ouroboros.Network.InboundGovernor.State
+    Ouroboros.Network.IOManager
     Ouroboros.Network.Mux
     Ouroboros.Network.MuxMode
     Ouroboros.Network.Protocol.Handshake
@@ -51,11 +51,12 @@ library
     Ouroboros.Network.Protocol.Handshake.Type
     Ouroboros.Network.Protocol.Handshake.Unversioned
     Ouroboros.Network.Protocol.Handshake.Version
+    Ouroboros.Network.RawBearer
     Ouroboros.Network.RethrowPolicy
+    Ouroboros.Network.Server2
     Ouroboros.Network.Server.ConnectionTable
     Ouroboros.Network.Server.RateLimiting
     Ouroboros.Network.Server.Socket
-    Ouroboros.Network.Server2
     Ouroboros.Network.Snocket
     Ouroboros.Network.Socket
     Ouroboros.Network.Subscription
@@ -173,15 +174,16 @@ test-suite sim-tests
     Test.Ouroboros.Network.Server2.Sim
     Test.Ouroboros.Network.Socket
     Test.Ouroboros.Network.Subscription
+    Test.Ouroboros.Network.RawBearer
     Test.Simulation.Network.Snocket
 
   build-depends:
-    QuickCheck,
     base >=4.14 && <4.21,
     bytestring,
     cborg,
     containers,
     contra-tracer,
+    directory,
     dns,
     io-classes,
     io-sim,
@@ -189,11 +191,13 @@ test-suite sim-tests
     monoidal-synchronisation,
     network,
     network-mux,
+    ouroboros-network-api,
     ouroboros-network-framework,
     ouroboros-network-framework:testlib,
     ouroboros-network-testing,
     pretty-simple,
     psqueues,
+    QuickCheck,
     quickcheck-instances,
     quickcheck-monoids,
     quiet,

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -38,10 +38,10 @@ library
     Ouroboros.Network.Driver.Simple
     Ouroboros.Network.Driver.Stateful
     Ouroboros.Network.ErrorPolicy
+    Ouroboros.Network.IOManager
     Ouroboros.Network.InboundGovernor
     Ouroboros.Network.InboundGovernor.Event
     Ouroboros.Network.InboundGovernor.State
-    Ouroboros.Network.IOManager
     Ouroboros.Network.Mux
     Ouroboros.Network.MuxMode
     Ouroboros.Network.Protocol.Handshake
@@ -53,10 +53,10 @@ library
     Ouroboros.Network.Protocol.Handshake.Version
     Ouroboros.Network.RawBearer
     Ouroboros.Network.RethrowPolicy
-    Ouroboros.Network.Server2
     Ouroboros.Network.Server.ConnectionTable
     Ouroboros.Network.Server.RateLimiting
     Ouroboros.Network.Server.Socket
+    Ouroboros.Network.Server2
     Ouroboros.Network.Snocket
     Ouroboros.Network.Socket
     Ouroboros.Network.Subscription
@@ -127,6 +127,7 @@ library testlib
     Ouroboros.Network.ConnectionManager.Test.Timeouts
     Ouroboros.Network.ConnectionManager.Test.Utils
     Ouroboros.Network.InboundGovernor.Test.Utils
+    Ouroboros.Network.RawBearer.Test.Utils
     Ouroboros.Network.Test.Orphans
 
   other-modules:
@@ -171,13 +172,14 @@ test-suite sim-tests
   other-modules:
     Test.Ouroboros.Network.ConnectionManager
     Test.Ouroboros.Network.RateLimiting
+    Test.Ouroboros.Network.RawBearer
     Test.Ouroboros.Network.Server2.Sim
     Test.Ouroboros.Network.Socket
     Test.Ouroboros.Network.Subscription
-    Test.Ouroboros.Network.RawBearer
     Test.Simulation.Network.Snocket
 
   build-depends:
+    QuickCheck,
     base >=4.14 && <4.21,
     bytestring,
     cborg,
@@ -191,13 +193,11 @@ test-suite sim-tests
     monoidal-synchronisation,
     network,
     network-mux,
-    ouroboros-network-api,
     ouroboros-network-framework,
     ouroboros-network-framework:testlib,
     ouroboros-network-testing,
     pretty-simple,
     psqueues,
-    QuickCheck,
     quickcheck-instances,
     quickcheck-monoids,
     quiet,
@@ -243,6 +243,7 @@ test-suite io-tests
   hs-source-dirs: io-tests
   other-modules:
     Test.Ouroboros.Network.Driver
+    Test.Ouroboros.Network.RawBearer
     Test.Ouroboros.Network.Server2.IO
     Test.Ouroboros.Network.Socket
     Test.Ouroboros.Network.Subscription
@@ -253,6 +254,7 @@ test-suite io-tests
     bytestring,
     containers,
     contra-tracer,
+    directory,
     dns,
     io-classes,
     io-sim,
@@ -276,9 +278,6 @@ test-suite io-tests
 
   if os(windows)
     build-depends: Win32-network <0.3
-  else
-    build-depends: directory
-
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   ghc-options:

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/RawBearer.hs
@@ -1,0 +1,189 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Ouroboros.Network.RawBearer where
+
+import           Ouroboros.Network.IOManager
+import           Ouroboros.Network.RawBearer
+import           Ouroboros.Network.Snocket
+import           Ouroboros.Network.Testing.Data.AbsBearerInfo
+
+import           Control.Concurrent.Class.MonadMVar
+import           Control.Exception (Exception)
+import           Control.Monad (when)
+import           Control.Monad.Class.MonadAsync
+import           Control.Monad.Class.MonadFork (labelThisThread)
+import           Control.Monad.Class.MonadSay
+import           Control.Monad.Class.MonadST (MonadST, withLiftST)
+import           Control.Monad.Class.MonadThrow (MonadThrow, bracket, catchJust,
+                     finally, throwIO)
+import           Control.Monad.IOSim hiding (liftST)
+import           Control.Monad.ST.Unsafe (unsafeIOToST)
+import           Control.Tracer (nullTracer)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import           Foreign.Marshal (copyBytes, free, mallocBytes)
+import           Foreign.Ptr (castPtr, plusPtr)
+import qualified Network.Socket as Socket
+import           Simulation.Network.Snocket as SimSnocket
+import           System.Directory (removeFile)
+import           System.IO.Error (ioeGetErrorType, isDoesNotExistErrorType)
+
+import           Test.Simulation.Network.Snocket (toBearerInfo)
+import           Test.Tasty
+import           Test.Tasty.QuickCheck
+
+tests :: TestTree
+tests = testGroup "Ouroboros.Network.RawBearer"
+  [ testProperty "raw bearer send receive simulated socket" prop_raw_bearer_send_and_receive_iosim
+  , testProperty "raw bearer send receive unix socket" prop_raw_bearer_send_and_receive_unix
+  ]
+
+prop_raw_bearer_send_and_receive_unix :: Message -> Property
+prop_raw_bearer_send_and_receive_unix msg =
+  ioProperty $ withIOManager $ \iomgr -> do
+    let clientName = "unix_socket_client.test"
+    let serverName = "unix_socket_server.test"
+    cleanUp clientName
+    cleanUp serverName
+    let clientAddr = Socket.SockAddrUnix clientName
+    let serverAddr = Socket.SockAddrUnix serverName
+    rawBearerSendAndReceive
+      (socketSnocket iomgr)
+      clientAddr serverAddr
+      msg `finally` do
+        cleanUp clientName
+        cleanUp serverName
+  where
+    cleanUp name = do
+        catchJust (\e -> if isDoesNotExistErrorType (ioeGetErrorType e) then Just () else Nothing)
+                  (removeFile name)
+                  (\_ -> return ())
+
+prop_raw_bearer_send_and_receive_iosim :: Int -> Int -> Message -> Property
+prop_raw_bearer_send_and_receive_iosim clientInt serverInt msg =
+  (clientInt /= serverInt) ==>
+  iosimProperty $
+    SimSnocket.withSnocket
+      nullTracer
+      (toBearerInfo absNoAttenuation)
+      mempty $ \snocket _observe -> do
+        rawBearerSendAndReceive
+          snocket
+          (TestAddress clientInt)
+          (TestAddress serverInt)
+          msg
+
+newtype Message = Message { messageBytes :: ByteString }
+  deriving (Show, Eq, Ord)
+
+instance Arbitrary Message where
+  shrink = filter (not . BS.null . messageBytes) . fmap (Message . BS.pack) . shrink . BS.unpack . messageBytes
+  arbitrary = Message . BS.pack <$> listOf1 arbitrary
+
+newtype TestError =
+  TestError String
+  deriving (Show)
+
+instance Exception TestError where
+
+rawBearerSendAndReceive :: forall m fd addr
+                         . ( MonadST m
+                           , MonadThrow m
+                           , MonadAsync m
+                           -- , MonadTimer m
+                           , MonadMVar m
+                           , MonadSay m
+                           , ToRawBearer m fd
+                           )
+                        => Snocket m fd addr
+                        -> addr
+                        -> addr
+                        -> Message
+                        -> m Property
+rawBearerSendAndReceive snocket clientAddr serverAddr msg =
+  withLiftST $ \liftST -> do
+    let io = liftST . unsafeIOToST
+    let size = BS.length (messageBytes msg)
+    retVar <- newEmptyMVar
+    senderDone <- newEmptyMVar
+    let sender = bracket (openToConnect snocket clientAddr) (close snocket) $ \s -> do
+                    say "sender: connecting"
+                    connect snocket s serverAddr
+                    say "sender: connected"
+                    bearer <- toRawBearer s
+                    bracket (io $ mallocBytes size) (io . free) $ \srcBuf -> do
+                      io $ BS.useAsCStringLen (messageBytes msg)
+                            (uncurry (copyBytes srcBuf))
+                      let go _ 0 = do
+                            say "sender: done"
+                            return ()
+                          go buf n = do
+                            say $ "sender: " ++ show n ++ " bytes left"
+                            bytesSent <- send bearer buf n
+                            when (bytesSent == 0) (throwIO $ TestError "sender: premature hangup")
+                            let n' = n - bytesSent
+                            say $ "sender: " ++ show bytesSent ++ " bytes sent, " ++ show n' ++ " remaining"
+                            go (plusPtr buf bytesSent) n'
+                      go (castPtr srcBuf) size
+                      putMVar senderDone ()
+        receiver s = do
+          let acceptLoop :: Accept m fd addr -> m ()
+              acceptLoop accept0 = do
+                say "receiver: accepting connection"
+                (accepted, acceptNext) <- runAccept accept0
+                case accepted :: Accepted fd addr of
+                  AcceptFailure err ->
+                    throwIO err
+                  Accepted s' _ -> do
+                    labelThisThread "accept"
+                    say "receiver: connection accepted"
+                    flip finally (say "receiver: closing connection" >> close snocket s' >> say "receiver: connection closed") $ do
+                      bearer <- toRawBearer s'
+                      retval <- bracket (io $ mallocBytes size) (io . free) $ \dstBuf -> do
+                        let go _ 0 = do
+                              say "receiver: done receiving"
+                              return ()
+                            go buf n = do
+                              say $ "receiver: " ++ show n ++ " bytes left"
+                              bytesReceived <- recv bearer buf n
+                              when (bytesReceived == 0) (throwIO $ TestError "receiver: premature hangup")
+                              let n' = n - bytesReceived
+                              say $ "receiver: " ++ show bytesReceived ++ " bytes received, " ++ show n' ++ " remaining"
+                              go (plusPtr buf bytesReceived) n'
+                        go (castPtr dstBuf) size
+                        io (BS.packCStringLen (castPtr dstBuf, size))
+                      say $ "receiver: received " ++ show retval
+                      written <- tryPutMVar retVar retval
+                      say $ if written then "receiver: stored " ++ show retval else "receiver: already have result"
+                    say "receiver: finishing connection"
+                    acceptLoop acceptNext
+          accept snocket s >>= acceptLoop
+
+    resBSEither <- bracket (open snocket (addrFamily snocket serverAddr)) (close snocket) $ \s -> do
+      say "receiver: starting"
+      bind snocket s serverAddr
+      listen snocket s
+      say "receiver: listening"
+      race
+        (sender `concurrently` receiver s)
+        (takeMVar retVar <* takeMVar senderDone)
+    return $ resBSEither === Right (messageBytes msg)
+
+iosimProperty :: (forall s . IOSim s Property)
+              -> Property
+iosimProperty sim =
+  let tr = runSimTrace sim
+   in case traceResult True tr of
+     Left e -> counterexample
+                (unlines
+                  [ "=== Say Events ==="
+                  , unlines (selectTraceEventsSay' tr)
+                  , "=== Trace Events ==="
+                  , unlines (show `map` traceEvents tr)
+                  , "=== Error ==="
+                  , show e ++ "\n"
+                  ])
+                False
+     Right prop -> prop
+

--- a/ouroboros-network-framework/src/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/RawBearer.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE CPP                   #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Ouroboros.Network.RawBearer where
+
+import           Data.Word (Word8)
+import           Foreign.Ptr (Ptr)
+import           Network.Socket (Socket)
+import qualified Network.Socket as Socket
+
+#if defined(mingw32_HOST_OS)
+import           Foreign.Ptr (castPtr)
+import qualified System.Win32 as Win32
+#endif
+
+-- | Generalized API for sending and receiving raw bytes over a file
+-- descriptor, socket, or similar object.
+data RawBearer m =
+  RawBearer
+    { send :: Ptr Word8 -> Int -> m Int
+    , recv :: Ptr Word8 -> Int -> m Int
+    }
+
+class ToRawBearer m fd where
+  toRawBearer :: fd -> m (RawBearer m)
+
+instance ToRawBearer IO Socket where
+  toRawBearer s =
+    return RawBearer
+      { send = Socket.sendBuf s
+      , recv = Socket.recvBuf s
+      }
+
+#if defined(mingw32_HOST_OS)
+
+-- | We cannot declare an @instance ToRawBearer Win32.HANDLE@, because
+-- 'Win32.Handle' is just a type alias for @Ptr ()@. So instead, we provide
+-- this function, which can be used to implement 'ToRawBearer' elsewhere (e.g.
+-- over a newtype).
+win32HandleToRawBearer :: Win32.HANDLE -> RawBearer IO
+win32HandleToRawBearer s =
+    RawBearer
+      { send = \buf size -> fromIntegral <$> Win32.win32_WriteFile s (castPtr buf) (fromIntegral size) Nothing
+      , recv = \buf size -> fromIntegral <$> Win32.win32_ReadFile s (castPtr buf) (fromIntegral size) Nothing
+      }
+#endif

--- a/ouroboros-network-framework/src/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/RawBearer.hs
@@ -3,14 +3,14 @@
 
 module Ouroboros.Network.RawBearer where
 
-import           Data.Word (Word8)
-import           Foreign.Ptr (Ptr)
-import           Network.Socket (Socket)
-import qualified Network.Socket as Socket
+import Data.Word (Word8)
+import Foreign.Ptr (Ptr)
+import Network.Socket (Socket)
+import Network.Socket qualified as Socket
 
 #if defined(mingw32_HOST_OS)
-import           Foreign.Ptr (castPtr)
-import qualified System.Win32 as Win32
+import Foreign.Ptr (castPtr)
+import System.Win32 qualified as Win32
 #endif
 
 -- | Generalized API for sending and receiving raw bytes over a file
@@ -21,22 +21,25 @@ data RawBearer m =
     , recv :: Ptr Word8 -> Int -> m Int
     }
 
-class ToRawBearer m fd where
-  toRawBearer :: fd -> m (RawBearer m)
+newtype MakeRawBearer m fd = MakeRawBearer {
+  getRawBearer :: fd -> m (RawBearer m)
+}
 
-instance ToRawBearer IO Socket where
-  toRawBearer s =
-    return RawBearer
+makeSocketRawBearer :: MakeRawBearer IO Socket
+makeSocketRawBearer = MakeRawBearer (return . socketToRawBearer)
+
+socketToRawBearer :: Socket -> RawBearer IO
+socketToRawBearer s =
+    RawBearer
       { send = Socket.sendBuf s
       , recv = Socket.recvBuf s
       }
 
 #if defined(mingw32_HOST_OS)
 
--- | We cannot declare an @instance ToRawBearer Win32.HANDLE@, because
--- 'Win32.Handle' is just a type alias for @Ptr ()@. So instead, we provide
--- this function, which can be used to implement 'ToRawBearer' elsewhere (e.g.
--- over a newtype).
+win32MakeRawBearer :: MakeRawBearer IO Win32.HANDLE
+win32MakeRawBearer = MakeRawBearer (return . win32HandleToRawBearer)
+
 win32HandleToRawBearer :: Win32.HANDLE -> RawBearer IO
 win32HandleToRawBearer s =
     RawBearer

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -21,6 +21,7 @@ module Ouroboros.Network.Snocket
   , AddressFamily (..)
   , Snocket (..)
   , makeSocketBearer
+  , makeLocalRawBearer
     -- ** Socket based Snockets
   , SocketSnocket
   , socketSnocket
@@ -395,17 +396,20 @@ data LocalSocket = LocalSocket { getLocalHandle :: !LocalHandle
     deriving (Eq, Generic)
     deriving Show via Quiet LocalSocket
 
-instance ToRawBearer IO LocalSocket where
-  toRawBearer = return . win32HandleToRawBearer . getLocalHandle
+localSocketToRawBearer :: LocalSocket -> RawBearer IO
+localSocketToRawBearer = win32HandleToRawBearer . getLocalHandle
 
 #else
 newtype LocalSocket  = LocalSocket { getLocalHandle :: LocalHandle }
     deriving (Eq, Generic)
     deriving Show via Quiet LocalSocket
 
-instance ToRawBearer IO LocalSocket where
-  toRawBearer = toRawBearer . getLocalHandle
+localSocketToRawBearer :: LocalSocket -> RawBearer IO
+localSocketToRawBearer = socketToRawBearer . getLocalHandle
 #endif
+
+makeLocalRawBearer :: MakeRawBearer IO LocalSocket
+makeLocalRawBearer = MakeRawBearer (return . localSocketToRawBearer)
 
 makeLocalBearer :: MakeBearer IO LocalSocket
 #if defined(mingw32_HOST_OS)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -68,6 +68,7 @@ import Network.Socket qualified as Socket
 import Network.Mux.Bearer
 
 import Ouroboros.Network.IOManager
+import Ouroboros.Network.RawBearer
 
 
 -- | Named pipes and Berkeley sockets have different API when accepting
@@ -393,10 +394,17 @@ data LocalSocket = LocalSocket { getLocalHandle :: !LocalHandle
                                }
     deriving (Eq, Generic)
     deriving Show via Quiet LocalSocket
+
+instance ToRawBearer IO LocalSocket where
+  toRawBearer = return . win32HandleToRawBearer . getLocalHandle
+
 #else
 newtype LocalSocket  = LocalSocket { getLocalHandle :: LocalHandle }
     deriving (Eq, Generic)
     deriving Show via Quiet LocalSocket
+
+instance ToRawBearer IO LocalSocket where
+  toRawBearer = toRawBearer . getLocalHandle
 #endif
 
 makeLocalBearer :: MakeBearer IO LocalSocket

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -49,20 +49,28 @@ import Prelude hiding (read)
 import Control.Applicative (Alternative)
 import Control.Concurrent.Class.MonadSTM qualified as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict
-import Control.Monad (when)
+import Control.Monad.Class.MonadSay
+import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadThrow
-import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
+import Control.Monad.Class.MonadTime.SI
+import Control.Monad.ST.Unsafe (unsafeIOToST)
+import Control.Monad (when)
 import Control.Tracer (Tracer, contramap, contramapM, traceWith)
 
 import GHC.IO.Exception
 
 import Data.Bifoldable (bitraverse_)
+import Data.ByteString.Lazy qualified as LBS
+import Data.ByteString qualified as BS
 import Data.Foldable (traverse_)
 import Data.Functor (($>))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Typeable (Typeable)
+import Foreign.C.Error
+import Foreign.Marshal (copyBytes)
+import Foreign.Ptr (castPtr)
 import Numeric.Natural (Natural)
 import Text.Printf (printf)
 
@@ -74,6 +82,7 @@ import Network.Mux.Bearer.AttenuatedChannel
 
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.ConnectionManager.Types (AddressType (..))
+import Ouroboros.Network.RawBearer
 import Ouroboros.Network.Snocket
 
 import Ouroboros.Network.Testing.Data.Script (Script (..), stepScriptSTM)
@@ -532,8 +541,92 @@ instance Show addr => Show (FD_ m addr) where
 
 -- | File descriptor type.
 --
-newtype FD m peerAddr = FD { fdVar :: (StrictTVar m (FD_ m peerAddr)) }
+newtype FD m peerAddr = FD { fdVar :: StrictTVar m (FD_ m peerAddr) }
 
+instance ( MonadST m
+         , MonadThrow m
+         , MonadSay m
+         , MonadLabelledSTM m
+         , Show addr
+         ) => ToRawBearer m (FD m (TestAddress addr)) where
+  toRawBearer = makeRawFDBearer
+
+-- | Make a 'RawBearer' from an 'FD'. Since this is only used for testing, we
+-- can bypass the requirement of moving raw bytes directly between file
+-- descriptors and provided memory buffers, and we can instead covertly use
+-- plain old 'ByteString' under the hood. This allows us to use the
+-- 'AttenuatedChannel' inside the `FD_`, even though its send and receive
+-- methods do not have the right format.
+makeRawFDBearer :: forall addr m.
+                   ( MonadST m
+                   , MonadLabelledSTM m
+                   , MonadThrow m
+                   , MonadSay m
+                   , Show addr
+                   )
+                => FD m (TestAddress addr)
+                -> m (RawBearer m)
+makeRawFDBearer (FD {fdVar}) = do
+    (bufVar :: StrictTMVar m LBS.ByteString) <- newTMVarIO LBS.empty
+    return RawBearer
+              { send = \src srcSize -> do
+                  labelTVarIO fdVar "sender"
+                  say $ "Sending " ++ show srcSize ++ " bytes"
+                  fd_ <- readTVarIO fdVar
+                  case fd_ of
+                    FDConnected _ conn -> do
+                      bs <- withLiftST $ \liftST ->
+                        liftST . unsafeIOToST $ BS.packCStringLen (castPtr src, srcSize)
+                      let bsl = LBS.fromStrict bs
+                      acWrite (connChannelLocal conn) bsl
+                      say $ "Sent " ++ show srcSize ++ " bytes"
+                      return srcSize
+                    _ ->
+                      throwIO (invalidError fd_)
+              , recv = \dst size -> do
+                  labelTVarIO fdVar "receiver"
+                  let size64 = fromIntegral size
+                  say $ "Receiving " ++ show size ++ " bytes"
+                  fd_ <- readTVarIO fdVar
+                  case fd_ of
+                    FDConnected _ conn -> do
+                      say $ "Checking buffer"
+                      bytesFromBuffer <- atomically $ takeTMVar bufVar
+                      say $ "Buffer: " ++ show bytesFromBuffer
+                      (lhs, rhs) <- if not (LBS.null bytesFromBuffer) then do
+                        say $ "Reading up to " ++ show size ++ " bytes from buffer"
+                        return (LBS.take size64 bytesFromBuffer, LBS.drop size64 bytesFromBuffer)
+                      else do
+                        bytesRead <- acRead (connChannelLocal conn)
+                        say $ "Received " ++ show (LBS.length $ LBS.take size64 bytesRead) ++ " or more bytes"
+                        return (LBS.take size64 bytesRead, LBS.drop size64 bytesRead)
+                      say $ "Updating buffer; use: " ++ show lhs ++ " keep: " ++ show (LBS.take 10 rhs) ++
+                            if (LBS.length . LBS.take 11 $ rhs) == 11 then "..." else ""
+                      atomically $ putTMVar bufVar rhs
+                      say $ "Receive: buffer updated"
+                      if LBS.null lhs then do
+                        say $ "Receive: End of stream"
+                        return 0
+                      else do
+                        say $ "Receive: copying."
+                        let bs = LBS.toStrict lhs
+                        withLiftST $ \liftST ->
+                          liftST . unsafeIOToST $ BS.useAsCStringLen bs $ \(src, srcSize) -> do
+                            copyBytes dst (castPtr src) srcSize
+                            return srcSize
+                    _ ->
+                      throwIO (invalidError fd_)
+              }
+  where
+    invalidError :: FD_ m (TestAddress addr) -> IOError
+    invalidError fd_ = IOError
+      { ioe_handle      = Nothing
+      , ioe_type        = InvalidArgument
+      , ioe_location    = "Ouroboros.Network.Snocket.Sim.toRawBearer"
+      , ioe_description = printf "Invalid argument (%s)" (show fd_)
+      , ioe_errno       = Nothing
+      , ioe_filename    = Nothing
+      }
 
 makeFDBearer :: forall addr m.
                 ( MonadMonotonicTime m
@@ -557,17 +650,16 @@ makeFDBearer = MakeBearer $ \sduTimeout muxTracer FD { fdVar } -> do
                                                 (connChannelLocal conn)
           FDClosed {} ->
             throwIO (invalidError fd_)
-      where
-        -- io errors
-        invalidError :: FD_ m (TestAddress addr) -> IOError
-        invalidError fd_ = IOError
-          { ioe_handle      = Nothing
-          , ioe_type        = InvalidArgument
-          , ioe_location    = "Ouroboros.Network.Snocket.Sim.toBearer"
-          , ioe_description = printf "Invalid argument (%s)" (show fd_)
-          , ioe_errno       = Nothing
-          , ioe_filename    = Nothing
-          }
+  where
+    invalidError :: FD_ m (TestAddress addr) -> IOError
+    invalidError fd_ = IOError
+      { ioe_handle      = Nothing
+      , ioe_type        = InvalidArgument
+      , ioe_location    = "Ouroboros.Network.Snocket.Sim.toBearer"
+      , ioe_description = printf "Invalid argument (%s)" (show fd_)
+      , ioe_errno       = Nothing
+      , ioe_filename    = Nothing
+      }
 
 --
 -- Simulated snockets

--- a/ouroboros-network-framework/test/Main.hs
+++ b/ouroboros-network-framework/test/Main.hs
@@ -1,15 +1,15 @@
 module Main (main) where
 
-import           Test.Tasty
+import Test.Tasty
 
-import qualified Test.Ouroboros.Network.ConnectionManager as ConnectionManager
-import qualified Test.Ouroboros.Network.Driver as Driver
-import qualified Test.Ouroboros.Network.RateLimiting as RateLimiting
-import qualified Test.Ouroboros.Network.RawBearer as RawBearer
-import qualified Test.Ouroboros.Network.Server2 as Server2
-import qualified Test.Ouroboros.Network.Socket as Socket
-import qualified Test.Ouroboros.Network.Subscription as Subscription
-import qualified Test.Simulation.Network.Snocket as Snocket
+import Test.Ouroboros.Network.ConnectionManager qualified as ConnectionManager
+import Test.Ouroboros.Network.Driver qualified as Driver
+import Test.Ouroboros.Network.RateLimiting qualified as RateLimiting
+import Test.Ouroboros.Network.RawBearer qualified as RawBearer
+import Test.Ouroboros.Network.Server2 qualified as Server2
+import Test.Ouroboros.Network.Socket qualified as Socket
+import Test.Ouroboros.Network.Subscription qualified as Subscription
+import Test.Simulation.Network.Snocket qualified as Snocket
 
 main :: IO ()
 main = defaultMain tests

--- a/ouroboros-network-framework/test/Main.hs
+++ b/ouroboros-network-framework/test/Main.hs
@@ -1,0 +1,30 @@
+module Main (main) where
+
+import           Test.Tasty
+
+import qualified Test.Ouroboros.Network.ConnectionManager as ConnectionManager
+import qualified Test.Ouroboros.Network.Driver as Driver
+import qualified Test.Ouroboros.Network.RateLimiting as RateLimiting
+import qualified Test.Ouroboros.Network.RawBearer as RawBearer
+import qualified Test.Ouroboros.Network.Server2 as Server2
+import qualified Test.Ouroboros.Network.Socket as Socket
+import qualified Test.Ouroboros.Network.Subscription as Subscription
+import qualified Test.Simulation.Network.Snocket as Snocket
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests =
+  testGroup "ouroboros-network-framework"
+  [ ConnectionManager.tests
+  , Driver.tests
+  , Server2.tests
+  , Socket.tests
+  , Subscription.tests
+  , RateLimiting.tests
+  , Snocket.tests
+  , RawBearer.tests
+  ]
+
+


### PR DESCRIPTION
# Description

This provides a socket-like API for Snockets (backed by sockets / named pipes, or simulated in IOSim), reading/writing directly to/from raw memory buffers.

This will be needed to securely send KES keys over a network connection or local pipe, because we need to ensure that key data is never stored on disk, nor on the GHC heap, from where it might be swapped to disk.

For context, see also:

- https://github.com/input-output-hk/cardano-base/pull/255: KES Secure Forgetting
- https://github.com/input-output-hk/cardano-base/issues/312: KES Agent
- https://github.com/input-output-hk/cardano-base/pull/317: KES Agent prerequisites

# Checklist

- Branch
    - [X] Commit sequence broadly makes sense
    - [X] Commits have useful messages
    - [X] The documentation has been properly updated
    - [X] New tests are added if needed and existing tests are updated
    - [X] Any changes affecting Consensus packages must have an entry in the appropriate `changelog.d` directory created using [`scriv`](https://github.com/input-output-hk/scriv). If in doubt, see the [Consensus release process](../ouroboros-consensus/docs/ReleaseProcess.md).
    - (n/a) If this branch changes Network and has any consequences for downstream repositories or end users, said changes must be documented in [`interface-CHANGELOG.md`](../docs/interface-CHANGELOG.md)
    - [X] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [X] Self-reviewed the diff
    - [X] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [X] Reviewer requested
