### PR TITLE
Allow the pipelined ChainSync client to observe MsgAwaitReply messages

### DIFF
--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Breaking changes
 
+* Add side-effect argument to `SendMsgRequestNextPipelined` to be invoked
+  promptly upon `MsgAwaitReply`.
+
+* Change the arguments of both `SendMsgRequestNext` constructors to have the
+  same shape (and limited expressivity) as does `SendMsgRequestNextPipelined`
+  (since we never use the extra expressivity).
+
 ### Non-breaking changes
 
 ## 0.7.0.0 -- 2024-01-22

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Direct.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Direct.hs
@@ -23,13 +23,13 @@ direct_ :: Monad m
         -> ClientStIdle header point tip m b
         -> m (a, b)
 direct_  ServerStIdle{recvMsgRequestNext}
-        (Client.SendMsgRequestNext stNext stAwait) = do
+        (Client.SendMsgRequestNext stAwait stNext) = do
     mresp <- recvMsgRequestNext
     case mresp of
       Left  resp    -> directStNext resp stNext
       Right waiting -> do resp <- waiting
-                          stNext' <- stAwait
-                          directStNext resp stNext'
+                          stAwait
+                          directStNext resp stNext
   where
     directStNext (SendMsgRollForward header tip server')
                   ClientStNext{recvMsgRollForward} = do

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Examples.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Examples.hs
@@ -104,10 +104,10 @@ chainSyncClientExample chainvar client = ChainSyncClient $
                 -> ClientStIdle header (Point block) tip m a
     requestNext client' =
       SendMsgRequestNext
+        -- We have the opportunity to do something when receiving
+        -- MsgAwaitReply. In this example we don't take up that opportunity.
+        (pure ())
         (handleNext client')
-        -- We received a wait message, and we have the opportunity to do
-        -- something. In this example we don't take up that opportunity.
-        (return (handleNext client'))
 
     handleNext :: Client header (Point block) tip m a
                -> ClientStNext header (Point block) tip m a

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -625,8 +625,8 @@ chainSyncClient' controlMessageSTM syncTracer _currentChainVar candidateChainVar
                      BlockHeader (Point BlockHeader) (Point BlockHeader) IO ()
     requestNext =
       ChainSync.SendMsgRequestNext
+        (pure ())   -- on MsgAwaitReply; could trace
         handleNext
-        (return handleNext) -- wait case, could trace
 
     terminate :: ChainSync.ClientStIdle
                      BlockHeader (Point BlockHeader) (Point BlockHeader) IO ()


### PR DESCRIPTION
Today's code completely hides `MsgAwaitReply` from clients that have sent pipelined messages. This PR alters it so that such a peer can supply a `m ()` side-effect that will be invoked when a `MsgAwaitReply` is received.

This enables the Bootstrap State Machine to identify idle upstream peers.

The PR also does a bit more tidying -- see the commit message.