### PR TITLE
Move functionality of calculating big ledger peers to ouroboros-network-api

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Non-Breaking changes
 
+* Transplanted `accBigPoolStake` and `reRelativeStake` from ouroboros-network
+  `LedgerPeers` module to expose functionality that facilitates serializing
+  of big ledger peers via LocalStateQuery miniprotocol.
+
 ## 0.7.3.0 -- 2024-06-07
 
 ### Breaking changes

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -43,6 +43,7 @@ library
 
                        Ouroboros.Network.PeerSelection.Bootstrap
                        Ouroboros.Network.PeerSelection.LedgerPeers.Type
+                       Ouroboros.Network.PeerSelection.LedgerPeers.Utils
                        Ouroboros.Network.PeerSelection.LocalRootPeers
                        Ouroboros.Network.PeerSelection.PeerMetric.Type
                        Ouroboros.Network.PeerSelection.PeerAdvertise

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -14,6 +14,7 @@ module Ouroboros.Network.PeerSelection.LedgerPeers.Type
   , LedgerPeersConsensusInterface (..)
   , UseLedgerPeers (..)
   , AfterSlot (..)
+  , LedgerPeersKind (..)
   , isLedgerPeersEnabled
   ) where
 
@@ -24,6 +25,11 @@ import Data.List.NonEmpty (NonEmpty)
 import GHC.Generics
 import NoThunks.Class
 import Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
+
+-- | Which ledger peers to pick.
+--
+data LedgerPeersKind = AllLedgerPeers | BigLedgerPeers
+  deriving Show
 
 -- | Only use the ledger after the given slot number.
 data UseLedgerPeers = DontUseLedgerPeers

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Utils.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Utils.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE BangPatterns     #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Ouroboros.Network.PeerSelection.LedgerPeers.Utils
+  ( bigLedgerPeerQuota
+  , accBigPoolStake
+  , reRelativeStake
+  , AccPoolStake (..)
+  , PoolStake (..)
+  , RelayAccessPoint (..)
+  ) where
+
+import Control.Exception (assert)
+import Data.Bifunctor (first)
+import Data.List (foldl', sortOn)
+import Data.List.NonEmpty (NonEmpty)
+import Data.Ord (Down (..))
+import Data.Ratio ((%))
+
+import Ouroboros.Network.PeerSelection.LedgerPeers.Type
+import Ouroboros.Network.PeerSelection.RelayAccessPoint
+
+-- | The total accumulated stake of big ledger peers.
+--
+bigLedgerPeerQuota :: AccPoolStake
+bigLedgerPeerQuota = 0.9
+
+-- | Sort ascendingly a given list of pools with stake,
+-- and tag each one with cumulative stake, with a cutoff
+-- at 'bigLedgerPeerQuota'
+--
+accBigPoolStake :: [(PoolStake, NonEmpty RelayAccessPoint)]
+                -> [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))]
+accBigPoolStake =
+    takeWhilePrev (\(acc, _) -> acc <= bigLedgerPeerQuota)
+    . go 0
+    . sortOn (Down . fst)
+    . reRelativeStake BigLedgerPeers
+  where
+    takeWhilePrev :: (a -> Bool) -> [a] -> [a]
+    takeWhilePrev f as =
+        fmap snd
+      . takeWhile (\(a, _) -> maybe True f a)
+      $ zip (Nothing : (Just <$> as)) as
+
+    -- natural fold
+    go :: AccPoolStake
+       -> [(PoolStake, NonEmpty RelayAccessPoint)]
+       -> [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))]
+    go _acc [] = []
+    go !acc (a@(s, _) : as) =
+      let acc' = acc + AccPoolStake (unPoolStake s)
+      in (acc', a) : go acc' as
+
+-- | Not all stake pools have valid \/ usable relay information. This means that
+-- we need to recalculate the relative stake for each pool.
+--
+reRelativeStake :: LedgerPeersKind
+                -> [(PoolStake, NonEmpty RelayAccessPoint)]
+                -> [(PoolStake, NonEmpty RelayAccessPoint)]
+reRelativeStake ledgerPeersKind pl =
+    let pl'   = first adjustment <$> pl
+        total = foldl' (+) 0 (fst <$> pl')
+        pl''  = first (/ total) <$> pl'
+    in
+    assert (let total' = sum $ map fst pl''
+            in total == 0 || (total' > (PoolStake $ 999999 % 1000000) &&
+                  total' < (PoolStake $ 1000001 % 1000000))
+           )
+    pl''
+  where
+    adjustment :: PoolStake -> PoolStake
+    adjustment =
+      case ledgerPeersKind of
+        AllLedgerPeers ->
+          -- We do loose some precision in the conversion. However we care about
+          -- precision in the order of 1 block per year and for that a Double is
+          -- good enough.
+          PoolStake . toRational . sqrt @Double . fromRational . unPoolStake
+        BigLedgerPeers ->
+          id

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Breaking changes
 
+* moved `accBigPoolStake` and `reRelativeStake` to ouroboros-networking-api
+  in order to expose functionality of creating snapshots of big ledger peers,
+  eg. for Genesis consensus mode.
+
 ### Non-Breaking changes
 
 * Refactored signature of `LedgerPeers.ledgerPeersThread` for concision

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -175,7 +175,7 @@ prop_pick100 seed (NonNegative n) (ArbLedgerPeersKind ledgerPeersKind) (MockRoot
 
         accumulatedStakeMap = case ledgerPeersKind of
           AllLedgerPeers -> accPoolStake sps
-          BigLedgerPeers -> accBigPoolStake sps
+          BigLedgerPeers -> accBigPoolStakeMap sps
 
         sim :: IOSim s [RelayAccessPoint]
         sim = do
@@ -334,7 +334,7 @@ prop_accBigPoolStake  (LedgerPools lps@(_:_)) =
          in counterexample ("initial sublist vaiolation: " ++ show (elems, lps'))
           $ elems `isPrefixOf` lps'
   where
-    accumulatedStakeMap = accBigPoolStake lps
+    accumulatedStakeMap = accBigPoolStakeMap lps
 
 prop_getLedgerPeers :: ArbitrarySlotNo
                     -> ArbitraryLedgerStateJudgement

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers/Common.hs
@@ -21,11 +21,6 @@ data IsLedgerPeer = IsLedgerPeer
                   | IsNotLedgerPeer
   deriving (Eq, Show)
 
--- | Which ledger peers to pick.
---
-data LedgerPeersKind = AllLedgerPeers | BigLedgerPeers
-  deriving Show
-
 -- | Ledger Peer request result
 --
 data LedgerPeers = LedgerPeers LedgerStateJudgement -- ^ Current ledger state


### PR DESCRIPTION
# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

This functionality is leveraged by downstream libraries to serialize a snapshot of big ledger peers in support of Genesis consensus mode.

# Checklist

- Branch
    - [ ] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [ ] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
