### PR TITLE
Introduction of serialization instances in support of ledger peer snapshot

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -9,6 +9,11 @@
 * Transplanted `accBigPoolStake` and `reRelativeStake` from ouroboros-network
   `LedgerPeers` module to expose functionality that facilitates serializing
   of big ledger peers via LocalStateQuery miniprotocol.
+* Introduced `LedgerPeerSnapshot` type for values of big ledger peers obtained
+  from the ledger at a particular volatile tip.
+  * New type supports CBOR & JSON for serialisation purposes.
+  * Ledger peer snapshot is versioned in case changes need to be made to the
+    encoding format in the future.
 
 * Added `Measure` and `BoundedMeasure` instances for `SizeInBytes`.
 

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -69,6 +69,7 @@ library
                        text              >=1.2 && <2.2,
                        quiet,
 
+                       cardano-binary,
                        cardano-slotting,
                        cardano-strict-containers,
                        contra-tracer,

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -1,7 +1,15 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
-{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE DerivingVia                #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 -- | Various types related to ledger peers.  This module is re-exported from
 -- "Ouroboros.Network.PeerSelection.LedgerPeers".
@@ -15,16 +23,130 @@ module Ouroboros.Network.PeerSelection.LedgerPeers.Type
   , UseLedgerPeers (..)
   , AfterSlot (..)
   , LedgerPeersKind (..)
+  , LedgerPeerSnapshot (.., LedgerPeerSnapshot)
   , isLedgerPeersEnabled
   ) where
 
-import Cardano.Slotting.Slot (SlotNo (..), WithOrigin)
+import Control.Monad (forM)
+import Data.ByteString.Char8 qualified as BS
+import Data.List.NonEmpty (NonEmpty)
+import Data.Text.Encoding (decodeUtf8)
+import GHC.Generics (Generic)
+import Text.Read (readMaybe)
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary qualified as Codec
+import Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
 import Control.Concurrent.Class.MonadSTM
 import Control.DeepSeq (NFData (..))
-import Data.List.NonEmpty (NonEmpty)
-import GHC.Generics
+import Data.Aeson
+import Data.Aeson.Types
 import NoThunks.Class
-import Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
+import Ouroboros.Network.PeerSelection.RelayAccessPoint
+
+-- |The type of big ledger peers that is serialised or later
+-- provided by node configuration for the networking layer
+-- to connect to when syncing.
+--
+data LedgerPeerSnapshot =
+  LedgerPeerSnapshotV1 (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+  -- ^ Internal use for version 1, use pattern synonym for public API
+  deriving (Eq, Show)
+
+-- |Public API to access snapshot data. Currently access to only most recent version is available.
+-- Nonetheless, serialisation from the node into JSON is supported for older versions via internal
+-- api so that newer CLI can still support older node formats.
+--
+pattern LedgerPeerSnapshot :: (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+                           -> LedgerPeerSnapshot
+pattern LedgerPeerSnapshot payload <- LedgerPeerSnapshotV1 payload where
+  LedgerPeerSnapshot payload = LedgerPeerSnapshotV1 payload
+
+{-# COMPLETE LedgerPeerSnapshot #-}
+
+-- | In case the format changes in the future, this function provides a migration functionality
+-- when possible.
+--
+migrateLedgerPeerSnapshot :: LedgerPeerSnapshot
+                          -> Maybe (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+migrateLedgerPeerSnapshot (LedgerPeerSnapshotV1 lps) = Just lps
+
+instance ToJSON LedgerPeerSnapshot where
+  toJSON (LedgerPeerSnapshotV1 (slot, pools)) =
+    object [ "version" .= (1 :: Int)
+           , "slotNo" .= slot
+           , "bigLedgerPools" .= [ object [ "accumulatedStake" .= fromRational @Double accStake
+                                          , "relativeStake"  .= fromRational @Double relStake
+                                          , "relays"   .= relays']
+                                 | (AccPoolStake accStake, (PoolStake relStake, relays)) <- pools
+                                 , let relays' = fmap RelayAccessPointCoded relays]]
+
+instance FromJSON LedgerPeerSnapshot where
+  parseJSON = withObject "LedgerPeerSnapshot" $ \v -> do
+    vNum :: Int <- v .: "version"
+    parsedSnapshot <-
+      case vNum of
+        1 -> do
+          slot <- v .: "slotNo"
+          bigPools <- v .: "bigLedgerPools"
+          bigPools' <- (forM bigPools . withObject "bigLedgerPools" $ \poolV -> do
+            AccPoolStakeCoded accStake <- poolV .: "accumulatedStake"
+            PoolStakeCoded reStake <- poolV .: "relativeStake"
+            relays <- fmap unRelayAccessPointCoded <$> poolV .: "relays"
+            return (accStake, (reStake, relays))) <?> Key "bigLedgerPools"
+
+          return $ LedgerPeerSnapshotV1 (slot, bigPools')
+        _ -> fail $ "Network.LedgerPeers.Type: parseJSON: failed to parse unsupported version " <> show vNum
+    case migrateLedgerPeerSnapshot parsedSnapshot of
+      Just payload -> return $ LedgerPeerSnapshot payload
+      Nothing      -> fail "Network.LedgerPeers.Type: parseJSON: failed to migrate big ledger peer snapshot"
+
+-- | cardano-slotting provides its own {To,From}CBOR instances for WithOrigin a
+-- but to pin down the encoding for CDDL we provide a wrapper with custom
+-- instances
+--
+newtype WithOriginCoded = WithOriginCoded (WithOrigin SlotNo)
+
+-- | Hand cranked CBOR instances to facilitate CDDL spec
+--
+instance ToCBOR WithOriginCoded where
+  toCBOR (WithOriginCoded Origin) = Codec.encodeListLen 1 <> Codec.encodeWord8 0
+  toCBOR (WithOriginCoded (At slotNo)) = Codec.encodeListLen 2 <> Codec.encodeWord8 1 <> toCBOR slotNo
+
+instance FromCBOR WithOriginCoded where
+  fromCBOR = do
+    listLen <- Codec.decodeListLen
+    tag <- Codec.decodeWord8
+    case (listLen, tag) of
+      (1, 0) -> pure $ WithOriginCoded Origin
+      (1, _) -> fail "LedgerPeers.Type: Expected tag for Origin constructor"
+      (2, 1) -> WithOriginCoded . At <$> fromCBOR
+      (2, _) -> fail "LedgerPeers.Type: Expected tag for At constructor"
+      _      -> fail "LedgerPeers.Type: Unrecognized list length while decoding WithOrigin SlotNo"
+
+instance ToCBOR LedgerPeerSnapshot where
+  toCBOR (LedgerPeerSnapshotV1 (wOrigin, pools)) =
+       Codec.encodeListLen 2
+    <> Codec.encodeWord8 1
+    <> toCBOR (WithOriginCoded wOrigin, pools')
+    where
+      pools' =
+        [(AccPoolStakeCoded accPoolStake, (PoolStakeCoded relStake, neRelayAccessPointCoded))
+        | (accPoolStake, (relStake, relays)) <- pools
+        , let neRelayAccessPointCoded = fmap RelayAccessPointCoded relays]
+
+instance FromCBOR LedgerPeerSnapshot where
+  fromCBOR = do
+    Codec.decodeListLenOf 2
+    version <- Codec.decodeWord8
+    case version of
+      1 -> LedgerPeerSnapshotV1 <$> do
+             (WithOriginCoded wOrigin, pools) <- fromCBOR
+             let pools' = [(accStake, (relStake, relays'))
+                          | (AccPoolStakeCoded accStake, (PoolStakeCoded relStake, relays)) <- pools
+                          , let relays' = unRelayAccessPointCoded <$> relays]
+             return (wOrigin, pools')
+      _ -> fail $ "LedgerPeers.Type: no decoder could be found for version " <> show version
 
 -- | Which ledger peers to pick.
 --
@@ -53,12 +175,18 @@ newtype PoolStake = PoolStake { unPoolStake :: Rational }
   deriving (Eq, Ord, Show)
   deriving newtype (Fractional, Num, NFData)
 
+newtype PoolStakeCoded = PoolStakeCoded PoolStake
+  deriving (ToCBOR, FromCBOR, FromJSON, ToJSON) via Rational
+
 -- | The accumulated relative stake of a stake pool, like PoolStake but it also includes the
 -- relative stake of all preceding pools. A value in the range [0, 1].
 --
 newtype AccPoolStake = AccPoolStake { unAccPoolStake :: Rational }
     deriving (Eq, Ord, Show)
     deriving newtype (Fractional, Num)
+
+newtype AccPoolStakeCoded = AccPoolStakeCoded AccPoolStake
+  deriving (ToCBOR, FromCBOR, FromJSON, ToJSON) via Rational
 
 -- | A boolean like type.  Big ledger peers are the largest SPOs which control
 -- 90% of staked stake.
@@ -85,3 +213,34 @@ data LedgerPeersConsensusInterface m = LedgerPeersConsensusInterface {
     lpGetLedgerStateJudgement :: STM m LedgerStateJudgement,
     lpGetLedgerPeers          :: STM m [(PoolStake, NonEmpty RelayAccessPoint)]
   }
+
+instance ToJSON RelayAccessPointCoded where
+  toJSON (RelayAccessPointCoded (RelayAccessDomain domain port)) =
+    object
+      [ "domain" .= decodeUtf8 domain
+      , "port"   .= (fromIntegral port :: Int)]
+
+  toJSON (RelayAccessPointCoded (RelayAccessAddress ip port)) =
+    object
+      [ "address" .= show ip
+      , "port" .= (fromIntegral port :: Int)]
+
+instance FromJSON RelayAccessPointCoded where
+  parseJSON = withObject "RelayAccessPointCoded" $ \v -> do
+    domain <- fmap BS.pack <$> v .:? "domain"
+    port <- fromIntegral @Int <$> v .: "port"
+    case domain of
+      Nothing ->
+            v .: "address"
+        >>= \case
+               Nothing -> fail "RelayAccessPointCoded: invalid IP address"
+               Just addr ->
+                 return . RelayAccessPointCoded $ RelayAccessAddress addr port
+            . readMaybe
+
+      Just domain'
+        | Just (_, '.') <- BS.unsnoc domain' ->
+          return . RelayAccessPointCoded $ RelayAccessDomain domain' port
+        | otherwise ->
+          let fullyQualified = domain' `BS.snoc` '.'
+          in return . RelayAccessPointCoded $ RelayAccessDomain fullyQualified port

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/RelayAccessPoint.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/RelayAccessPoint.hs
@@ -1,18 +1,22 @@
 {-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms   #-}
+{-# LANGUAGE TypeApplications  #-}
 {-# LANGUAGE ViewPatterns      #-}
 
 module Ouroboros.Network.PeerSelection.RelayAccessPoint
   ( DomainAccessPoint (..)
   , RelayAccessPoint (.., RelayDomainAccessPoint)
+  , RelayAccessPointCoded (..)
   , IP.IP (..)
     -- * Socket type re-exports
   , Socket.PortNumber
   ) where
 
 import Control.DeepSeq (NFData (..))
+import Control.Monad (when)
 
 import Data.Aeson
 import Data.IP qualified as IP
@@ -21,6 +25,8 @@ import Data.Text qualified as Text
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import Text.Read (readMaybe)
 
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary qualified as Codec
 import Network.DNS qualified as DNS
 import Network.Socket qualified as Socket
 
@@ -52,6 +58,51 @@ instance ToJSON DomainAccessPoint where
 data RelayAccessPoint = RelayAccessDomain  !DNS.Domain !Socket.PortNumber
                       | RelayAccessAddress !IP.IP      !Socket.PortNumber
   deriving (Eq, Ord)
+
+newtype RelayAccessPointCoded = RelayAccessPointCoded { unRelayAccessPointCoded :: RelayAccessPoint }
+
+-- | These instances are used to serialize 'LedgerPeerSnapshot'
+-- consensus LocalStateQuery server which uses these instances
+-- for all its query responses. It appears they provide some improved
+-- debugging diagnostics over Serialize instances.
+instance ToCBOR RelayAccessPointCoded where
+  toCBOR (RelayAccessPointCoded rap) = case rap of
+    RelayAccessDomain domain port ->
+         Codec.encodeListLen 3
+      <> Codec.encodeWord8 0
+      <> serialise' port
+      <> toCBOR domain
+    RelayAccessAddress (IP.IPv4 ipv4) port ->
+         Codec.encodeListLen 3
+      <> Codec.encodeWord8 1
+      <> serialise' port
+      <> toCBOR (IP.fromIPv4 ipv4)
+    RelayAccessAddress (IP.IPv6 ip6) port ->
+         Codec.encodeListLen 3
+      <> Codec.encodeWord8 2
+      <> serialise' port
+      <> toCBOR (IP.fromIPv6 ip6)
+    where
+      serialise' = toCBOR . toInteger
+
+instance FromCBOR RelayAccessPointCoded where
+  fromCBOR = do
+    listLen <- Codec.decodeListLen
+    when (listLen /= 3) . fail $    "Unrecognized RelayAccessPoint list length "
+                                 <> show listLen
+    constructorTag <- Codec.decodeWord8
+    port <- fromInteger <$> fromCBOR @Integer
+    case constructorTag of
+      0 -> do
+        domain <- fromCBOR
+        return . RelayAccessPointCoded $ RelayAccessDomain domain port
+      1 -> do
+        ip4 <- IP.IPv4 . IP.toIPv4 <$> fromCBOR
+        return . RelayAccessPointCoded $ RelayAccessAddress ip4 port
+      2 -> do
+        ip6 <- IP.IPv6 . IP.toIPv6 <$> fromCBOR
+        return . RelayAccessPointCoded $ RelayAccessAddress ip6 port
+      _ -> fail $ "Unrecognized RelayAccessPoint tag: " <> show constructorTag
 
 instance Show RelayAccessPoint where
     show (RelayAccessDomain domain port) =


### PR DESCRIPTION
# Description

<!-- CI flakiness -- delete this before opening a PR

Sadly, some CI checks are currently flaky. Right now, this includes:

 - GH Actions Windows job sometimes run out of memory

 - The "Subscription.Resolve Subscribe (IO)" test sometimes fails

If you encounter one of these, try restarting the job to see if the failure vanishes. If it does not or when in doubt, consider posting in the #network or #consensus channels on Slack.
-->

This change adds support for serialization of ledger peers by defining instances for its subcomponent types. The snapshot type will be introduced in a future commit.

# Checklist

- Branch
    - [x] Updated changelog files.
    - [ ] Commit sequence broadly makes sense
    - [x] Commits have useful messages
    - [ ] The documentation has been properly updated
    - [ ] New tests are added if needed and existing tests are updated
    - [ ] If serialization changes, user-facing consequences (e.g. replay from genesis) are confirmed to be intentional.
- Pull Request
    - [ ] Self-reviewed the diff
    - [ ] Useful pull request description at least containing the following information:
      - What does this PR change?
      - Why these changes were needed?
      - How does this affect downstream repositories and/or end-users?
      - Which ticket does this PR close (if any)? If it does, is it [linked](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)?
    - [ ] Reviewer requested
