### PR TITLE
Delay peersharing

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -8,6 +8,9 @@
 ### Non-breaking changes
 
 * Fix random selection of peers to peershare with.
+* Reduce peersharing retry from 1h to 15m.
+* Delay peersharing with newly established peers until they have been around
+  for 5 minutes.
 
 ## 0.10.0.1 -- 2023-11-16
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -3036,6 +3036,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing = do
                 policyPeerShareRetryTime         = 0, -- seconds
                 policyPeerShareBatchWaitTime     = 0, -- seconds
                 policyPeerShareOverallTimeout    = 0, -- seconds
+                policyPeerShareActivationDelay   = 1, -- seconds
                 policyErrorDelay              = 0  -- seconds
               }
     pickTrivially :: Applicative m => Set SockAddr -> Int -> m (Set SockAddr)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -528,6 +528,7 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
       policyPeerShareRetryTime         = 3600, -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
+      policyPeerShareActivationDelay   = 300,  -- seconds
       policyErrorDelay              = 10    -- seconds
     }
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -91,6 +91,7 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
       policyPeerShareRetryTime         = 900,  -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
+      policyPeerShareActivationDelay   = 300,  -- seconds
 
       policyErrorDelay = ExitPolicy.reconnectDelay errorDelay
     }

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -88,7 +88,7 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
 
       policyFindPublicRootTimeout      = 5,    -- seconds
       policyMaxInProgressPeerShareReqs = 2,
-      policyPeerShareRetryTime         = 3600, -- seconds
+      policyPeerShareRetryTime         = 900,  -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -121,6 +121,8 @@ data PeerSelectionPolicy peeraddr m = PeerSelectionPolicy {
        policyPeerShareOverallTimeout    :: !DiffTime,
        -- ^ Amount of time the overall batches of peer sharing requests are
        -- allowed to take
+       policyPeerShareActivationDelay    :: !DiffTime,
+       -- ^ Delay until we consider a peer suitable for peersharing
 
        -- | Reconnection delay, passed from `ExitPolicy`.
        --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
@@ -162,20 +162,13 @@ member peeraddr = Map.member peeraddr . allPeers
 insert :: Ord peeraddr
        => peeraddr
        -> peerconn
+       -> Time
        -> EstablishedPeers peeraddr peerconn
        -> EstablishedPeers peeraddr peerconn
-insert peeraddr peerconn ep@EstablishedPeers { allPeers, availableForPeerShare } =
-   ep { allPeers = Map.insert peeraddr peerconn allPeers,
-
-        -- The sets tracking peers ready for peer share need to be updated with any
-        -- /fresh/ peers, but any already present are ignored since they are
-        -- either already in these sets or they are in the corresponding PSQs,
-        -- for which we also preserve existing info.
-        availableForPeerShare =
-          if Map.member peeraddr allPeers
-             then availableForPeerShare
-             else Set.insert peeraddr availableForPeerShare
-      }
+insert peeraddr peerconn peerShareAt ep@EstablishedPeers { allPeers } =
+   -- Newly established peers are available for peersharing after the specified delay.
+   setPeerShareTime (Set.singleton peeraddr) peerShareAt $
+     ep { allPeers = Map.insert peeraddr peerconn allPeers }
 
 delete :: Ord peeraddr
        => peeraddr


### PR DESCRIPTION
# Description
Delay peer sharing for newly established peers for 5 minutes. The 5 minute gives the new peer plenty of time to prove itself useful, or violate the protocol and be disconnected.
This change also fixes a startup problem where, when the node starts it could end up asking the first peer it manages to connect to for 100 peers.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ x Reviewer requested
