### PR TITLE
Fix hot demotion

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -49,6 +49,9 @@
 
 * `PeerSharingController` is now private and `requestPeers` is exported
 
+* Fix hot demototion by having blockfetch give chainsync a chance to exit
+  cleanly before killing it.
+
 ## 0.11.0.0 -- 2023-01-22
 
 ### Breaking changes


### PR DESCRIPTION
# Description

During hot demotion all hot protocols are supposed to be given deactivateTimeout (300s) time to exit. However as soon as blockfetch exits it will kill chainsync. This will cause the hot demotion to fail and the connection to be closed.

This patch changes the unregister logic for blockfetch so that it will attempt to give chainsync time to exit nicely before killing it. If, while waiting blockfetch receives further exceptions it will kill chainsync directly.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
