### PR TITLE
LocalStateQuery: let the client acquire the immutable tip

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -1282,25 +1282,36 @@ ledger state.
 \end{figure}
 
 \paragraph{Protocol messages}
-% TODO description of each message
+
+See Figure~\ref{fig:lsq-messages}, in which $AcquireFailure$ is either
+$AcquireFailurePointTooOld$ or $AcquireFailurePointNotOnChain$, and $Target$ is
+either $ImmutableTip$, $VolatileTip$, or $SpecificPoint pt$.
+
+The primary motivation for being able to acquire the $ImmutableTip$ is that
+it's the most recent ledger state that the node will never abandon: the node
+will never rollback to prefix of that immutable chain (unless the on-disk
+ChainDB is corrupted/manipulated). Therefore, answers to queries against the
+$ImmutableTip$ are necessarily not subject rollback.
+
+% TODO natural language description of each message
+
 \begin{figure}[h]
   \begin{tabular}{|l|l|l|l|}
     \hline
     \multicolumn{4}{|c|}{Transition table} \\ \hline
     from state          & message             & parameters          & to state \\ \hline\hline
-    \StIdle             & \MsgAcquire         & $Maybe\ point$      & \StAcquiring \\\hline
+    \StIdle             & \MsgAcquire         & $Target\ point$     & \StAcquiring \\\hline
     \StAcquiring        & \MsgFailure         & $AcquireFailure$    & \StIdle      \\\hline
     \StAcquiring        & \MsgAcquired        &                     & \StAcquired  \\\hline
     \StAcquired         & \MsgQuery           & $query$             & \StQuerying  \\\hline
     \StQuerying         & \MsgResult          & $result$            & \StAcquired  \\\hline
-    \StAcquired         & \MsgReAcquire       & $Maybe\ point$      & \StAcquiring \\\hline
+    \StAcquired         & \MsgReAcquire       & $Target\ point$     & \StAcquiring \\\hline
     \StAcquired         & \MsgRelease         &                     & \StIdle      \\\hline
     \StIdle             & \MsgDone            &                     & \StDone        \\\hline
   \end{tabular}
   \caption{Local State Query mini-protocol messages.}
+  \label{fig:lsq-messages}
 \end{figure}
-where $AcquireFailure$ is either $AcquireFailurePointTooOld$ or
-$AcquireFailurePointNotOnChain$.
 
 \subsection{CDDL encoding specification}
 \lstinputlisting[style=cddl]{../../ouroboros-network-protocols/test-cddl/specs/local-state-query.cddl}

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## next release
 
+### Non-breaking changes
+
+- CI requires me to add an entry here even though I merely updated a comment on
+  `NodeToClientV_16` mention new `ImmutableTip` argument in LocalStateQuery
+  mini protocol
+
 ## 0.6.2.0 -- 2023-12-14
 
 ### Non-breaking changes

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -38,7 +38,8 @@ data NodeToClientVersion
     | NodeToClientV_15
     -- ^ added `query` to NodeToClientVersionData
     | NodeToClientV_16
-    -- ^ enabled @CardanoNodeToClientVersion11@, i.e., Conway and
+    -- ^ add @ImmutableTip@ to @LocalStateQuery@, enabled
+    -- @CardanoNodeToClientVersion11@, i.e., Conway and
     -- @GetStakeDelegDeposits@.
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable)
 

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 * Pipeline depth type changed from `Word32` to `Word16`.
 
+* In LocalStateQuery, changed the argument of `MsgAcquire` and `MsgReAcquire`
+  from `Maybe point` to a new ADT `Target point`. It still allows the client to
+  acquire either the volatile tip or a specific point, but now also allows them
+  to instead acquire the immutable tip.
+
 ### Non-breaking changes
 
 * ghc-9.8 support.

--- a/ouroboros-network-protocols/test-cddl/Main.hs
+++ b/ouroboros-network-protocols/test-cddl/Main.hs
@@ -429,6 +429,7 @@ localStateQueryCodec :: Codec (LocalStateQuery Block BlockPoint Query)
                               CBOR.DeserialiseFailure IO BL.ByteString
 localStateQueryCodec =
     codecLocalStateQuery
+      maxBound
       Serialise.encode Serialise.decode
       encodeQuery decodeQuery
       (\Query{} -> Serialise.encode) (\Query{} -> Serialise.decode)

--- a/ouroboros-network-protocols/test-cddl/specs/local-state-query.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/local-state-query.cddl
@@ -22,7 +22,8 @@ query        = any
 result       = any
 
 msgAcquire   = [0, point]
-             / [8] 
+             / [8]
+             / [10]
 msgAcquired  = [1]
 msgFailure   = [2, failure]
 msgQuery     = [3, query]
@@ -30,5 +31,5 @@ msgResult    = [4, result]
 msgRelease   = [5]
 msgReAcquire = [6, point]
              / [9]
+             / [11]
 lsqMsgDone   = [7]
-

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalStateQuery/Direct.hs
@@ -20,8 +20,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
       :: ClientStIdle block point query m a
       -> ServerStIdle block point query m b
       -> m (a, b)
-    directIdle (SendMsgAcquire pt client') ServerStIdle{recvMsgAcquire} = do
-      server' <- recvMsgAcquire pt
+    directIdle (SendMsgAcquire tgt client') ServerStIdle{recvMsgAcquire} = do
+      server' <- recvMsgAcquire tgt
       directAcquiring client' server'
     directIdle (SendMsgDone a) ServerStIdle{recvMsgDone} = do
       b <- recvMsgDone
@@ -45,8 +45,8 @@ direct (LocalStateQueryClient mclient) (LocalStateQueryServer mserver) = do
     directAcquired (SendMsgQuery query client') ServerStAcquired{recvMsgQuery} = do
       server' <- recvMsgQuery query
       directQuerying client' server'
-    directAcquired (SendMsgReAcquire pt client') ServerStAcquired{recvMsgReAcquire} = do
-      server' <- recvMsgReAcquire pt
+    directAcquired (SendMsgReAcquire tgt client') ServerStAcquired{recvMsgReAcquire} = do
+      server' <- recvMsgReAcquire tgt
       directAcquiring client' server'
     directAcquired (SendMsgRelease client) ServerStAcquired{recvMsgRelease} = do
       client' <- client


### PR DESCRIPTION
# Description

We will use this to make it easier for the CLI to only output answers that are not subject to rollback.

This change to `LocalStateQuery` is gated by `NodeToClient_Version16`, since that is still mutable (it enables Conway et al).

It is a breaking change for any code that involves `MsgAcquire` or `MsgReAcquire`, since the type of the argument has changed to a new (more perspicuous and expressive) ADT.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested
