### PR TITLE
Bump network-mux

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -24,7 +24,7 @@ library
                        ouroboros-network-api        >= 0.5.2 && < 0.7,
                        ouroboros-network            >= 0.9 && < 0.12,
                        ouroboros-network-framework  >= 0.8 && < 0.12,
-                       network-mux                 ^>= 0.4.4,
+                       network-mux                 ^>= 0.4.5,
 
   ghc-options:         -Wall
                        -Wno-unticked-promoted-constructors

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -32,7 +32,7 @@ library
                         si-timers                    ^>=1.3,
                         strict-stm,
 
-                        network-mux                  ^>=0.4.4,
+                        network-mux                  ^>=0.4.5,
                         tdigest                      ^>=0.3,
                         text                          >=1.2.4    && <2.2,
                         transformers                  >=0.5      && <0.7,

--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Non-breaking changes
 
-## 0.4.4.0 -- 2024-01-22
+## 0.4.5.0 -- 2024-01-22
 
 ### Non-breaking changes
 

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   network-mux
-version:                0.4.4.0
+version:                0.4.5.0
 synopsis:               Multiplexing library
 description:            Multiplexing library.
 license:                Apache-2.0

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -67,7 +67,7 @@ library
                        contra-tracer,
 
                        io-classes       ^>=1.3.1,
-                       network-mux      ^>=0.4.4,
+                       network-mux      ^>=0.4.5,
                        strict-stm,
                        si-timers,
                        typed-protocols  ^>=0.1.1,

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -98,7 +98,7 @@ library
                      , monoidal-synchronisation
                                       ^>=0.1.0.5
                      , network        ^>=3.1.4
-                     , network-mux    ^>=0.4.4
+                     , network-mux    ^>=0.4.5
                      , ouroboros-network-api
                                       ^>=0.6.3
                      , ouroboros-network-testing


### PR DESCRIPTION
It turns out `network-mux-0.4.4.0` was released to `CHaP` already.
