### PR TITLE
Don't include failing peers in peershare rsps

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-Breaking changes
 
+* Don't include peers that are failing in peershare responses.
+
 ## 0.16.0.0 -- 2024-05-07
 
 ### Breaking changes

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/State/KnownPeers.hs
@@ -450,6 +450,7 @@ canSharePeers pa KnownPeers { allPeers } =
     Just KnownPeerInfo
           { knownPeerAdvertise        = DoAdvertisePeer
           , knownSuccessfulConnection = True
+          , knownPeerFailCount        = 0
           } -> True
     _       -> False
 
@@ -474,6 +475,7 @@ getPeerSharingResponsePeers knownPeers =
                   KnownPeerInfo
                     { knownPeerAdvertise        = DoAdvertisePeer
                     , knownSuccessfulConnection = True
+                    , knownPeerFailCount        = 0
                     } -> True
                   _   -> False
                )


### PR DESCRIPTION
# Description

Don't include failing peers in peershare responses. This prevents us from propagating previously working but currently failing peers.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
