### PR TITLE
Expose OutboundConnectionState for consensus

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-Breaking changes
 
+* Added `OutboundConnectionsState` data type
+
 ## 0.7.1.0 -- 2024-03-14
 
 ### Breaking changes

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -43,6 +43,7 @@ library
 
                        Ouroboros.Network.PeerSelection.Bootstrap
                        Ouroboros.Network.PeerSelection.LedgerPeers.Type
+                       Ouroboros.Network.PeerSelection.LocalRootPeers
                        Ouroboros.Network.PeerSelection.PeerMetric.Type
                        Ouroboros.Network.PeerSelection.PeerAdvertise
                        Ouroboros.Network.PeerSelection.PeerTrustable

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState (..)) where
+
+import GHC.Generics
+import NoThunks.Class
+
+data OutboundConnectionsState =
+    TrustedStateWithExternalPeers
+    -- ^
+    -- * /in the Praos mode/: connected only to trusted local
+    --   peers and at least one bootstrap peer or public root;
+    -- * /in the Genesis mode/: meeting target of active big ledger peers;
+    -- * or it is in `Unrestricted` mode
+    --   (see `Ouroboros.Network.PeerSelection.Governor.AssociationMode`).
+
+  | UntrustedState
+    -- ^ catch all other cases
+  deriving (Eq, Show, Generic)
+
+instance NoThunks OutboundConnectionsState

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -11,6 +11,11 @@
   The counters cover more groups including: all peers, big ledger peers,
   bootstrap peers, local roots and shared peers.
 * `emptyPeerSelectionState` doesn't take targets of local roots.
+* Added `daUpdateOutboundConnectionsState :: OutboundConnectionsState -> STM m ()`
+  to `Diffusion.Common.Applications`. This callback is to be provided by
+  consensus and is propagated all the way to the peer selection governor.
+* Added `AssociationMode` and `LedgerStateJudgement` to `DebugPeerSelectionState`.
+  Both should be exposed through `EKG` counters by the node.
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -94,6 +94,7 @@ import Simulation.Network.Snocket (AddressType (..), FD)
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
            (LedgerPeersConsensusInterface, UseLedgerPeers)
+import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise (..))
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
@@ -124,6 +125,8 @@ data Interfaces m = Interfaces
     , iDomainMap         :: StrictTVar m (Map Domain [(IP, TTL)])
     , iLedgerPeersConsensusInterface
                          :: LedgerPeersConsensusInterface m
+    , iUpdateOutboundConnectionsState
+                         :: OutboundConnectionsState -> STM m ()
     }
 
 type NtNFD m = FD m NtNAddr
@@ -410,6 +413,8 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
       , Node.aaShouldChainSyncExit      = aShouldChainSyncExit na
       , Node.aaChainSyncEarlyExit       = aChainSyncEarlyExit na
       , Node.aaOwnPeerSharing           = aOwnPeerSharing na
+      , Node.aaUpdateOutboundConnectionsState =
+          iUpdateOutboundConnectionsState ni
       }
 
 --- Utils

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -88,6 +88,7 @@ import Ouroboros.Network.NodeToNode (blockFetchMiniProtocolNum,
            chainSyncMiniProtocolNum, keepAliveMiniProtocolNum,
            peerSharingMiniProtocolNum)
 import Ouroboros.Network.PeerSelection.LedgerPeers
+import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
 import Ouroboros.Network.PeerSelection.PeerSharing qualified as PSTypes
 import Ouroboros.Network.PeerSharing (PeerSharingAPI, bracketPeerSharingClient,
            peerSharingClient, peerSharingServer)
@@ -205,6 +206,8 @@ data AppArgs header block m = AppArgs
   , aaChainSyncEarlyExit  :: Bool
   , aaOwnPeerSharing
      :: PSTypes.PeerSharing
+  , aaUpdateOutboundConnectionsState
+     :: OutboundConnectionsState -> STM m ()
   }
 
 
@@ -253,6 +256,7 @@ applications debugTracer nodeKernel
                , aaShouldChainSyncExit
                , aaChainSyncEarlyExit
                , aaOwnPeerSharing
+               , aaUpdateOutboundConnectionsState
                }
              toHeader =
     Diff.Applications
@@ -270,6 +274,8 @@ applications debugTracer nodeKernel
                                   localResponderApp
       , Diff.daLedgerPeersCtx =
           aaLedgerPeersConsensusInterface
+      , Diff.daUpdateOutboundConnectionsState =
+          aaUpdateOutboundConnectionsState
       }
   where
     initiatorApp

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -86,6 +86,8 @@ instance Arbitrary ArbitraryLedgerStateJudgement where
     shrink (ArbitraryLedgerStateJudgement TooOld)      =
       []
 
+-- TODO: import the `SlotNo` instance from
+-- `Test.Ouroboros.Network.PeerSelection.Instances`
 newtype ArbitrarySlotNo =
   ArbitrarySlotNo {
     getArbitrarySlotNo :: SlotNo

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -211,11 +211,14 @@ governorAction mockEnv = do
                              (ledgerStateJudgement mockEnv)
     usbVar <- playTimedScript (contramap TraceEnvSetUseBootstrapPeers tracerMockEnv)
                              (useBootstrapPeers mockEnv)
-    debugVar <- StrictTVar.newTVarIO (emptyPeerSelectionState (mkStdGen 42))
+    debugStateVar <- StrictTVar.newTVarIO (emptyPeerSelectionState (mkStdGen 42))
     countersVar <- StrictTVar.newTVarIO emptyPeerSelectionCounters
     policy  <- mockPeerSelectionPolicy                mockEnv
     actions <- mockPeerSelectionActions tracerMockEnv mockEnv (readTVar usbVar) (readTVar lsjVar) policy
     let interfaces = PeerSelectionInterfaces {
+            countersVar,
+            publicStateVar,
+            debugStateVar,
             -- peer selection tests are not relying on `UseLedgerPeers`
             readUseLedgerPeers = return DontUseLedgerPeers
           }
@@ -228,9 +231,6 @@ governorAction mockEnv = do
         tracerDebugPeerSelection
         tracerTracePeerSelectionCounters
         (mkStdGen 42)
-        countersVar
-        publicStateVar
-        debugVar
         actions
         policy
         interfaces

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -34,7 +34,7 @@ module Test.Ouroboros.Network.Testnet.Simulation.Node
 import Control.Applicative (Alternative)
 import Control.Concurrent.Class.MonadMVar (MonadMVar)
 import Control.Concurrent.Class.MonadSTM.Strict
-import Control.Monad (forM)
+import Control.Monad (forM, when)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadSay
@@ -120,6 +120,8 @@ import Data.Typeable (Typeable)
 import Ouroboros.Network.BlockFetch (FetchMode (..), TraceFetchClientState,
            TraceLabelPeer (..))
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
+import Ouroboros.Network.PeerSelection.LocalRootPeers
+           (OutboundConnectionsState (..))
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise (..))
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
 import Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
@@ -1066,6 +1068,7 @@ diffusionSimulation
             dMapVar = do
       chainSyncExitVar <- newTVarIO chainSyncExitOnBlockNo
       ledgerPeersVar <- initScript' ledgerPeers
+      onlyOutboundConnectionsStateVar <- newTVarIO UntrustedState
       let (bgaRng, rng) = Random.split $ mkStdGen seed
           acceptedConnectionsLimit =
             AcceptedConnectionsLimit maxBound maxBound 0
@@ -1147,6 +1150,11 @@ diffusionSimulation
                              $ accPoolStake
                              $ getLedgerPools
                              $ ledgerPools)
+              , NodeKernel.iUpdateOutboundConnectionsState =
+                  \a -> do
+                    a' <- readTVar onlyOutboundConnectionsStateVar
+                    when (a /= a') $
+                      writeTVar onlyOutboundConnectionsStateVar a
               }
 
           shouldChainSyncExit :: StrictTVar m (Maybe BlockNo) -> BlockHeader -> m Bool

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
@@ -34,6 +34,7 @@ import Ouroboros.Network.NodeToNode qualified as NodeToNode
 import Ouroboros.Network.PeerSelection.Governor.Types (PublicPeerSelectionState)
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
            (LedgerPeersConsensusInterface)
+import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
 import Ouroboros.Network.Snocket (FileDescriptor)
 import Ouroboros.Network.Socket (SystemdSocketTracer)
 
@@ -193,4 +194,13 @@ data Applications ntnAddr ntnVersion ntnVersionData
       --
       -- TODO: it should be in 'InterfaceExtra'
     , daLedgerPeersCtx :: LedgerPeersConsensusInterface m
+
+      -- | Callback provided by consensus to inform it if the node is
+      -- connected to only local roots or also some external peers.
+      --
+      -- This is useful in order for the Bootstrap State Machine to
+      -- simply refuse to transition from TooOld to YoungEnough while
+      -- it only has local peers.
+      --
+    , daUpdateOutboundConnectionsState :: OutboundConnectionsState -> STM m ()
   }

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1006,12 +1006,12 @@ runM Interfaces
               peerSelectionTracer
               dtTracePeerSelectionCounters
               fuzzRng
-              countersVar
-              daPublicPeerSelectionVar
-              dbgVar
               peerSelectionActions
               peerSelectionPolicy
               PeerSelectionInterfaces {
+                countersVar,
+                publicStateVar     = daPublicPeerSelectionVar,
+                debugStateVar      = dbgVar,
                 readUseLedgerPeers = daReadUseLedgerPeers
               }
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -125,7 +125,6 @@ import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import Ouroboros.Network.PeerSelection.PeerStateActions (PeerConnectionHandle,
            PeerSelectionActionsTrace (..), PeerStateActionsArguments (..),
            pchPeerSharing, withPeerStateActions)
-import Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
 import Ouroboros.Network.PeerSelection.RootPeersDNS
 import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions (DNSActions,
@@ -134,8 +133,7 @@ import Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
            (TraceLocalRootPeers)
 import Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
            (TracePublicRootPeers)
-import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency,
-           WarmValency)
+import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRootPeers
 import Ouroboros.Network.PeerSharing (PeerSharingRegistry (..))
 import Ouroboros.Network.RethrowPolicy
 import Ouroboros.Network.Server2 (ServerArguments (..), ServerTrace (..))
@@ -246,17 +244,17 @@ nullTracers =
 data ArgumentsExtra m = ArgumentsExtra {
       -- | selection targets for the peer governor
       --
-      daPeerSelectionTargets :: PeerSelectionTargets
+      daPeerSelectionTargets  :: PeerSelectionTargets
 
-    , daReadLocalRootPeers  :: STM m [(HotValency, WarmValency, Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
-    , daReadPublicRootPeers :: STM m (Map RelayAccessPoint PeerAdvertise)
+    , daReadLocalRootPeers    :: STM m (LocalRootPeers.Config RelayAccessPoint)
+    , daReadPublicRootPeers   :: STM m (Map RelayAccessPoint PeerAdvertise)
     , daReadUseBootstrapPeers :: STM m UseBootstrapPeers
 
     -- | Peer's own PeerSharing value.
     --
     -- This value comes from the node's configuration file and is static.
-    , daOwnPeerSharing      :: PeerSharing
-    , daReadUseLedgerPeers  :: STM m UseLedgerPeers
+    , daOwnPeerSharing        :: PeerSharing
+    , daReadUseLedgerPeers    :: STM m UseLedgerPeers
 
       -- | Timeout which starts once all responder protocols are idle. If the
       -- responders stay idle for duration of the timeout, the connection will
@@ -267,7 +265,7 @@ data ArgumentsExtra m = ArgumentsExtra {
       --
       -- See 'serverProtocolIdleTimeout'.
       --
-    , daProtocolIdleTimeout :: DiffTime
+    , daProtocolIdleTimeout   :: DiffTime
 
       -- | Time for which /node-to-node/ connections are kept in
       -- 'TerminatingState', it should correspond to the OS configured @TCP@
@@ -277,7 +275,7 @@ data ArgumentsExtra m = ArgumentsExtra {
       -- purpose is to be resilient for delayed packets in the same way @TCP@
       -- is using @TIME_WAIT@.
       --
-    , daTimeWaitTimeout :: DiffTime
+    , daTimeWaitTimeout       :: DiffTime
 
       -- | Churn interval between churn events in deadline mode.  A small fuzz
       -- is added (max 10 minutes) so that not all nodes churn at the same time.
@@ -291,7 +289,7 @@ data ArgumentsExtra m = ArgumentsExtra {
       --
       -- By default it is set to 300 seconds.
       --
-    , daBulkChurnInterval :: DiffTime
+    , daBulkChurnInterval     :: DiffTime
     }
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -29,10 +29,12 @@ module Ouroboros.Network.PeerSelection.Governor.Types
     -- These records are needed to run the peer selection.
   , PeerStateActions (..)
   , PeerSelectionActions (..)
+  , PeerSelectionInterfaces (..)
   , ChurnMode (..)
     -- * P2P governor internals
   , PeerSelectionState (..)
   , emptyPeerSelectionState
+  , AssociationMode (..)
   , DebugPeerSelectionState (..)
   , makeDebugPeerSelectionState
   , assertPeerSelectionState
@@ -143,7 +145,8 @@ import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
 import Ouroboros.Network.PeerSelection.LedgerPeers (IsBigLedgerPeer,
            LedgerPeersKind)
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
-           (LedgerStateJudgement (..))
+           (LedgerStateJudgement (..), UseLedgerPeers (..))
+import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
 import Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
@@ -386,8 +389,28 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
 
        -- | Read the current ledger state judgement
        --
-       readLedgerStateJudgement :: STM m LedgerStateJudgement
+       readLedgerStateJudgement :: STM m LedgerStateJudgement,
+
+       -- | Callback provided by consensus to inform it if the node is
+       -- connected to only local roots or also some external peers.
+       --
+       -- This is useful in order for the Bootstrap State Machine to
+       -- simply refuse to transition from TooOld to YoungEnough while
+       -- it only has local peers.
+       --
+       updateOutboundConnectionsState :: OutboundConnectionsState -> STM m ()
+
      }
+
+-- | Interfaces required by the peer selection governor, which do not need to
+-- be shared with actions and thus are not part of `PeerSelectionActions`.
+--
+-- TODO: add other `TVar`s which outbound governor is using.
+--
+data PeerSelectionInterfaces m = PeerSelectionInterfaces {
+      readUseLedgerPeers :: STM m UseLedgerPeers
+    }
+
 
 -- | Callbacks which are performed to change peer state.
 --
@@ -536,6 +559,27 @@ data PeerSelectionState peeraddr peerconn = PeerSelectionState {
      }
   deriving Show
 
+-- | A node is classified as `LocalRootsOnly` if it is a hidden relay or
+-- a BP, e.g. if it is configured such that it can only have a chance to be
+-- connected to local roots. This is true if the node is configured in one of
+-- two ways:
+--
+-- * `DontUseBootstrapPeers`, `DontUseLedgerPeers` and
+--   `PeerSharingDisabled`; or
+-- * `UseBootstrapPeers`, `DontUseLedgerPeers` and
+--   `PeerSharingDisabled`, but it's not using any bootstrap peers (i.e. it is
+--   synced).
+--
+-- Note that in the second case a node might transition between `LocalRootsOnly`
+-- and `Unrestricted` modes, depending on `LedgerStateJudgement`.
+--
+-- See `Ouroboros.Network.PeerSelection.Governor.readAssociationMode`.
+--
+data AssociationMode =
+     LocalRootsOnly
+   | Unrestricted
+  deriving Show
+
 -----------------------
 -- Debug copy of Peer Selection State
 --
@@ -561,14 +605,18 @@ data DebugPeerSelectionState peeraddr = DebugPeerSelectionState {
        dpssInProgressDemoteHot         :: !(Set peeraddr),
        dpssInProgressDemoteToCold      :: !(Set peeraddr),
        dpssUpstreamyness               :: !(Map peeraddr Int),
-       dpssFetchynessBlocks            :: !(Map peeraddr Int)
+       dpssFetchynessBlocks            :: !(Map peeraddr Int),
+       dpssLedgerStateJudgement        :: !LedgerStateJudgement,
+       dpssAssociationMode             :: !AssociationMode
 } deriving Show
 
 makeDebugPeerSelectionState :: PeerSelectionState peeraddr peerconn
                             -> Map peeraddr Int
                             -> Map peeraddr Int
+                            -> LedgerStateJudgement
+                            -> AssociationMode
                             -> DebugPeerSelectionState peeraddr
-makeDebugPeerSelectionState PeerSelectionState {..} up bp =
+makeDebugPeerSelectionState PeerSelectionState {..} up bp lsj am =
   DebugPeerSelectionState {
       dpssTargets                     = targets
     , dpssLocalRootPeers              = localRootPeers
@@ -590,6 +638,8 @@ makeDebugPeerSelectionState PeerSelectionState {..} up bp =
     , dpssInProgressDemoteToCold      = inProgressDemoteToCold
     , dpssUpstreamyness               = up
     , dpssFetchynessBlocks            = bp
+    , dpssLedgerStateJudgement        = lsj
+    , dpssAssociationMode             = am
     }
 
 -- | Public 'PeerSelectionState' that can be accessed by Peer Sharing
@@ -622,8 +672,7 @@ makePublicPeerSelectionStateVar = newTVarIO emptyPublicPeerSelectionState
 --
 toPublicState :: PeerSelectionState peeraddr peerconn
               -> PublicPeerSelectionState peeraddr
-toPublicState PeerSelectionState { knownPeers
-                                 } =
+toPublicState PeerSelectionState { knownPeers } =
    PublicPeerSelectionState {
      availableToShare =
        KnownPeers.getPeerSharingResponsePeers knownPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -147,9 +147,7 @@ import Ouroboros.Network.PeerSelection.LedgerPeers (IsBigLedgerPeer,
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
            (LedgerStateJudgement (..), UseLedgerPeers (..))
 import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
-import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
-import Ouroboros.Network.PeerSelection.PeerTrustable (PeerTrustable)
 import Ouroboros.Network.PeerSelection.PublicRootPeers (PublicRootPeers)
 import Ouroboros.Network.PeerSelection.PublicRootPeers qualified as PublicRootPeers
 import Ouroboros.Network.PeerSelection.State.EstablishedPeers (EstablishedPeers)
@@ -318,8 +316,6 @@ sanePeerSelectionTargets PeerSelectionTargets{..} =
  && targetNumberOfKnownBigLedgerPeers       <= 10000
 
 
--- | Actions performed by the peer selection governor.
---
 -- These being pluggable allows:
 --
 -- * choice of known peer root sets
@@ -339,10 +335,7 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
        -- It is structured as a collection of (non-overlapping) groups of peers
        -- where we are supposed to select n from each group.
        --
-       readLocalRootPeers       :: STM m [( HotValency
-                                          , WarmValency
-                                          , Map peeraddr ( PeerAdvertise
-                                                         , PeerTrustable))],
+       readLocalRootPeers       :: STM m (LocalRootPeers.Config peeraddr),
 
        readNewInboundConnection :: STM m (peeraddr, PeerSharing),
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -405,10 +405,24 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
 -- | Interfaces required by the peer selection governor, which do not need to
 -- be shared with actions and thus are not part of `PeerSelectionActions`.
 --
--- TODO: add other `TVar`s which outbound governor is using.
---
-data PeerSelectionInterfaces m = PeerSelectionInterfaces {
-      readUseLedgerPeers :: STM m UseLedgerPeers
+data PeerSelectionInterfaces peeraddr peerconn m = PeerSelectionInterfaces {
+      -- | PeerSelectionCounters are shared with churn through a `StrictTVar`.
+      --
+      countersVar                   :: StrictTVar m PeerSelectionCounters,
+
+      -- | PublicPeerSelectionState var.
+      --
+      publicStateVar                :: StrictTVar m (PublicPeerSelectionState peeraddr),
+
+      -- | PeerSelectionState shared for debugging purposes (to support SIGUSR1
+      -- debug event tracing)
+      --
+      debugStateVar                 :: StrictTVar m (PeerSelectionState peeraddr peerconn),
+
+      -- | `UseLedgerPeers` used by `peerSelectionGovernor` to support
+      -- `HiddenRelayOrBP`
+      --
+      readUseLedgerPeers            :: STM m UseLedgerPeers
     }
 
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
@@ -38,26 +38,19 @@ import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore (DNSSemaphore,
            newDNSLocalRootSemaphore, withDNSSemaphore)
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency,
            WarmValency)
+import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRootPeers
 
 data TraceLocalRootPeers peerAddr exception =
-       TraceLocalRootDomains [( HotValency
-                              , WarmValency
-                              , Map RelayAccessPoint (PeerAdvertise, PeerTrustable))]
+       TraceLocalRootDomains (LocalRootPeers.Config RelayAccessPoint)
        -- ^ 'Int' is the configured valency for the local producer groups
      | TraceLocalRootWaiting DomainAccessPoint DiffTime
      | TraceLocalRootResult  DomainAccessPoint [(IP, DNS.TTL)]
-     | TraceLocalRootGroups  [( HotValency
-                              , WarmValency
-                              , Map peerAddr (PeerAdvertise, PeerTrustable))]
+     | TraceLocalRootGroups  (LocalRootPeers.Config peerAddr)
        -- ^ This traces the results of the local root peer provider
      | TraceLocalRootDNSMap  (Map DomainAccessPoint [peerAddr])
        -- ^ This traces the results of the domain name resolution
-     | TraceLocalRootReconfigured [( HotValency
-                                   , WarmValency
-                                   , Map RelayAccessPoint (PeerAdvertise, PeerTrustable))] -- ^ Old value
-                                  [( HotValency
-                                   , WarmValency
-                                   , Map RelayAccessPoint (PeerAdvertise, PeerTrustable))] -- ^ New value
+     | TraceLocalRootReconfigured (LocalRootPeers.Config RelayAccessPoint) -- ^ Old value
+                                  (LocalRootPeers.Config RelayAccessPoint) -- ^ New value
      | TraceLocalRootFailure DomainAccessPoint (DNSorIOError exception)
        --TODO: classify DNS errors, config error vs transitory
      | TraceLocalRootError   DomainAccessPoint SomeException

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/LocalRootPeers.hs
@@ -9,6 +9,7 @@ module Ouroboros.Network.PeerSelection.State.LocalRootPeers
     LocalRootPeers (..)
   , HotValency (..)
   , WarmValency (..)
+  , Config
     -- Export constructors for defining tests.
   , invariant
     -- * Basic operations
@@ -71,6 +72,12 @@ newtype HotValency = HotValency { getHotValency :: Int }
 newtype WarmValency = WarmValency { getWarmValency :: Int }
   deriving (Show, Eq, Ord)
   deriving Num via Int
+
+-- | Data available from topology file.
+--
+type Config peeraddr =
+     [(HotValency, WarmValency, Map peeraddr ( PeerAdvertise, PeerTrustable))]
+
 
 -- It is an abstract type, so the derived Show is unhelpful, e.g. for replaying
 -- test cases.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/LocalRootPeers.hs
@@ -23,6 +23,7 @@ module Ouroboros.Network.PeerSelection.State.LocalRootPeers
   , toGroupSets
   , toMap
   , keysSet
+  , trustableKeysSet
     -- * Special operations
   , clampToLimit
   , clampToTrustable
@@ -251,3 +252,12 @@ isPeerTrustable peeraddr lrp =
   case Map.lookup peeraddr (toMap lrp) of
     Just (_, IsTrustable) -> True
     _                     -> False
+
+trustableKeysSet :: LocalRootPeers peeraddr
+                 -> Set peeraddr
+trustableKeysSet (LocalRootPeers m _) =
+    Map.keysSet
+  . Map.filter (\(_, trustable) -> case trustable of
+                    IsTrustable    -> True
+                    IsNotTrustable -> False)
+  $ m


### PR DESCRIPTION
# Description

This PR subsumes #4836.  It provides API for Genesis which allow consensus to
know if the node is connected just to local root peers or has any external
peers.  Fixes #4815.

TODO:
* [x] - add a basic churn tests
* [x] - #4845

# Checklist

- Branch
    - [x] Updated changelog files.
    - [x] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [x] The documentation has been properly updated
    - [x] New tests are added if needed and existing tests are updated
    - [x] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [x] Self-reviewed the diff
    - [x] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [x] Reviewer requested