### PR TITLE
Move ShowProxy SlotNo to ShowProxy

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-Breaking changes
 
+* Added `ShowProxy SlotNo` instance
+
 ## 0.7.2.0 -- 2024-05-07
 
 ### Breaking changes

--- a/ouroboros-network-api/src/Ouroboros/Network/Util/ShowProxy.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Util/ShowProxy.hs
@@ -6,6 +6,7 @@ module Ouroboros.Network.Util.ShowProxy
   , Proxy (..)
   ) where
 
+import Cardano.Slotting.Slot (SlotNo)
 import Data.Typeable
 
 class ShowProxy p where
@@ -15,3 +16,4 @@ class ShowProxy p where
     showProxy p = showsTypeRep (typeRep p) ""
 
 instance ShowProxy Int where
+instance ShowProxy SlotNo where

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* Un-orphan `ShowProxy SlotNo` instance.
+
 ### Non-Breaking changes
 
 ## 0.8.1.0 -- 2024-03-14

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
@@ -197,8 +197,6 @@ instance ShowProxy TxId where
 -- Orphans Plumbing
 --
 
-instance ShowProxy SlotNo where
-
 instance (Arbitrary txid, Arbitrary tx, Arbitrary slot)
     => Arbitrary (AnyMessageAndAgency (LocalTxMonitor txid tx slot))
   where


### PR DESCRIPTION
# Description

This instance was defined twice, once in the ouroboros-network testlib and another one in Consensus. Moving it next to the class definition helps getting rid of the instance in Consensus.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
