### PR TITLE
Add Socket.NoDelay option to configureOutboundSocket

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-breaking changes
 
+* Add Socket.NoDelay option to configureOutboundSocket
+
 ## 0.10.2.0 -- 2023-12-14
 
 ### Non-breaking changes

--- a/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Socket.hs
@@ -225,6 +225,7 @@ data SystemdSocketTracer = SocketOptionNotSet Socket.SocketOption
 --
 configureOutboundSocket :: Socket -> IO ()
 configureOutboundSocket sock = do
+    Socket.setSocketOption sock Socket.NoDelay 1
     Socket.setSockOpt sock Socket.Linger
                           (StructLinger { sl_onoff  = 1,
                                           sl_linger = 0 })


### PR DESCRIPTION
# Description

It looks like an oversight to not set the `Socket.NoDelay` option for outgoing sockets. This PR corrects that.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
