### PR TITLE
Added central configuration module

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -77,6 +77,8 @@
 
 * Implemented Churn for bootstrap peers
 
+* Coalesced various diffusion configuration parameters in a new Configuration module which were scattered around previously
+
 ## 0.11.0.0 -- 2023-01-22
 
 ### Breaking changes

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -37,6 +37,7 @@ library
                        Ouroboros.Network.BlockFetch.State
                        Ouroboros.Network.DeltaQ
                        Ouroboros.Network.Diffusion
+                       Ouroboros.Network.Diffusion.Configuration
                        Ouroboros.Network.Diffusion.P2P
                        Ouroboros.Network.Diffusion.NonP2P
                        Ouroboros.Network.Diffusion.Policies

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Ouroboros.Network.Diffusion.Configuration
+  ( DefaultNumBootstrapPeers (..)
+  , defaultNumBootstrapPeers
+  , defaultPeerSelectionTargets
+  , defaultAcceptedConnectionsLimit
+  , defaultDiffusionMode
+  , defaultPeerSharing
+  , defaultBlockFetchConfiguration
+  , defaultChainSyncTimeout
+    -- re-exports
+  , AcceptedConnectionsLimit (..)
+  , BlockFetchConfiguration (..)
+  , ChainSyncTimeout (..)
+  , MiniProtocolParameters (..)
+  , P2P (..)
+  , PeerSelectionTargets (..)
+  , PeerSharing (..)
+  , defaultMiniProtocolParameters
+  , deactivateTimeout
+  , closeConnectionTimeout
+  , peerMetricsConfiguration
+  , defaultTimeWaitTimeout
+  , defaultProtocolIdleTimeout
+  , defaultResetTimeout
+  , handshake_QUERY_SHUTDOWN_DELAY
+  , ps_POLICY_PEER_SHARE_STICKY_TIME
+  , ps_POLICY_PEER_SHARE_MAX_PEERS
+  ) where
+
+import System.Random (randomRIO)
+
+import Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
+import Ouroboros.Network.ConnectionManager.Core (defaultProtocolIdleTimeout,
+           defaultResetTimeout, defaultTimeWaitTimeout)
+import Ouroboros.Network.Diffusion (P2P (..))
+import Ouroboros.Network.Diffusion.Policies (closeConnectionTimeout,
+           deactivateTimeout, peerMetricsConfiguration)
+import Ouroboros.Network.NodeToNode (MiniProtocolParameters (..),
+           defaultMiniProtocolParameters)
+import Ouroboros.Network.PeerSelection.Governor.Types
+           (PeerSelectionTargets (..))
+import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
+import Ouroboros.Network.PeerSharing (ps_POLICY_PEER_SHARE_MAX_PEERS,
+           ps_POLICY_PEER_SHARE_STICKY_TIME)
+import Ouroboros.Network.Protocol.ChainSync.Codec (ChainSyncTimeout (..))
+import Ouroboros.Network.Protocol.Handshake (handshake_QUERY_SHUTDOWN_DELAY)
+import Ouroboros.Network.Protocol.Limits (shortWait)
+import Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
+
+
+newtype DefaultNumBootstrapPeers = DefaultNumBootstrapPeers { getDefaultNumBootstrapPeers :: Int }
+  deriving (Eq, Show)
+
+defaultNumBootstrapPeers :: DefaultNumBootstrapPeers
+defaultNumBootstrapPeers = DefaultNumBootstrapPeers 30
+
+-- |Outbound governor targets
+--
+defaultPeerSelectionTargets :: PeerSelectionTargets
+defaultPeerSelectionTargets =
+  PeerSelectionTargets {
+    targetNumberOfRootPeers                 = 85,
+    targetNumberOfKnownPeers                = 85,
+    targetNumberOfEstablishedPeers          = 40,
+    targetNumberOfActivePeers               = 15,
+    targetNumberOfKnownBigLedgerPeers       = 15,
+    targetNumberOfEstablishedBigLedgerPeers = 10,
+    targetNumberOfActiveBigLedgerPeers      = 5 }
+
+-- |Inbound governor targets
+--
+defaultAcceptedConnectionsLimit :: AcceptedConnectionsLimit
+defaultAcceptedConnectionsLimit =
+  AcceptedConnectionsLimit {
+    acceptedConnectionsHardLimit = 512,
+    acceptedConnectionsSoftLimit = 384,
+    acceptedConnectionsDelay     = 5 }
+
+-- |Principal mode of network operation
+defaultDiffusionMode :: P2P
+defaultDiffusionMode = NonP2P
+
+-- |Node's peer sharing participation flag
+defaultPeerSharing :: PeerSharing
+defaultPeerSharing = PeerSharingDisabled
+
+-- | Configuration for FetchDecisionPolicy.
+defaultBlockFetchConfiguration :: Int -> BlockFetchConfiguration
+defaultBlockFetchConfiguration bfcSalt =
+  BlockFetchConfiguration {
+    bfcMaxConcurrencyBulkSync = 1,
+    bfcMaxConcurrencyDeadline = 1,
+    bfcMaxRequestsInflight    = fromIntegral $ blockFetchPipeliningMax defaultMiniProtocolParameters,
+    bfcDecisionLoopInterval   = 0.01, -- 10ms
+    bfcSalt }
+
+defaultChainSyncTimeout :: IO ChainSyncTimeout
+defaultChainSyncTimeout = do
+    -- These values approximately correspond to false positive
+    -- thresholds for streaks of empty slots with 99% probability,
+    -- 99.9% probability up to 99.999% probability.
+    -- t = T_s [log (1-Y) / log (1-f)]
+    -- Y = [0.99, 0.999...]
+    -- T_s = slot length of 1s.
+    -- f = 0.05
+    -- The timeout is randomly picked per bearer to avoid all bearers
+    -- going down at the same time in case of a long streak of empty
+    -- slots.
+    -- To avoid global synchronosation the timeout is picked uniformly
+    -- from the interval 135 - 269, corresponds to the a 99.9% to
+    -- 99.9999% thresholds.
+    -- TODO: The timeout should be drawn at random everytime chainsync
+    --       enters the must reply state. A static per connection timeout
+    --       leads to selection preassure for connections with a large
+    --       timeout, see #4244.
+    mustReplyTimeout <- Just . realToFrac <$> randomRIO (135,269 :: Double)
+    return ChainSyncTimeout { canAwaitTimeout  = shortWait,
+                              intersectTimeout = shortWait,
+                              mustReplyTimeout,
+                              idleTimeout      = Just 3673 }


### PR DESCRIPTION
# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

resolves #4805 

# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
