### PR TITLE
Honour policyPeerShareActivationDelay timeout

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Breaking changes
 
 ### Non-Breaking changes
+* Honour policyPeerShareActivationDelay timeout when peersharing
 
 ## 0.13.0.0 -- 2023-03-14
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Non-Breaking changes
 * Honour policyPeerShareActivationDelay timeout when peersharing
+* Increase timeout to 120s for 'any Cold async demotion' test
 
 ## 0.13.0.0 -- 2023-03-14
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -837,7 +837,7 @@ prop_track_coolingToCold_demotions defaultBearerInfo diffScript =
           notInProgressDemoteToColdForTooLong =
             map (\addr ->
                   Signal.keyedTimeoutTruncated
-                    60
+                    120
                     (\case
                         Just s | Set.member addr s -> Set.singleton addr
                         _                          -> Set.empty

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/EstablishedPeers.hs
@@ -431,9 +431,10 @@ jobPromoteColdPeer PeerSelectionActions {
                                          }
                              }
                              now ->
-        let establishedPeers' = EstablishedPeers.insert peeraddr peerconn
-                                                        (addTime policyPeerShareActivationDelay now)
-                                                        establishedPeers
+        let psTime = case peerSharing of
+                          PeerSharingEnabled  -> Just (addTime policyPeerShareActivationDelay now)
+                          PeerSharingDisabled -> Nothing
+            establishedPeers' = EstablishedPeers.insert peeraddr peerconn psTime establishedPeers
             advertise = case peerSharing of
                           PeerSharingEnabled  -> DoAdvertisePeer
                           PeerSharingDisabled -> DoNotAdvertisePeer

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -53,6 +53,7 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Monoid.Synchronisation (FirstToFinish (..))
+import Data.OrdPSQ qualified as PSQ
 import Data.Semigroup (Min (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
@@ -722,6 +723,11 @@ assertPeerSelectionState PeerSelectionState{..} =
     -- and disjoint local root peers.
   . assert (Set.isSubsetOf bigLedgerPeers knownPeersSet)
   . assert (Set.null (Set.intersection bigLedgerPeers localRootPeersSet))
+
+    -- Only peer which has support peersharing should be possible to issue
+    -- peersharing requests to.
+  . assert (Set.isSubsetOf establishedShareSet
+      (KnownPeers.getPeerSharingRequestPeers knownPeersSet knownPeers))
   where
     knownPeersSet       = KnownPeers.toSet knownPeers
     localRootPeersSet   = LocalRootPeers.keysSet localRootPeers
@@ -729,6 +735,9 @@ assertPeerSelectionState PeerSelectionState{..} =
     bigLedgerPeers      = PublicRootPeers.getBigLedgerPeers publicRootPeers
     establishedPeersSet = EstablishedPeers.toSet      establishedPeers
     establishedReadySet = EstablishedPeers.readyPeers establishedPeers
+    establishedShareSet = EstablishedPeers.availableForPeerShare establishedPeers <>
+                            Set.fromList (PSQ.keys (EstablishedPeers.nextPeerShareTimes
+                                                    establishedPeers))
     activePeersSet      = activePeers
     coldPeersSet        = knownPeersSet Set.\\ establishedPeersSet
     warmPeersSet        = establishedPeersSet Set.\\ activePeersSet


### PR DESCRIPTION
# Description
The policyPeerShareActivationDelay was effectivly ignored.
Commit 194ea32b removed the timeout logic because it was broken. This
was because availableForPeerShare contained a mix of peers that supported
and didn't support peersharing. As soon as a peer that doesn't support
peersharing is more than 900s old it would prevent any timeouts from
taking effect.
    
This commit change it so that only peers that support peersharing are
added to nextPeerShareTimes/availableForPeerShare. With that the
Guarskip related minPeerShareTime can be restored.


# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
