### PR TITLE
Release ouroboros-network-framework 0.12.0.0

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -24,7 +24,7 @@ library
                        containers,
                        ouroboros-network-api        >= 0.5.2 && < 0.8,
                        ouroboros-network            >= 0.9 && < 0.14,
-                       ouroboros-network-framework  >= 0.8 && < 0.12,
+                       ouroboros-network-framework  >= 0.8 && < 0.13,
                        network-mux                 ^>= 0.4.5,
 
   ghc-options:         -Wall

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -6,13 +6,14 @@
 
 ### Non-breaking changes
 
-## 0.11.2.0 -- 2024-03-14
+## 0.12.0.0 -- 2024-03-15
 
 ### Breaking changes
 
+* Let light peer sharing depend on the configured peer sharing flag
+
 ### Non-breaking changes
 
-* Let light peer sharing depend on the configured peer sharing flag
 * Added `Generic` and `NFData` instance derivations for `NodeToNodeVersion`
   data type
 * Added `NFData` for `Handshake` protocol related types

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network-framework
-version:                0.11.2.0
+version:                0.12.0.0
 synopsis:               Ouroboros network framework
 description:            Ouroboros network framework.
 license:                Apache-2.0

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -134,7 +134,7 @@ library
                        network-mux,
                        si-timers,
                        ouroboros-network-api       ^>=0.7.1,
-                       ouroboros-network-framework ^>=0.11.2,
+                       ouroboros-network-framework ^>=0.12,
                        ouroboros-network-protocols ^>=0.8,
                        strict-stm,
                        typed-protocols  ^>=0.1.1,


### PR DESCRIPTION
This fixes previous release PRs that were releasing ouroboros-network-framework as a minor bump instead of a major bump


