### PR TITLE
Make it possible to compile with tcp tracing again

### DIFF
--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## next release
 
+### Breaking changes
+
+### Non-breaking changes
+
+* Fix compilation with `tracetcpinfo` flag.
+
 ## 0.4.5.3 -- 2024-08-07
 
 ### Breaking changes

--- a/network-mux/src/Network/Mux/TCPInfo.hs
+++ b/network-mux/src/Network/Mux/TCPInfo.hs
@@ -2,12 +2,12 @@
 
 module Network.Mux.TCPInfo
   ( StructTCPInfo (..)
-#if os_HOST_linux
+#if linux_HOST_OS
   , SocketOption (TCPInfoSocketOption)
 #endif
   ) where
 
-#if os_HOST_linux
+#if linux_HOST_OS
 import           Network.Mux.TCPInfo.Linux
 #else
 data StructTCPInfo = TCPInfoUnavailable

--- a/network-mux/src/Network/Mux/Trace.hs
+++ b/network-mux/src/Network/Mux/Trace.hs
@@ -192,7 +192,7 @@ instance Show MuxTrace where
     show (MuxTraceTerminating mid dir) = printf "Terminating (%s) in %s" (show mid) (show dir)
     show MuxTraceStopping = "Mux stopping"
     show MuxTraceStopped  = "Mux stoppped"
-#ifdef os_HOST_linux
+#ifdef linux_HOST_OS
     show (MuxTraceTCPInfo StructTCPInfo
             { tcpi_snd_mss, tcpi_rcv_mss, tcpi_lost, tcpi_retrans
             , tcpi_rtt, tcpi_rttvar, tcpi_snd_cwnd }


### PR DESCRIPTION
# Description

The correct define is linux_HOST_OS. For some reason it was changed in a refactoring.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
