### PR TITLE
KnownPeers insert function bug fix and PeerSharing improvements

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -14,7 +14,12 @@
   which hide both `Min` and `FirstToFinish`.
 * Adds 'unit_reconnect' testnet test
 * When churning split restoring known peers and established peers targets into
-  two separate steps. 
+  two separate steps.
+* Fix `KnownPeers.insert` function semantic bug where it could easily misused,
+  overwriting values.
+* Made (light) peer sharing results advertisable unless already known
+* Peer sharing is now delayed for 5minutes for newly established peers.
+* `policyPeerShareRetryTime` to 900s
 
 ## 0.10.2.2 -- 2023-12-15
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -3051,6 +3051,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing = do
                 policyPeerShareRetryTime         = 0, -- seconds
                 policyPeerShareBatchWaitTime     = 0, -- seconds
                 policyPeerShareOverallTimeout    = 0, -- seconds
+                policyPeerShareActivationDelay   = 1, -- seconds
                 policyErrorDelay              = 0  -- seconds
               }
     pickTrivially :: Applicative m => Set SockAddr -> Int -> m (Set SockAddr)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -536,6 +536,7 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
       policyPeerShareRetryTime         = 3600, -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
+      policyPeerShareActivationDelay   = 300,  -- seconds
       policyErrorDelay              = 10    -- seconds
     }
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -92,6 +92,7 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
       policyPeerShareRetryTime         = 3600, -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
+      policyPeerShareActivationDelay   = 300,  -- seconds
 
       policyErrorDelay = ExitPolicy.repromoteDelay errorDelay
     }

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -89,7 +89,7 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
 
       policyFindPublicRootTimeout      = 5,    -- seconds
       policyMaxInProgressPeerShareReqs = 2,
-      policyPeerShareRetryTime         = 3600, -- seconds
+      policyPeerShareRetryTime         = 900,  -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
       policyPeerShareActivationDelay   = 300,  -- seconds

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/BigLedgerPeers.hs
@@ -21,7 +21,6 @@ import           Ouroboros.Network.PeerSelection.Governor.Types
 import           Ouroboros.Network.PeerSelection.LedgerPeers (IsLedgerPeer (..))
 import           Ouroboros.Network.PeerSelection.PeerAdvertise
                      (PeerAdvertise (..))
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
@@ -116,7 +115,7 @@ jobReqBigLedgerPeers PeerSelectionActions{ requestBigLedgerPeers }
 
             knownPeers'
                      = KnownPeers.insert
-                         (Map.fromSet (\_ -> ( Just PeerSharingDisabled
+                         (Map.fromSet (\_ -> ( Nothing
                                                -- the peer sharing flag will be
                                                -- updated once we negotiate
                                                -- the connection

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -71,7 +71,7 @@ belowTargetLocal :: forall peeraddr peerconn m.
                  => PeerSelectionActions peeraddr peerconn m
                  -> MkGuardedDecision peeraddr peerconn m
 belowTargetLocal actions
-                 PeerSelectionPolicy {
+                 policy@PeerSelectionPolicy {
                    policyPickColdPeersToPromote
                  }
                  st@PeerSelectionState {
@@ -127,7 +127,7 @@ belowTargetLocal actions
                           inProgressPromoteCold = inProgressPromoteCold
                                                <> selectedToPromote
                         },
-        decisionJobs  = [ jobPromoteColdPeer actions peer IsNotBigLedgerPeer
+        decisionJobs  = [ jobPromoteColdPeer actions policy peer IsNotBigLedgerPeer
                         | peer <- Set.toList selectedToPromote ]
       }
 
@@ -167,7 +167,7 @@ belowTargetOther :: forall peeraddr peerconn m.
                  => PeerSelectionActions peeraddr peerconn m
                  -> MkGuardedDecision peeraddr peerconn m
 belowTargetOther actions
-                 PeerSelectionPolicy {
+                 policy@PeerSelectionPolicy {
                    policyPickColdPeersToPromote
                  }
                  st@PeerSelectionState {
@@ -217,7 +217,7 @@ belowTargetOther actions
                           inProgressPromoteCold = inProgressPromoteCold
                                                <> selectedToPromote
                         },
-        decisionJobs  = [ jobPromoteColdPeer actions peer IsNotBigLedgerPeer
+        decisionJobs  = [ jobPromoteColdPeer actions policy peer IsNotBigLedgerPeer
                         | peer <- Set.toList selectedToPromote ]
       }
 
@@ -245,7 +245,7 @@ belowTargetBigLedgerPeers :: forall peeraddr peerconn m.
                           => PeerSelectionActions peeraddr peerconn m
                           -> MkGuardedDecision peeraddr peerconn m
 belowTargetBigLedgerPeers actions
-                          PeerSelectionPolicy {
+                          policy@PeerSelectionPolicy {
                             policyPickColdPeersToPromote
                           }
                           st@PeerSelectionState {
@@ -296,7 +296,7 @@ belowTargetBigLedgerPeers actions
                           inProgressPromoteCold = inProgressPromoteCold
                                                <> selectedToPromote
                         },
-        decisionJobs  = [ jobPromoteColdPeer actions peer IsBigLedgerPeer
+        decisionJobs  = [ jobPromoteColdPeer actions policy peer IsBigLedgerPeer
                         | peer <- Set.toList selectedToPromote ]
       }
 
@@ -336,13 +336,16 @@ maxColdPeerRetryBackoff = 5
 jobPromoteColdPeer :: forall peeraddr peerconn m.
                        (Monad m, Ord peeraddr)
                    => PeerSelectionActions peeraddr peerconn m
+                   -> PeerSelectionPolicy peeraddr m
                    -> peeraddr
                    -> IsBigLedgerPeer
                    -> Job () m (Completion m peeraddr peerconn)
 jobPromoteColdPeer PeerSelectionActions {
                      peerStateActions = PeerStateActions {establishPeerConnection},
                      peerConnToPeerSharing
-                   } peeraddr isBigLedgerPeer =
+                   }
+                   PeerSelectionPolicy { policyPeerShareActivationDelay }
+                   peeraddr isBigLedgerPeer =
     Job job handler () "promoteColdPeer"
   where
     handler :: SomeException -> m (Completion m peeraddr peerconn)
@@ -411,8 +414,9 @@ jobPromoteColdPeer PeerSelectionActions {
                                            targetNumberOfEstablishedBigLedgerPeers
                                          }
                              }
-                             _now ->
+                             now ->
         let establishedPeers' = EstablishedPeers.insert peeraddr peerconn
+                                                        (addTime policyPeerShareActivationDelay now)
                                                         establishedPeers
             -- Update PeerSharing value in KnownPeers
             knownPeers'       = KnownPeers.insert (Map.singleton peeraddr (Just peerSharing, Nothing, Nothing))

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -23,6 +23,9 @@ import           System.Random (randomR)
 import           Ouroboros.Network.PeerSelection.Governor.Types
 import           Ouroboros.Network.PeerSelection.LedgerPeers.Type
                      (IsBigLedgerPeer (..))
+import           Ouroboros.Network.PeerSelection.PeerAdvertise
+                     (PeerAdvertise (..))
+import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import           Ouroboros.Network.PeerSelection.State.LocalRootPeers
@@ -418,8 +421,16 @@ jobPromoteColdPeer PeerSelectionActions {
         let establishedPeers' = EstablishedPeers.insert peeraddr peerconn
                                                         (addTime policyPeerShareActivationDelay now)
                                                         establishedPeers
+            advertise = case peerSharing of
+                          PeerSharingEnabled  -> DoAdvertisePeer
+                          PeerSharingDisabled -> DoNotAdvertisePeer
             -- Update PeerSharing value in KnownPeers
-            knownPeers'       = KnownPeers.insert (Map.singleton peeraddr (Just peerSharing, Nothing, Nothing))
+            knownPeers'       = KnownPeers.insert (Map.singleton peeraddr ( Just peerSharing
+                                                                          , newDefaultValue peeraddr
+                                                                                            advertise
+                                                                                            knownPeers
+                                                                          , Nothing))
+                              $ KnownPeers.setSuccessfulConnectionFlag peeraddr
                               $ KnownPeers.clearTepidFlag peeraddr $
                                     KnownPeers.resetFailCount
                                         peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -9,7 +9,6 @@ module Ouroboros.Network.PeerSelection.Governor.KnownPeers
   , aboveTarget
   ) where
 
-import qualified Data.Map as Map
 import           Data.Maybe (fromMaybe)
 import qualified Data.Set as Set
 
@@ -189,16 +188,19 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                           ]
                         , decisionState =
                            st { -- TODO: also update with the failures
-                                knownPeers = KnownPeers.insert
-                                               (Map.fromList
-                                                $ map (\a -> ( a
-                                                             , ( Nothing
-                                                               , newDefaultValue a DoAdvertisePeer (knownPeers st)
-                                                               , Nothing
-                                                               ))
-                                                      )
-                                                      newPeers)
-                                               (knownPeers st),
+                                knownPeers = KnownPeers.alter
+                                              (\x -> case x of
+                                                Nothing ->
+                                                  KnownPeers.alterKnownPeerInfo
+                                                    (Nothing, Just DoAdvertisePeer, Nothing)
+                                                    x
+                                                Just _ ->
+                                                  KnownPeers.alterKnownPeerInfo
+                                                    (Nothing, Nothing, Nothing)
+                                                    x
+                                              )
+                                              (Set.fromList newPeers)
+                                              (knownPeers st),
                                 inProgressPeerShareReqs = inProgressPeerShareReqs st
                                                         - length peers
                            }
@@ -234,15 +236,19 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                            ]
                          , decisionState =
                             st { -- TODO: also update with the failures
-                                 knownPeers = KnownPeers.insert
-                                                (Map.fromList
-                                                 $ map (\a -> ( a
-                                                              , ( Nothing
-                                                                , newDefaultValue a DoAdvertisePeer (knownPeers st)
-                                                                , Nothing))
-                                                       )
-                                                       newPeers)
-                                                (knownPeers st),
+                                 knownPeers = KnownPeers.alter
+                                               (\x -> case x of
+                                                 Nothing ->
+                                                   KnownPeers.alterKnownPeerInfo
+                                                     (Nothing, Just DoAdvertisePeer, Nothing)
+                                                     x
+                                                 Just _ ->
+                                                   KnownPeers.alterKnownPeerInfo
+                                                     (Nothing, Nothing, Nothing)
+                                                     x
+                                               )
+                                               (Set.fromList newPeers)
+                                               (knownPeers st),
                                  inProgressPeerShareReqs = inProgressPeerShareReqs st
                                                          - length peerResults
                                }
@@ -297,15 +303,19 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                        ]
                      , decisionState =
                         st { -- TODO: also update with the failures
-                             knownPeers = KnownPeers.insert
-                                            (Map.fromList
-                                             $ map (\a -> ( a
-                                                          , ( Nothing
-                                                            , newDefaultValue a DoAdvertisePeer (knownPeers st)
-                                                            , Nothing))
-                                                   )
-                                                   newPeers)
-                                            (knownPeers st),
+                             knownPeers = KnownPeers.alter
+                                           (\x -> case x of
+                                             Nothing ->
+                                               KnownPeers.alterKnownPeerInfo
+                                                 (Nothing, Just DoAdvertisePeer, Nothing)
+                                                 x
+                                             Just _ ->
+                                               KnownPeers.alterKnownPeerInfo
+                                                 (Nothing, Nothing, Nothing)
+                                                 x
+                                           )
+                                           (Set.fromList newPeers)
+                                           (knownPeers st),
                              inProgressPeerShareReqs = inProgressPeerShareReqs st
                                                      - length peers
                            }

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -21,6 +21,8 @@ import           Control.Monad.Class.MonadTime.SI
 import           Control.Monad.Class.MonadTimer.SI
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
+import           Ouroboros.Network.PeerSelection.PeerAdvertise
+                     (PeerAdvertise (..))
 import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import           Ouroboros.Network.PeerSelection.State.KnownPeers
@@ -191,8 +193,9 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                                (Map.fromList
                                                 $ map (\a -> ( a
                                                              , ( Nothing
+                                                               , newDefaultValue a DoAdvertisePeer (knownPeers st)
                                                                , Nothing
-                                                               , Nothing))
+                                                               ))
                                                       )
                                                       newPeers)
                                                (knownPeers st),
@@ -235,7 +238,7 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                                 (Map.fromList
                                                  $ map (\a -> ( a
                                                               , ( Nothing
-                                                                , Nothing
+                                                                , newDefaultValue a DoAdvertisePeer (knownPeers st)
                                                                 , Nothing))
                                                        )
                                                        newPeers)
@@ -289,7 +292,6 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                 Left partialResults -> [ p | Just (Right (PeerSharingResult ps)) <- partialResults
                                            , p <- ps
                                            , not (isKnownLedgerPeer p (knownPeers st)) ]
-
          in Decision { decisionTrace = [ TracePeerShareResults peerResults
                                        , TracePeerShareResultsFiltered newPeers
                                        ]
@@ -299,7 +301,7 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                                             (Map.fromList
                                              $ map (\a -> ( a
                                                           , ( Nothing
-                                                            , Nothing
+                                                            , newDefaultValue a DoAdvertisePeer (knownPeers st)
                                                             , Nothing))
                                                    )
                                                    newPeers)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -35,6 +35,8 @@ import           Ouroboros.Network.PeerSelection.Governor.ActivePeers
                      (jobDemoteActivePeer)
 import           Ouroboros.Network.PeerSelection.Governor.Types hiding
                      (PeerSelectionCounters (..))
+import           Ouroboros.Network.PeerSelection.PeerAdvertise
+                     (PeerAdvertise (..))
 import qualified Ouroboros.Network.PeerSelection.State.EstablishedPeers as EstablishedPeers
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
@@ -118,7 +120,10 @@ inboundPeers PeerSelectionActions{
     return $ \_ ->
       let -- If peer happens to already be present in the Known Peer set
           -- 'insert' is going to do its due diligence before adding.
-          newEntry    = Map.singleton addr (Just ps, Nothing, Nothing)
+          newEntry    = Map.singleton addr ( Just ps
+                                           , newDefaultValue addr DoAdvertisePeer knownPeers
+                                           , Nothing
+                                           )
           knownPeers' = KnownPeers.insert newEntry knownPeers
        in Decision {
             decisionTrace = [TraceKnownInboundConnection addr ps],

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/RootPeers.hs
@@ -12,7 +12,6 @@ import           Control.Monad.Class.MonadSTM
 import           Control.Monad.Class.MonadTime.SI
 
 import           Ouroboros.Network.PeerSelection.Governor.Types
-import           Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import qualified Ouroboros.Network.PeerSelection.State.KnownPeers as KnownPeers
 import qualified Ouroboros.Network.PeerSelection.State.LocalRootPeers as LocalRootPeers
 
@@ -115,9 +114,7 @@ jobReqPublicRootPeers PeerSelectionActions{ requestPublicRootPeers
                                        `Map.withoutKeys` bigLedgerPeers st
             publicRootPeers' = publicRootPeers st <> Map.keysSet newPeers
             knownPeers'      = KnownPeers.insert
-                                 -- When we don't know about the PeerSharing information
-                                 -- we default to NoPeerSharing
-                                 (Map.map (\(a, b) -> (Just PeerSharingDisabled, Just a, Just b)) newPeers)
+                                 (Map.map (\(a, b) -> (Nothing, Just a, Just b)) newPeers)
                                  (knownPeers st)
 
             -- We got a successful response to our request, but if we're still

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -122,6 +122,8 @@ data PeerSelectionPolicy peeraddr m = PeerSelectionPolicy {
        policyPeerShareOverallTimeout    :: !DiffTime,
        -- ^ Amount of time the overall batches of peer sharing requests are
        -- allowed to take
+       policyPeerShareActivationDelay    :: !DiffTime,
+       -- ^ Delay until we consider a peer suitable for peer sharing.
 
        -- | Re-promote delay, passed from `ExitPolicy`.
        --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -122,8 +122,8 @@ data PeerSelectionPolicy peeraddr m = PeerSelectionPolicy {
        policyPeerShareOverallTimeout    :: !DiffTime,
        -- ^ Amount of time the overall batches of peer sharing requests are
        -- allowed to take
-       policyPeerShareActivationDelay    :: !DiffTime,
-       -- ^ Delay until we consider a peer suitable for peer sharing.
+       policyPeerShareActivationDelay   :: !DiffTime,
+       -- ^ Delay until we consider a peer suitable for peer sharing
 
        -- | Re-promote delay, passed from `ExitPolicy`.
        --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -43,6 +43,8 @@ module Ouroboros.Network.PeerSelection.Governor.Types
     -- * Traces
   , TracePeerSelection (..)
   , DebugPeerSelection (..)
+    -- * Auxiliary function
+  , newDefaultValue
   ) where
 
 import           Data.Cache (Cache (..))
@@ -464,7 +466,8 @@ toPublicState :: PeerSelectionState peeraddr peerconn
 toPublicState PeerSelectionState { knownPeers
                                  } =
    PublicPeerSelectionState {
-     availableToShare = KnownPeers.getPeerSharingResponsePeers knownPeers
+     availableToShare =
+       KnownPeers.getPeerSharingResponsePeers knownPeers
    }
 
 -- Peer selection counters.
@@ -969,4 +972,20 @@ deriving instance (Ord peeraddr, Show peeraddr)
 
 data ChurnMode = ChurnModeBulkSync
                | ChurnModeNormal deriving Show
+
+
+-- | Auxiliary function to set a different default value in case the peer is
+-- not a member of the known peers set.
+--
+-- This function is useful to use with KnownPeers.insert function, in the
+-- special cases of inbound peers and peer share result peers.
+--
+newDefaultValue :: Ord peeraddr
+                => peeraddr
+                -> v
+                -> KnownPeers peeraddr
+                -> Maybe v
+newDefaultValue a value knownPeers
+  | KnownPeers.member a knownPeers = Nothing
+  | otherwise                      = Just value
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -43,8 +43,6 @@ module Ouroboros.Network.PeerSelection.Governor.Types
     -- * Traces
   , TracePeerSelection (..)
   , DebugPeerSelection (..)
-    -- * Auxiliary function
-  , newDefaultValue
   ) where
 
 import           Data.Cache (Cache (..))
@@ -972,20 +970,4 @@ deriving instance (Ord peeraddr, Show peeraddr)
 
 data ChurnMode = ChurnModeBulkSync
                | ChurnModeNormal deriving Show
-
-
--- | Auxiliary function to set a different default value in case the peer is
--- not a member of the known peers set.
---
--- This function is useful to use with KnownPeers.insert function, in the
--- special cases of inbound peers and peer share result peers.
---
-newDefaultValue :: Ord peeraddr
-                => peeraddr
-                -> v
-                -> KnownPeers peeraddr
-                -> Maybe v
-newDefaultValue a value knownPeers
-  | KnownPeers.member a knownPeers = Nothing
-  | otherwise                      = Just value
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/EstablishedPeers.hs
@@ -162,20 +162,13 @@ member peeraddr = Map.member peeraddr . allPeers
 insert :: Ord peeraddr
        => peeraddr
        -> peerconn
+       -> Time
        -> EstablishedPeers peeraddr peerconn
        -> EstablishedPeers peeraddr peerconn
-insert peeraddr peerconn ep@EstablishedPeers { allPeers, availableForPeerShare } =
-   ep { allPeers = Map.insert peeraddr peerconn allPeers,
-
-        -- The sets tracking peers ready for peer share need to be updated with any
-        -- /fresh/ peers, but any already present are ignored since they are
-        -- either already in these sets or they are in the corresponding PSQs,
-        -- for which we also preserve existing info.
-        availableForPeerShare =
-          if Map.member peeraddr allPeers
-             then availableForPeerShare
-             else Set.insert peeraddr availableForPeerShare
-      }
+insert peeraddr peerconn peerShareAt ep@EstablishedPeers { allPeers } =
+   -- Ask newly established peers for its peers after the specified delay.
+   setPeerShareTime (Set.singleton peeraddr) peerShareAt $
+     ep { allPeers = Map.insert peeraddr peerconn allPeers }
 
 delete :: Ord peeraddr
        => peeraddr

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
@@ -22,6 +22,7 @@ module Ouroboros.Network.PeerSelection.State.KnownPeers
   , lookupTepidFlag
   , setTepidFlag
   , clearTepidFlag
+  , setSuccessfulConnectionFlag
     -- ** Tracking when we can (re)connect
   , minConnectTime
   , setConnectTimes
@@ -93,7 +94,7 @@ data KnownPeerInfo = KnownPeerInfo {
        -- It is used to implement the exponential backoff strategy and may also
        -- be used by policies to select peers to forget.
        --
-       knownPeerFailCount :: !Int,
+       knownPeerFailCount        :: !Int,
 
        -- | Indicates if the peer was hot but then got demoted.
        --
@@ -104,7 +105,7 @@ data KnownPeerInfo = KnownPeerInfo {
        -- It is also used as useful information for the Peer Selection Governor
        -- when deciding which peers to share when Peer Sharing.
        --
-       knownPeerTepid     :: !Bool,
+       knownPeerTepid            :: !Bool,
 
        -- | Indicates current remote Peer Willingness information.
        --
@@ -113,7 +114,7 @@ data KnownPeerInfo = KnownPeerInfo {
        --
        -- It is used by the Peer Sharing logic to decide if we should share/ask
        -- about/to this peer's address to others.
-       knownPeerSharing   :: !PeerSharing,
+       knownPeerSharing          :: !PeerSharing,
 
        -- | Indicates current local Peer Willingness information.
        --
@@ -122,7 +123,7 @@ data KnownPeerInfo = KnownPeerInfo {
        --
        -- It is used by the Peer Sharing logic to decide if we should share
        -- about this peer's address to others.
-       knownPeerAdvertise :: !PeerAdvertise,
+       knownPeerAdvertise        :: !PeerAdvertise,
 
        -- | Indicates if peer came from ledger.
        --
@@ -130,7 +131,16 @@ data KnownPeerInfo = KnownPeerInfo {
        -- reply, since ledger peers are not particularly what one is looking for
        -- in a Peer Sharing reply.
        --
-       knownLedgerPeer    :: !IsLedgerPeer
+       knownLedgerPeer           :: !IsLedgerPeer,
+
+       -- | Indicates if the node managed to connect to the peer at some point
+       -- in time.
+       --
+       -- This differs from the tepid flag in a way that this flag will be
+       -- set/enabled if we established a successful connection with this
+       -- peer. It won't be unset after this.
+       --
+       knownSuccessfulConnection :: !Bool
      }
   deriving (Eq, Show)
 
@@ -215,6 +225,7 @@ insert peeraddrs
           , knownPeerSharing   = fromMaybe PeerSharingDisabled peerSharing
           , knownPeerAdvertise = fromMaybe DoNotAdvertisePeer peerAdvertise
           , knownLedgerPeer    = fromMaybe IsNotLedgerPeer ledgerPeers
+          , knownSuccessfulConnection = False
           }
         Just kpi -> Just $
           kpi {
@@ -324,6 +335,17 @@ setTepidFlag' val peeraddr knownPeers@KnownPeers{allPeers} =
                               peeraddr allPeers
                }
 
+setSuccessfulConnectionFlag' :: Ord peeraddr
+                             => Bool
+                             -> peeraddr
+                             -> KnownPeers peeraddr
+                             -> KnownPeers peeraddr
+setSuccessfulConnectionFlag' val peeraddr knownPeers@KnownPeers{allPeers} =
+    assert (peeraddr `Map.member` allPeers) $
+    knownPeers { allPeers = Map.update (\kpi  -> Just kpi { knownSuccessfulConnection = val })
+                              peeraddr allPeers
+               }
+
 clearTepidFlag :: Ord peeraddr
              => peeraddr
              -> KnownPeers peeraddr
@@ -335,6 +357,12 @@ setTepidFlag :: Ord peeraddr
              -> KnownPeers peeraddr
              -> KnownPeers peeraddr
 setTepidFlag = setTepidFlag' True
+
+setSuccessfulConnectionFlag :: Ord peeraddr
+                            => peeraddr
+                            -> KnownPeers peeraddr
+                            -> KnownPeers peeraddr
+setSuccessfulConnectionFlag = setSuccessfulConnectionFlag' True
 
 -----------------------------------
 -- Tracking when we can (re)connect
@@ -388,8 +416,10 @@ setConnectTimes times
 canPeerShareRequest :: Ord peeraddr => peeraddr -> KnownPeers peeraddr -> Bool
 canPeerShareRequest pa KnownPeers { allPeers } =
   case Map.lookup pa allPeers of
-    Just (KnownPeerInfo _ _ PeerSharingEnabled _ _) -> True
-    _                                               -> False
+    Just KnownPeerInfo
+          { knownPeerSharing = PeerSharingEnabled
+          } -> True
+    _     -> False
 
 -- Only share peers which are allowed to be advertised, i.e. have
 -- 'DoAdvertisePeer' 'PeerAdvertise' values.
@@ -397,8 +427,11 @@ canPeerShareRequest pa KnownPeers { allPeers } =
 canSharePeers :: Ord peeraddr => peeraddr -> KnownPeers peeraddr -> Bool
 canSharePeers pa KnownPeers { allPeers } =
   case Map.lookup pa allPeers of
-    Just (KnownPeerInfo _ _ _ DoAdvertisePeer _) -> True
-    _                                            -> False
+    Just KnownPeerInfo
+          { knownPeerAdvertise        = DoAdvertisePeer
+          , knownSuccessfulConnection = True
+          } -> True
+    _     -> False
 
 -- | Filter peers available for Peer Sharing requests, according to their
 -- 'PeerSharing' information
@@ -418,8 +451,11 @@ getPeerSharingResponsePeers :: KnownPeers peeraddr
 getPeerSharingResponsePeers knownPeers =
     Map.keysSet
   $ Map.filter (\case
-                  KnownPeerInfo _ _ _ DoAdvertisePeer _ -> True
-                  _                                     -> False
+                  KnownPeerInfo
+                    { knownPeerAdvertise        = DoAdvertisePeer
+                    , knownSuccessfulConnection = True
+                    } -> True
+                  _   -> False
                )
   $ allPeers knownPeers
 


### PR DESCRIPTION
# Description


- Introduction of `knownSuccessfulConnection` Flag: added a new flag to the `KnownPeerInfo` data type. This flag serves an essential purpose in tracking the peers a node has successfully connected to previously. It plays a vital role in filtering peers for subsequent sharing operations.

- Resolution of the `KnownPeers` Insert Function Bug: fix of a semantic bug in the `KnownPeers` insert function. Previously, the function's implementation led to unintended overwriting of  information, notably the `PeerAdvertise` flag. This caused an issue where no peers were available for sharing, which has now been effectively addressed.

- Delay in Peer Sharing for New Connections: implemented a five-minute delay in peer sharing for newly established connections. This delay ensures a more stable and reliable integration of new peers into the network's sharing mechanism.

- Optimization of Peer Share Retry Time: adjusted the peer share retry time to 900 seconds.

- Enabling of `PeerAdvertise` Flag: enabled the `PeerAdvertise` flag for peer sharing results and inbound connections. This enhancement is applied unless the peers in question are already known by the outbound governor, in which case their original `PeerAdvertise` status is preserved.
