### PR TITLE
Adjust peer selection governor tracing sequence in the main loop.

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Non-Breaking changes
 
+* Changed tracing sequence in the outbound governor loop to output
+  decision and peer selection state immediately from the monitoring
+  action which completed first. Previously, these traces were delivered
+  with a lag of one iteration.
+
 ## 0.16.0.0 -- 2024-05-07
 
 ### Breaking changes


### PR DESCRIPTION
# Description

Peer selection decision and state traces now come from the latest monitoring action which finished first. Previously, these were delivered with a lag of one iteration.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
