### PR TITLE
Fix local roots clamp to trustable & changed LedgerPeersConsensusInterface function type signature

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Changed `LedgerConsensusInterface` type:
     `LedgerConsensusInterface` now has to fill 3 STM actions:
-        * `lpGetLatestSlot :: STM m SlotNo`
+        * `lpGetLatestSlot :: STM m (WithOrigin SlotNo)`
         * `lpGetLedgerStateJudgment :: STM m LedgerStateJudgement`
         * `lpGetLedgerPeers :: STM m [(PoolStake, NonEmpty RelayAccessPoint)]`
 

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -17,7 +17,7 @@ module Ouroboros.Network.PeerSelection.LedgerPeers.Type
   , isLedgerPeersEnabled
   ) where
 
-import Cardano.Slotting.Slot (SlotNo (..))
+import Cardano.Slotting.Slot (SlotNo (..), WithOrigin)
 import Control.Concurrent.Class.MonadSTM
 import Control.DeepSeq (NFData (..))
 import Data.List.NonEmpty (NonEmpty)
@@ -75,7 +75,7 @@ data LedgerStateJudgement = YoungEnough | TooOld
 -- | Return ledger state information and ledger peers.
 --
 data LedgerPeersConsensusInterface m = LedgerPeersConsensusInterface {
-    lpGetLatestSlot           :: STM m SlotNo,
+    lpGetLatestSlot           :: STM m (WithOrigin SlotNo),
     lpGetLedgerStateJudgement :: STM m LedgerStateJudgement,
     lpGetLedgerPeers          :: STM m [(PoolStake, NonEmpty RelayAccessPoint)]
   }

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -54,6 +54,9 @@
 
 * Disable mean reward for new peers
 
+* Fix `targetPeers` monitoring action to use the correct set of local peers
+  when in sensitive mode.
+
 ## 0.11.0.0 -- 2023-01-22
 
 ### Breaking changes

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -370,8 +370,9 @@ mockPeerSelectionActions' tracer
         traceWith tracer TraceEnvPublicRootTTL
 
       -- Read the current ledger state judgement
-      isSensitive <- atomically $ requiresBootstrapPeers <$> readUseBootstrapPeers
-                                                         <*> readLedgerStateJudgement
+      usingBootstrapPeers <- atomically
+                           $ requiresBootstrapPeers <$> readUseBootstrapPeers
+                                                    <*> readLedgerStateJudgement
       -- If the ledger state is YoungEnough we should get ledger peers.
       -- Otherwise we should get bootstrap peers
       let publicConfigPeers = PublicRootPeers.getPublicConfigPeers publicRootPeers
@@ -379,7 +380,7 @@ mockPeerSelectionActions' tracer
           ledgerPeers       = PublicRootPeers.getLedgerPeers publicRootPeers
           bigLedgerPeers    = PublicRootPeers.getBigLedgerPeers publicRootPeers
           result =
-            if isSensitive
+            if usingBootstrapPeers
                then PublicRootPeers.fromBootstrapPeers bootstrapPeers
                else case ledgerPeersKind of
                  AllLedgerPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -88,7 +88,9 @@ targetPeers PeerSelectionActions{readPeerSelectionTargets}
             )
       -- We simply ignore target updates that are not "sane".
 
-      let -- We have to enforce the invariant that the number of root peers is
+      let usingBootstrapPeers = requiresBootstrapPeers bootstrapPeersFlag
+                                                       ledgerStateJudgement
+          -- We have to enforce the invariant that the number of root peers is
           -- not more than the target number of known peers. It's unlikely in
           -- practice so it's ok to resolve it arbitrarily using clampToLimit.
           --
@@ -101,7 +103,9 @@ targetPeers PeerSelectionActions{readPeerSelectionTargets}
           localRootPeers' =
               LocalRootPeers.clampToLimit
                               (targetNumberOfKnownPeers targets')
-            $ LocalRootPeers.clampToTrustable
+            $ (if usingBootstrapPeers
+                  then LocalRootPeers.clampToTrustable
+                  else id)
             $ localRootPeers
 
           -- We have to enforce that local and big ledger peers are disjoint.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
@@ -160,9 +160,10 @@ withPeerSelectionActions
       -> m (PublicRootPeers peeraddr, DiffTime)
     requestPublicRootPeers ledgerPeersKind n getLedgerPeers dnsSemaphore = do
       -- Check if the node is in a sensitive state
-      isSensitive <- atomically $ requiresBootstrapPeers <$> readUseBootstrapPeers
-                                                         <*> readLedgerStateJudgement
-      if isSensitive
+      usingBootstrapPeers <- atomically
+                           $ requiresBootstrapPeers <$> readUseBootstrapPeers
+                                                    <*> readLedgerStateJudgement
+      if usingBootstrapPeers
          then do
           -- If the ledger state is in sensitive state we should get trustable peers.
           (bootstrapPeers, dt) <- requestConfiguredBootstrapPeers dnsSemaphore n


### PR DESCRIPTION
# Description

Fixes an issue where the `targetPeers` monitoring action would be truncating the local roots wrongly. It also changes the type signature of `lpGetLatestSlot`