### PR TITLE
Run GHA on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ concurrency:
 on:
   pull_request:
   merge_group:
+  push:
+    branches:
+      - "release/*"
 
 jobs:
   build:


### PR DESCRIPTION
We cannot use merge queue on release branches (because we use `*`
pattern), and thus we should enable GHA on push events.
