### PR TITLE
Peersharing improvements

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Added `PeerSharingAPI` with all the things necessary to run peer sharing.
 * Fix 'any Cold async demotion' test
 * Let light peer sharing depend on the configured peer sharing flag
+* Split churning of non-active peers into an established step and a known step.
+* When peer sharing ask for more peers than needed, but only add as many unique
+    peers as desired.
 
 ## 0.12.0.0 -- 2023-02-21
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE NamedFieldPuns    #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns             #-}
+{-# LANGUAGE OverloadedStrings          #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -19,6 +20,7 @@ import Data.Word (Word32)
 
 import Ouroboros.Network.PeerSelection.Governor
 
+import Data.Hashable
 import Data.IP qualified as IP
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise (..))
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
@@ -39,7 +41,7 @@ import Test.QuickCheck
 -- | Simple address representation for the tests
 --
 newtype PeerAddr = PeerAddr Int
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Hashable)
 
 -- | We mostly avoid using this instance since we need careful control over
 -- the peer addrs, e.g. to make graphs work, and sets overlap etc. But it's

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -45,6 +45,7 @@ import Control.Monad.Fix (MonadFix)
 import Control.Tracer (Tracer, contramap, nullTracer, traceWith)
 import Data.ByteString.Lazy (ByteString)
 import Data.Foldable (asum)
+import Data.Hashable (Hashable)
 import Data.IP (IP)
 import Data.IP qualified as IP
 import Data.List.NonEmpty (NonEmpty (..))
@@ -535,6 +536,7 @@ runM
        , Typeable  ntnAddr
        , Ord       ntnAddr
        , Show      ntnAddr
+       , Hashable  ntnAddr
        , Typeable  ntnVersion
        , Ord       ntnVersion
        , Show      ntnVersion

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -36,6 +36,7 @@ module Ouroboros.Network.PeerSelection.Governor
 
 import Data.Cache
 import Data.Foldable (traverse_)
+import Data.Hashable
 import Data.Void (Void)
 
 import Control.Applicative (Alternative ((<|>)))
@@ -440,6 +441,7 @@ peerSelectionGovernor :: ( Alternative (STM m)
                          , MonadTimer m
                          , Ord peeraddr
                          , Show peerconn
+                         , Hashable peeraddr
                          )
                       => Tracer m (TracePeerSelection peeraddr)
                       -> Tracer m (DebugPeerSelection peeraddr)
@@ -488,6 +490,7 @@ peerSelectionGovernorLoop :: forall m peeraddr peerconn.
                              , MonadTimer m
                              , Ord peeraddr
                              , Show peerconn
+                             , Hashable peeraddr
                              )
                           => Tracer m (TracePeerSelection peeraddr)
                           -> Tracer m (DebugPeerSelection peeraddr)


### PR DESCRIPTION
# Description


Ask for more peers than needed. This makes it a lot easier for a node to reach its known peers target when peer sharing. Especially when only a few of its peers support peer sharing.

Split the forgetting of non-active peers into an established and a known phase. This means that we can pick newly demoted established peers to forget too.



# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
