### PR TITLE
Document that `NodeToNodeV_12` is now unused

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -57,9 +57,10 @@ data NodeToNodeVersion
     --   in Peer Sharing to newer versions.
     -- * Adds `query` to NodeToClientVersionData.
     | NodeToNodeV_12
-    -- ^ Changes:
+    -- ^ No changes.
     --
-    -- * Enable @CardanoNodeToNodeVersion7@, i.e., Conway
+    -- (In the past, this enabled Conway, but the negotiated 'NodeToNodeVersion'
+    -- no longer en-/disables eras.)
     | NodeToNodeV_13
     -- ^ Changes:
     --


### PR DESCRIPTION
See https://github.com/IntersectMBO/ouroboros-consensus/pull/913
