### PR TITLE
contributing guide: nix hash format in an srp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,7 +374,7 @@ package, we should release it to CHaP instead (see the
 for more).
 
 If you do add a temporary `source-repository-package` stanza, you need to
-provide a `--sha256` comment in `cabal.project` so that Nix knows the hash
+provide a `--sha256: <HASH>` comment in `cabal.project` so that Nix knows the hash
 of the content. There are two relatively straightforward ways to do this:
 
 1. The TOFU approach: put in the wrong hash and then Nix will tell you the correct one, which you can copy in.


### PR DESCRIPTION
# Description

Specify the `--sha256: <HASH>` syntax correctly for nix hashes in `srp`s.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
