### PR TITLE
MiniProtocolParameters:  Change pipelining types to Word16

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -8,6 +8,9 @@
   demotion to `cold` as well as `warm` state.  A `ReconnectDelay` type alias is
   still provided but deprecated.
 
+* Changed pipelining parameters in `MiniProtocolParameters` from `Word32` to
+  `Word16` to match the types elsewhere.
+
 ### Non-breaking changes
 
 * The internal `Guarded` type changed.  It is provided with pattern synonyms

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -194,11 +194,11 @@ type NodeToNodeProtocolsWithMinimalCtx  appType ntnAddr bytes m a b =
 
 
 data MiniProtocolParameters = MiniProtocolParameters {
-      chainSyncPipeliningHighMark :: !Word32,
+      chainSyncPipeliningHighMark :: !Word16,
       -- ^ high threshold for pipelining (we will never exceed that many
       -- messages pipelined).
 
-      chainSyncPipeliningLowMark  :: !Word32,
+      chainSyncPipeliningLowMark  :: !Word16,
       -- ^ low threshold: if we hit the 'chainSyncPipeliningHighMark' we will
       -- listen for responses until there are at most
       -- 'chainSyncPipeliningLowMark' pipelined message
@@ -208,7 +208,7 @@ data MiniProtocolParameters = MiniProtocolParameters {
       -- Note: 'chainSyncPipeliningLowMark' and 'chainSyncPipeliningLowMark'
       -- are passed to 'pipelineDecisionLowHighMark'.
 
-      blockFetchPipeliningMax     :: !Word,
+      blockFetchPipeliningMax     :: !Word16,
       -- ^ maximal number of pipelined messages in 'block-fetch' mini-protocol.
 
       txSubmissionMaxUnacked      :: !Word16
@@ -341,8 +341,8 @@ blockFetchProtocolLimits MiniProtocolParameters { blockFetchPipeliningMax } = Mi
     -- In the byron era this limit was set to `10 * 2MB`, we keep the more
     -- relaxed limit here.
     --
-    maximumIngressQueue = addSafetyMargin $ fromIntegral $
-      max (10 * 2_097_154) (blockFetchPipeliningMax * 65535)
+    maximumIngressQueue = addSafetyMargin $
+      max (10 * 2_097_154 :: Int) (fromIntegral blockFetchPipeliningMax * 65_535)
   }
 
 txSubmissionProtocolLimits MiniProtocolParameters { txSubmissionMaxUnacked } = MiniProtocolLimits {


### PR DESCRIPTION
Follow on from 8258206046f13769dd9236206c57c4c0ab8e6dde.

# Description MiniProtocolParameters:  Change pipelining types to Word16

# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
