### PR TITLE
Verification of big ledger peer snapshot file

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 * Make it build with ghc-9.10
 
+* added `compareLedgerPeerSnapshotApproximate` function which compares
+  two snapshots for approximate equality wrt stake distribution and
+  fully qualified domain names.
+
 ## 0.7.3.0 -- 2024-06-07
 
 ### Breaking changes

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -39,7 +39,9 @@
   peers
 * Implemented separate configurable peer selection targets for Praos and
   Genesis consensus modes. Genesis mode may use more big ledger peers when
-  a node is syncing up. 
+* Implemented verification of big ledger peer snapshot when syncing reaches
+  the point at which the snapshot was taken. An error is raised when there's
+  a mismatch detected. 
 
 ## 0.16.1.1 -- 2024-06-28
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -1096,7 +1096,8 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         show a
       peerSelectionTraceMap a@TraceChurnTimeout {}                   =
         show a
-
+      peerSelectionTraceMap (TraceVerifyPeerSnapshot result)         =
+        "TraceVerifyPeerSnapshot " <> show result
       eventsSeenNames = map peerSelectionTraceMap events
 
    -- TODO: Add checkCoverage here

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -115,12 +115,14 @@ import Ouroboros.Network.PeerSelection.Governor.Types
 #endif
 import Ouroboros.Network.PeerSelection.LedgerPeers (TraceLedgerPeers,
            WithLedgerPeersArgs (..))
+#ifdef POSIX
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type (LedgerPeerSnapshot,
            LedgerPeersConsensusInterface (..), UseLedgerPeers)
-#ifdef POSIX
 import Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics,
            fetchynessBlocks, upstreamyness)
 #else
+import Ouroboros.Network.PeerSelection.LedgerPeers.Type (LedgerPeerSnapshot,
+           UseLedgerPeers)
 import Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics)
 #endif
 import Ouroboros.Network.ConsensusMode
@@ -659,9 +661,7 @@ runM Interfaces
        { daApplicationInitiatorMode
        , daApplicationInitiatorResponderMode
        , daLocalResponderApplication
-       , daLedgerPeersCtx =
-          daLedgerPeersCtx@LedgerPeersConsensusInterface
-            { lpGetLedgerStateJudgement }
+       , daLedgerPeersCtx
        , daUpdateOutboundConnectionsState
        }
      ApplicationsExtra
@@ -990,7 +990,7 @@ runM Interfaces
                                          psLocalRootPeersTracer = dtTraceLocalRootPeersTracer,
                                          psPublicRootPeersTracer = dtTracePublicRootPeersTracer,
                                          psReadTargets = readTVar peerSelectionTargetsVar,
-                                         psJudgement = lpGetLedgerStateJudgement,
+                                         getLedgerStateCtx = daLedgerPeersCtx,
                                          psReadLocalRootPeers = daReadLocalRootPeers,
                                          psReadPublicRootPeers = daReadPublicRootPeers,
                                          psReadUseBootstrapPeers = daReadUseBootstrapPeers,
@@ -1002,7 +1002,8 @@ runM Interfaces
                                              PeerSharingDisabled -> pure Map.empty
                                              PeerSharingEnabled  -> readInboundPeers,
                                          psUpdateOutboundConnectionsState = daUpdateOutboundConnectionsState,
-                                         peerTargets = daPeerTargets }
+                                         peerTargets = daPeerTargets,
+                                         readLedgerPeerSnapshot = daReadLedgerPeerSnapshot }
                                        WithLedgerPeersArgs {
                                          wlpRng = ledgerPeersRng,
                                          wlpConsensusInterface = daLedgerPeersCtx,

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -654,6 +654,13 @@ peerSelectionGovernorLoop tracer
 
       <> Monitor.connections          actions st
       <> Monitor.jobs                 jobPool st
+      -- This job monitors for changes in big ledger peer snapshot file (eg. reload)
+      -- and copies it into the governor's private state. When a change is detected,
+      -- it also flips private state LedgerStateJudgement to TooYoung so that it
+      -- can launch the appropriate verification task in the job pool when external
+      -- LedgerStateJudgement is TooOld. If the verification job detects a discrepancy
+      -- vs. big peers on the ledger, it throws and the node is shut down.
+      <> Monitor.ledgerPeerSnapshotChange st actions
       -- In Genesis consensus mode, this is responsible for settings targets on the basis
       -- of the ledger state judgement. It takes into account whether
       -- the churn governor is running via a tmvar such that targets are set


### PR DESCRIPTION
# Description

A check was added to verify if big ledger stake pools from the peer snapshot file match what is provided by the ledger once syncing reaches the point at which the snapshot was ostensibly taken at. If there's a mismatch, an error is raised.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
