### PR TITLE
Peersharing improvements

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -43,6 +43,10 @@
 * Updated other monitoring tasks to consider a possible sensitive state that
   involves the bootstrap peers flag and the ledger state judgement value.
 
+* Improved tracing when peersharing
+* set knownSuccessfulConnection for incomming peers
+* Don't use minPeerShareTime with GuardedSkip
+
 ## 0.11.0.0 -- 2023-01-22
 
 ### Breaking changes

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -106,7 +106,7 @@ belowTarget actions
         decisionTrace = [TracePeerShareRequests
                           targetNumberOfKnownPeers
                           numKnownPeers
-                          availableForPeerShare
+                          canAsk
                           selectedForPeerShare],
         decisionState = st {
                           inProgressPeerShareReqs = inProgressPeerShareReqs
@@ -190,7 +190,7 @@ jobPeerShare PeerSelectionActions{requestPeerShare}
                -- sharing results is welcome.
                newPeers    = [ p | Right (PeerSharingResult ps) <- totalResults
                                  , p <- ps
-                                 , not (Set.member p (PublicRootPeers.toAllLedgerPeerSet (publicRootPeers st))) ]
+                                 , not (KnownPeers.member p (knownPeers st)) ]
             in Decision { decisionTrace = [ TracePeerShareResults peerResults
                                           , TracePeerShareResultsFiltered newPeers
                                           ]

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/KnownPeers.hs
@@ -120,13 +120,6 @@ belowTarget actions
           [jobPeerShare actions policy numPeersToReq (Set.toList selectedForPeerShare)]
       }
 
-    -- If we could peer share except that there are none currently available
-    -- then we return the next wakeup time (if any)
-  | numKnownPeers < targetNumberOfKnownPeers
-  , numPeerShareReqsPossible > 0
-  , Set.null availableForPeerShare
-  = GuardedSkip (EstablishedPeers.minPeerShareTime establishedPeers)
-
   | otherwise
   = GuardedSkip Nothing
   where

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -158,6 +158,7 @@ inboundPeers PeerSelectionActions{
       (addr, ps) <- readNewInboundConnection
       return $ \_ ->
         let knownPeers' =
+              KnownPeers.setSuccessfulConnectionFlag addr $
               KnownPeers.alter
                 (\x -> case x of
                   Nothing ->


### PR DESCRIPTION
# Description

Some Peersharing improvements. 
This PR fixes a bug where a peer with a `minPeerShareTime` could prevent us from peersharing with any other peer.
This PR changes the behavior so that we can start to gossip about incoming peers directly. Previously had to promote them to warm before we would let anyone else know about them.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
