### PR TITLE
Release ouroboros-network 0.13.0.0

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -23,7 +23,7 @@ library
                        bytestring        >=0.10 && <0.13,
                        containers,
                        ouroboros-network-api        >= 0.5.2 && < 0.8,
-                       ouroboros-network            >= 0.9 && < 0.13,
+                       ouroboros-network            >= 0.9 && < 0.14,
                        ouroboros-network-framework  >= 0.8 && < 0.12,
                        network-mux                 ^>= 0.4.5,
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,21 +6,22 @@
 
 ### Non-Breaking changes
 
-## 0.12.1.0 -- 2023-03-14
+## 0.13.0.0 -- 2023-03-14
 
 ### Breaking changes
+
+* Added `PeerSharingAPI` with all the things necessary to run peer sharing.
 
 ### Non-Breaking changes
 
 * Fix `LedgerStateJudgement` redundant tracing
 * Refactored `computePeerSharingPeers` and moved it to
   `Ouroboros.Network.Peersharing`
-* Added `PeerSharingAPI` with all the things necessary to run peer sharing.
 * Fix 'any Cold async demotion' test
 * Let light peer sharing depend on the configured peer sharing flag
 * Split churning of non-active peers into an established step and a known step.
 * When peer sharing ask for more peers than needed, but only add as many unique
-    peers as desired.
+  peers as desired.
 
 ## 0.12.0.0 -- 2023-02-21
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network
-version:                0.12.1.0
+version:                0.13.0.0
 synopsis:               A networking layer for the Ouroboros blockchain protocol
 description:            A networking layer for the Ouroboros blockchain protocol.
 license:                Apache-2.0


### PR DESCRIPTION
This is a fix for the previous commit which wrongly tries to release version 0.12.1.0.


