### PR TITLE
Fix haddocks for `TrustedStateWithExternalPeers`

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -11,8 +11,9 @@ data OutboundConnectionsState =
     -- * /in the Praos mode/: connected only to trusted local
     --   peers and at least one bootstrap peer or public root;
     -- * /in the Genesis mode/: meeting target of active big ledger peers;
-    -- * or it is in `Unrestricted` mode
-    --   (see `Ouroboros.Network.PeerSelection.Governor.AssociationMode`).
+    -- * or it is in `LocalRootsOnly` mode and indeed only connected to
+    --   trusted local root peers (see
+    --   `Ouroboros.Network.PeerSelection.Governor.AssociationMode`).
 
   | UntrustedState
     -- ^ catch all other cases


### PR DESCRIPTION
# Description

If we are in the `LocalRootsOnly` state (ie block producers or hidden relays), we still should have a chance to signal `TrustedStateWithExternalPeers` in order to became caught up (also see https://github.com/IntersectMBO/ouroboros-consensus/pull/1091). This is already correctly implemented as pointed out by @karknu, but the docs erroneously said that is only signaled when the `AssociationMode` is `Unrestricted`.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
