### PR TITLE
Implement AnchoredSeq.splitAtMeasure

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -18,6 +18,8 @@
 
 - Bump io-sim and io-classes
 * Added `ShowProxy SlotNo` instance
+* Added `AnchoredSeq.splitAtMeasure`
+* Added `AnchoredFragment.splitAtSlot`
 
 ## 0.7.2.0 -- 2024-05-07
 

--- a/ouroboros-network-api/src/Ouroboros/Network/AnchoredFragment.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/AnchoredFragment.hs
@@ -70,6 +70,7 @@ module Ouroboros.Network.AnchoredFragment
   , selectPoints
   , isPrefixOf
   , splitAfterPoint
+  , splitAtSlot
   , splitBeforePoint
   , sliceRange
   , join
@@ -529,6 +530,24 @@ splitBeforePoint af p =
       (pointSlot p)
       ((== castPoint p) . blockPoint)
       af
+
+-- | \( O(\log(\min(i,n-i)) \). Split the 'AnchoredFragment' at the given
+-- slot.
+--
+-- POSTCONDITION: when @(before, after) = splitAtSlot s f@, then:
+--
+-- * @anchorPoint before == anchorPoint f@
+-- * @headPoint   before == anchorPoint after@
+-- * @headPoint   after  == headPoint f@
+-- * @join before after  == Just f@
+-- * @toOldestFirst before == filter ((< s) . blockSlot) (toOldestFirst f)@
+-- * @toOldestFirst after == filter ((s <=) . blockSlot) (toOldestFirst f)@
+splitAtSlot
+   :: HasHeader block
+   => SlotNo
+   -> AnchoredFragment block
+   -> (AnchoredFragment block, AnchoredFragment block)
+splitAtSlot = splitAtMeasure . At
 
 -- | Select a slice of an anchored fragment between two points, inclusive.
 --

--- a/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
@@ -304,8 +304,10 @@ splitAt i (AnchoredSeq a ft) = case FT.split (\v -> measureSize v > i) ft of
 -- > anchor      before == anchor s
 -- > headAnchor  before == anchor after
 -- > headAnchor  after  == headAnchor s
--- > [before] == filter ((< v) . getElementMeasure . MeasuredWith) s
--- > [after] == filter ((v <=) . getElementMeasure . MeasuredWith) s
+-- > toOldestFirst before ==
+-- >   filter ((< v) . getAnchorMeasure @v @a (Proxy @b) . asAnchor) (toOldestFirst s)
+-- > toOldestFirst after ==
+-- >   filter ((v <=) . getAnchorMeasure @v @a (Proxy @b) . asAnchor) (toOldestFirst s)
 splitAtMeasure ::
       Anchorable v a b
    => v

--- a/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/AnchoredSeq.hs
@@ -25,6 +25,7 @@ module Ouroboros.Network.AnchoredSeq
   , fromNewestFirst
   , fromOldestFirst
   , splitAt
+  , splitAtMeasure
   , dropNewest
   , takeOldest
   , dropWhileNewest
@@ -291,6 +292,26 @@ splitAt ::
    -> AnchoredSeq v a b
    -> (AnchoredSeq v a b, AnchoredSeq v a b)
 splitAt i (AnchoredSeq a ft) = case FT.split (\v -> measureSize v > i) ft of
+   (before, after) ->
+     let before' = AnchoredSeq a before
+     in (before', AnchoredSeq (headAnchor before') after)
+
+-- | \( O(\log(\min(i,n-i)) \). Split the 'AnchoredSeq' at a given
+--  measure.
+--
+-- POSTCONDITION: @(before, after) = splitAtMeasure v s@, then:
+--
+-- > anchor      before == anchor s
+-- > headAnchor  before == anchor after
+-- > headAnchor  after  == headAnchor s
+-- > [before] == filter ((< v) . getElementMeasure . MeasuredWith) s
+-- > [after] == filter ((v <=) . getElementMeasure . MeasuredWith) s
+splitAtMeasure ::
+      Anchorable v a b
+   => v
+   -> AnchoredSeq v a b
+   -> (AnchoredSeq v a b, AnchoredSeq v a b)
+splitAtMeasure v (AnchoredSeq a ft) = case FT.split ((v <=) . measureMax) ft of
    (before, after) ->
      let before' = AnchoredSeq a before
      in (before', AnchoredSeq (headAnchor before') after)

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -12,7 +12,8 @@
 
 ### Non-Breaking changes
 
-- Bump io-sim and io-classes
+* Bump io-sim and io-classes
+* Added a test for `AnchoredFragment.splitAtSlot`.
 
 ## 0.8.1.0 -- 2024-03-14
 


### PR DESCRIPTION
This PR implements a function that allows to split an `AnchoredSeq` at an arbitrary measure boundary.

It is helpful in the Genesis implementation to split `AnchoredFragment`s. We need to count the amount of headers that a fragment contains in a window of slots (the genesis window). We currently do this with `dropWhileNewest`.

We use `dropWhileNewest` to cut the upper end of the fragment because we don't know the slot of the headers before or after the end of the window, which rules out `splitBeforePoint`, `splitBeforeMeasure`, etc.

Also tried `filter` to keep the headers in the window, but it was a bit slower than `dropWhileNewest`.

The implementation of `splitAtMeasure` provided here is at least as fast as `dropWhileNewest` in our measuring.

### Alternatives

Expose a more general function `split :: (v -> Bool) -> AnchoredSeq v a b -> AnchoredSeq v a b` which delegates to `FingerTree.split`.

Or expose the implementation of `AnchoredSeq`, so we can implement this function in a "Utils" module without having to upgrade or fork `ouroboros-network-api`.