### PR TITLE
Limit the rate with which one can discover all nodes

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-breaking changes
 
+* Limit the rate at which one can discover peers through peersharing.
+
 ## 0.11.0.0 -- 2023-01-22
 
 ### Breaking changes

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -3051,7 +3051,9 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains peerSharing = do
                 policyPeerShareRetryTime         = 0, -- seconds
                 policyPeerShareBatchWaitTime     = 0, -- seconds
                 policyPeerShareOverallTimeout    = 0, -- seconds
-                policyPeerShareActivationDelay   = 1, -- seconds
+                policyPeerShareActivationDelay   = 2, -- seconds
+                policyPeerShareStickyTime        = 1, --seconds
+                policyPeerShareMaxPeers          = 10,
                 policyErrorDelay              = 0  -- seconds
               }
     pickTrivially :: Applicative m => Set SockAddr -> Int -> m (Set SockAddr)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -537,6 +537,8 @@ mockPeerSelectionPolicy GovernorMockEnvironment {
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
       policyPeerShareActivationDelay   = 300,  -- seconds
+      policyPeerShareStickyTime        = 257,  -- seconds
+      policyPeerShareMaxPeers          = 10,
       policyErrorDelay              = 10    -- seconds
     }
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -90,9 +90,11 @@ simplePeerSelectionPolicy rngVar getChurnMode metrics errorDelay = PeerSelection
       policyFindPublicRootTimeout      = 5,    -- seconds
       policyMaxInProgressPeerShareReqs = 2,
       policyPeerShareRetryTime         = 900,  -- seconds
+      policyPeerShareStickyTime        = 823,  -- seconds
       policyPeerShareBatchWaitTime     = 3,    -- seconds
       policyPeerShareOverallTimeout    = 10,   -- seconds
       policyPeerShareActivationDelay   = 300,  -- seconds
+      policyPeerShareMaxPeers          = 10,
 
       policyErrorDelay = ExitPolicy.repromoteDelay errorDelay
     }

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -117,6 +117,9 @@ data PeerSelectionPolicy peeraddr m = PeerSelectionPolicy {
        policyPeerShareRetryTime         :: !DiffTime,
        -- ^ Amount of time a node has to wait before issuing a new peer sharing
        -- request
+       policyPeerShareStickyTime        :: !DiffTime,
+       -- ^ Amount of time between changes to the salt used to pick peers to
+       -- gossip about.
        policyPeerShareBatchWaitTime     :: !DiffTime,
        -- ^ Amount of time a batch of peer sharing requests is allowed to take
        policyPeerShareOverallTimeout    :: !DiffTime,
@@ -124,6 +127,8 @@ data PeerSelectionPolicy peeraddr m = PeerSelectionPolicy {
        -- allowed to take
        policyPeerShareActivationDelay   :: !DiffTime,
        -- ^ Delay until we consider a peer suitable for peer sharing
+       policyPeerShareMaxPeers          :: !PeerSharingAmount,
+       -- ^ Maximum number of peers to respond with in a single request
 
        -- | Re-promote delay, passed from `ExitPolicy`.
        --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
@@ -493,33 +493,6 @@ getPeerSharingResponsePeers knownPeers =
 
 
 ---------------------------------
--- Selecting peers to advertise
---
-
--- | Select a random subset of the known peers that are available to publish.
---
--- The selection is done in such a way that when the same initial PRNG state is
--- used, the selected set does not significantly vary with small perturbations
--- in the set of published peers.
---
--- The intention of this selection method is that the selection should give
--- approximately the same replies to the same peers over the course of multiple
--- requests from the same peer. This is to deliberately slow the rate at which
--- peers can discover and map out the entire network.
---
-{-
-sampleAdvertisedPeers :: RandomGen prng
-                      => KnownPeers peeraddr
-                      -> prng
-                      -> Int
-                      -> [peeraddr]
-sampleAdvertisedPeers _ _ _ = []
--- idea is to generate a sequence of random numbers and map them to locations
--- in a relatively stable way, that's mostly insensitive to additions or
--- deletions
--}
-
----------------------------------
 -- Filter ledger peers
 --
 


### PR DESCRIPTION
# Description

The commented out function sampleAdvertisedPeers outlined an idea of limiting the rate with which one can discover all nodes in the network.

This implements that behaviour within computePeerSharingPeers. Given how cheap it is to create a new connection that can ask for peers the node will generate one list of peers regardless of who is asking. The list of peers will change after `policyPeerShareRetryTime` seconds. The list of peers shared does at most change by the number of peers added or removed. That is a newly added or removed peer can at most lead to one new peer beeing shared.



# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
