### PR TITLE
Doc: Handshake should pass TRUE for initiatorOnlyDiffusionMode

### DIFF
--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11-12.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v11-12.cddl
@@ -16,11 +16,11 @@ versionTable = { * versionNumber => nodeToNodeVersionData }
 
 versionNumber = 11 / 12
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool
 ; range between 0 and 2
 peerSharing = 0..2
 query = bool

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v13.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node-v13.cddl
@@ -16,11 +16,11 @@ versionTable = { * versionNumber => nodeToNodeVersionData }
 
 versionNumber = 13
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool
 ; range between 0 and 1
 peerSharing = 0..1
 query = bool

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-node.cddl
@@ -15,11 +15,11 @@ versionTable = { * versionNumber => nodeToNodeVersionData }
 
 versionNumber = 7 / 8 / 9 / 10
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool
 
 refuseReason
     = refuseReasonVersionMismatch

--- a/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data-v11-12.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data-v11-12.cddl
@@ -2,11 +2,11 @@
 ; NodeToNodeVersionData, v11 to v12
 ;
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool
 ; range between 0 and 2
 peerSharing = 0..2
 query = bool

--- a/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data-v13.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data-v13.cddl
@@ -2,11 +2,11 @@
 ; NodeToNodeVersionData, v13
 ;
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode, peerSharing, query ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode, peerSharing, query ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool
 ; range between 0 and 1
 peerSharing = 0..1
 query = bool

--- a/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/node-to-node-version-data.cddl
@@ -2,8 +2,8 @@
 ; NodeToNodeVersionData, v7 to v10
 ;
 
-nodeToNodeVersionData = [ networkMagic, initiatorAndResponderDiffusionMode ]
+nodeToNodeVersionData = [ networkMagic, initiatorOnlyDiffusionMode ]
 
 ; range between 0 and 0xffffffff
 networkMagic = 0..4294967295
-initiatorAndResponderDiffusionMode = bool
+initiatorOnlyDiffusionMode = bool


### PR DESCRIPTION
# Description

The network-spec.pdf document describes the handshake protocol as passing a bool flag for `initiatorAndResponderDiffusionMode`.  According to the haskell code, this should really be `initiatorOnlyDiffusionMode` since we should pass `TRUE` for requesting a unidirectional connection. I've confirmed with @karknu that this corrects a misunderstanding in the spec doc.

![Screenshot from 2024-01-24 19-54-19](https://github.com/IntersectMBO/ouroboros-network/assets/245918/c861e99a-2b54-45cc-a975-79f54be668e0)



# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [x] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
