### PR TITLE
Split restoring of churn goal into 2 steps

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -13,6 +13,8 @@
 * The internal `Guarded` type changed.  It is provided with pattern synonyms
   which hide both `Min` and `FirstToFinish`.
 * Adds 'unit_reconnect' testnet test
+* When churning split restoring known peers and established peers targets into
+  two separate steps. 
 
 ## 0.10.2.2 -- 2023-12-15
 


### PR DESCRIPTION
# Description
Split restoring of churn goal into one step that discovers new known peers and one step that promotes known peers to established. When it was done in one atomic action only old known peers would get promoted.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
