### PR TITLE
Remove the mutex between peer selection and churn governors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,6 +213,9 @@ will make it easier for others to rebase on top of your committed changes).  If
 you need to rebase your branch we prefer to rebase over merge (since then the
 actually merged changes are more explicit).
 
+We also keep the convention that a source branch's name for a pull request
+includes github user name of the contributor.
+
 Since the code base of `ouroboros-network` is quite large, we don't require
 that every commit is buildable across all included packages.  You can update
 upstream dependencies later in the commit history; although note that if you do

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -9,6 +9,13 @@
 * Transplanted `accBigPoolStake` and `reRelativeStake` from ouroboros-network
   `LedgerPeers` module to expose functionality that facilitates serializing
   of big ledger peers via LocalStateQuery miniprotocol.
+* Added `ToCBOR` and `FromCBOR` instance definitions for `RelayAccessPoint`,
+  `PoolStake` and `AccPoolStake` in support of upcoming serialization of (big)
+  ledger peers.
+* Introduced `LedgerPeerSnapshot` type for values of big ledger peers obtained
+  from the ledger at a particular volatile tip.
+  * Ledger peer snapshot is versioned in case changes need to be made to the
+    encoding format in the future.
 
 ## 0.7.3.0 -- 2024-06-07
 

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -18,6 +18,8 @@
   from the ledger at a particular volatile tip.
   * Ledger peer snapshot is versioned in case changes need to be made to the
     encoding format in the future.
+* Added `ConsensusMode` which must be passed to start diffusion in the
+  appropriate mode 
 
 ## 0.7.3.0 -- 2024-06-07
 

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -9,6 +9,8 @@
 * Transplanted `accBigPoolStake` and `reRelativeStake` from ouroboros-network
   `LedgerPeers` module to expose functionality that facilitates serializing
   of big ledger peers via LocalStateQuery miniprotocol.
+  * Renamed `accBigPoolStake` -> `accumulateBigLedgerStake`
+  * Renamed `reRelativeStake` -> `recomputeRelativeStake`
 * Added `ToCBOR` and `FromCBOR` instance definitions for `RelayAccessPoint`,
   `PoolStake` and `AccPoolStake` in support of upcoming serialization of (big)
   ledger peers.

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -29,6 +29,7 @@ library
                        Ouroboros.Network.BlockFetch.ConsensusInterface
 
                        Ouroboros.Network.CodecCBORTerm
+                       Ouroboros.Network.ConsensusMode
                        Ouroboros.Network.ControlMessage
                        Ouroboros.Network.Handshake
                        Ouroboros.Network.Handshake.Acceptable

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -67,6 +67,7 @@ library
                        serialise         >=0.2   && <0.3,
                        text              >=1.2 && <2.2,
 
+                       cardano-binary,
                        cardano-slotting,
                        cardano-strict-containers,
                        contra-tracer,

--- a/ouroboros-network-api/src/Ouroboros/Network/ConsensusMode.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/ConsensusMode.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+
+module Ouroboros.Network.ConsensusMode where
+
+import Data.Aeson
+import GHC.Generics (Generic)
+
+-- | Configures the diffusion layer
+-- The two modes determine which `PeerSelectionTargets` basis is used
+-- by churn and OG. The node's configuration sets this, and diffusion
+-- is initiated and remains only in this mode.
+data ConsensusMode =
+    GenesisMode
+  -- ^ When `LedgerStateJudgement` is `TooOld`, the targets basis is changed
+  -- from default to one specific for this mode, which uses more big ledger peers
+  -- until syncing is complete.
+  | PraosMode
+  -- ^ The legacy mode which depends on official relays and/or bootstrap peers
+  -- configuration. This mode uses only the default target basis irrespective
+  -- ledger state.
+  deriving (Eq, Show, Generic, FromJSON)
+
+defaultConsensusMode :: ConsensusMode
+defaultConsensusMode = PraosMode

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -1,7 +1,14 @@
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE OverloadedStrings          #-}
+{-# LANGUAGE PatternSynonyms            #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans       #-}
 
 -- | Various types related to ledger peers.  This module is re-exported from
 -- "Ouroboros.Network.PeerSelection.LedgerPeers".
@@ -15,16 +22,136 @@ module Ouroboros.Network.PeerSelection.LedgerPeers.Type
   , UseLedgerPeers (..)
   , AfterSlot (..)
   , LedgerPeersKind (..)
+  , LedgerPeerSnapshot (.., LedgerPeerSnapshot)
   , isLedgerPeersEnabled
   ) where
 
-import Cardano.Slotting.Slot (SlotNo (..), WithOrigin)
+import Control.Monad (forM)
+import Data.List.NonEmpty (NonEmpty)
+import GHC.Generics (Generic)
+import Text.Read (readMaybe)
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+import Cardano.Binary qualified as Codec
+import Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
 import Control.Concurrent.Class.MonadSTM
 import Control.DeepSeq (NFData (..))
-import Data.List.NonEmpty (NonEmpty)
-import GHC.Generics
+import Data.Aeson
+import Data.Aeson.Types
 import NoThunks.Class
 import Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint)
+
+-- |The type of big ledger peers that is serialised or later
+-- provided by node configuration for the networking layer
+-- to connect to when syncing.
+--
+data LedgerPeerSnapshot =
+  LedgerPeerSnapshotV1 (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+  -- ^ Internal use for version 1, use pattern synonym for public API
+  deriving (Eq, Show)
+
+-- |Public API to access snapshot data. Currently access to only most recent version is available.
+-- Nonetheless, serialisation from the node into JSON is supported for older versions via internal
+-- api so that newer CLI can still support older node formats.
+--
+pattern LedgerPeerSnapshot :: (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+                           -> LedgerPeerSnapshot
+pattern LedgerPeerSnapshot payload <- LedgerPeerSnapshotV1 payload where
+  LedgerPeerSnapshot payload = LedgerPeerSnapshotV1 payload
+
+{-# COMPLETE LedgerPeerSnapshot #-}
+
+-- | In case the format changes in the future, this function provides a migration functionality
+-- when possible.
+--
+migrateLedgerPeerSnapshot :: LedgerPeerSnapshot
+                          -> Maybe (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+migrateLedgerPeerSnapshot (LedgerPeerSnapshotV1 lps) = Just lps
+
+instance ToJSON LedgerPeerSnapshot where
+  toJSON (LedgerPeerSnapshotV1 (slot, pools)) =
+    object [ "Version" .= (1 :: Int)
+           , "SlotNo" .= slot
+           , "BigLedgerPools" .= [ object [ "AccStake" .= show accStake
+                                          , "ReStake"  .= show stake
+                                          , "Relays"   .= relays]
+                                 | (AccPoolStake accStake, (PoolStake stake, relays)) <- pools]]
+
+instance FromJSON LedgerPeerSnapshot where
+  parseJSON = withObject "LedgerPeerSnapshot" $ \v -> do
+    vNum <- v .: "Version"
+    parsedSnapshot <-
+      case (vNum :: Int) of
+        1 -> do
+          slot <- v .: "SlotNo"
+          bigPools <- v .: "BigLedgerPools"
+          bigPools' <- (forM bigPools . withObject "BigLedgerPools" $ \poolV -> do
+            accStake <-
+              poolV .: "AccStake"
+              >>= (\case
+                    Just accStake -> pure accStake
+                    Nothing    ->
+                      fail "Invalid AccStake value")
+                  . readMaybe
+            reStake <-
+              poolV .: "ReStake"
+              >>= (\case
+                    Just reStake -> pure reStake
+                    Nothing    ->
+                      fail "Invalid ReStake value")
+                  . readMaybe
+            relays <- poolV .: "Relays"
+            return (accStake, (reStake, relays))) <?> Key "BigLedgerPools"
+
+          return $ LedgerPeerSnapshotV1 (slot, bigPools')
+        _ -> fail $ "Network.LedgerPeers.Type: parseJSON: failed to parse unsupported version " <> show vNum
+    case migrateLedgerPeerSnapshot parsedSnapshot of
+      Just payload -> return $ LedgerPeerSnapshot payload
+      Nothing      -> fail "Network.LedgerPeers.Type: parseJSON: failed to migrate big ledger peer snapshot"
+
+-- | cardano-slotting provides its own {To,From}CBOR instances for WithOrigin a
+-- but to pin down the encoding for CDDL we provide a wrapper with custom
+-- instances
+--
+newtype WithOriginWrapper = WithOriginWrapper (WithOrigin SlotNo)
+
+-- | Hand cranked CBOR instances to facilitate CDDL spec
+--
+instance ToCBOR WithOriginWrapper where
+  toCBOR (WithOriginWrapper Origin) = Codec.encodeListLen 1 <> Codec.encodeWord8 0
+  toCBOR (WithOriginWrapper (At (SlotNo slot))) = Codec.encodeListLen 2 <> Codec.encodeWord8 1 <> toCBOR slot
+
+instance FromCBOR WithOriginWrapper where
+  fromCBOR = do
+    listLen <- Codec.decodeListLen
+    tag <- Codec.decodeWord8
+    case (listLen, tag) of
+      (1, 0) -> pure $ WithOriginWrapper Origin
+      (1, _) -> fail "LedgerPeers.Type: Expected tag for Origin constructor"
+      (2, 1) -> WithOriginWrapper . At . SlotNo <$> fromCBOR
+      (2, _) -> fail "LedgerPeers.Type: Expected tag for At constructor"
+      _      -> fail "LedgerPeers.Type: Unrecognized list length while decoding WithOrigin SlotNo"
+
+instance ToCBOR LedgerPeerSnapshot where
+  toCBOR (LedgerPeerSnapshotV1 (slot, pools)) =
+       Codec.encodeListLen 3
+    <> Codec.encodeWord8 1
+    <> toCBOR (WithOriginWrapper slot)
+    <> toCBOR pools'
+    where
+      pools' = map (\(AccPoolStake accPoolStake, (PoolStake reStake, relays)) -> (accPoolStake, reStake, relays)) pools
+
+instance FromCBOR LedgerPeerSnapshot where
+  fromCBOR = do
+    Codec.decodeListLenOf 3
+    version <- Codec.decodeWord8
+    case version of
+      1 -> LedgerPeerSnapshotV1 <$> do
+             (WithOriginWrapper slot, pools) <- (,) <$> fromCBOR <*> fromCBOR
+             let pools' = [(AccPoolStake accStake, (PoolStake reStake, relays))
+                          | (accStake, reStake, relays) <- pools]
+             return (slot, pools')
+      _ -> fail $ "LedgerPeers.Type: no decoder could be found for version " <> show version
 
 -- | Which ledger peers to pick.
 --
@@ -51,14 +178,14 @@ isLedgerPeersEnabled UseLedgerPeers {}  = True
 --
 newtype PoolStake = PoolStake { unPoolStake :: Rational }
   deriving (Eq, Ord, Show)
-  deriving newtype (Fractional, Num, NFData)
+  deriving newtype (Fractional, Num, NFData, Read)
 
 -- | The accumulated relative stake of a stake pool, like PoolStake but it also includes the
 -- relative stake of all preceding pools. A value in the range [0, 1].
 --
 newtype AccPoolStake = AccPoolStake { unAccPoolStake :: Rational }
     deriving (Eq, Ord, Show)
-    deriving newtype (Fractional, Num)
+    deriving newtype (Fractional, Num, Read)
 
 -- | A boolean like type.  Big ledger peers are the largest SPOs which control
 -- 90% of staked stake.

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -28,7 +28,10 @@
       or Genesis mode, which influences what `PeerSelectionTargets` both
       governors should use. Genesis may use two different sets of targets
       depending on ledger state, while Praos uses only one set. Either set
-      once active is appropriately churned. 
+      once active is appropriately churned.
+* Implemented verification of big ledger peer snapshot when syncing reaches
+  the point at which the snapshot was taken. An error is raised when there's
+  a mismatch detected. 
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -44,6 +44,8 @@
   a churn cycle is running, a change in ledger state (in Genesis) will make
   peer selection governor hold its target basis until churn completes its round,
   to prevent some non-deterministic interleaving of targets. 
+* Explicit synchronization via a TMVar between churn & peer selection governors
+  has been removed.
 
 ## 0.16.1.0 -- 2024-06-07
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -7,6 +7,13 @@
 * moved `accBigPoolStake` and `reRelativeStake` to ouroboros-networking-api
   in order to expose functionality of creating snapshots of big ledger peers,
   eg. for Genesis consensus mode.
+* Introduced `daReadLedgerPeerSnapshot` to `P2P.ArgumentsExtra` which holds
+  a `Maybe LedgerPeerSnapshot` from a node's configuration. If present, it
+  may be used to pick big ledger peers by the peer selection governor when
+  bootstrapping a node in Genesis consensus mode, or in general when 
+  LedgerStateJudgement = TooOld, subject to conditions in
+  `LedgerPeers.ledgerPeersThread`.
+* Implemented provision of big ledger peers from the snapshot by `ledgerPeersThread`
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -19,11 +19,28 @@
 * Added property tests checking if `LedgerPeerSnapshot` CBOR encoding is valid,
   and decode/encode = id, as well as some property tests for calculating big ledger
   peers
+* Diffusion run function in P2P mode has new paramaters:
+    * `daPeerTargets` - replaces daPeerSelectionTargets. `Configuration`
+        module provides an API. Used by peer selection & churn governors. Given
+        required arguments, it returns the correct target basis to use for churn
+        and peer selection governors.
+    * `daConsensusMode` - flag indicating whether diffusion should run in Praos
+      or Genesis mode, which influences what `PeerSelectionTargets` both
+      governors should use. Genesis may use two different sets of targets
+      depending on ledger state, while Praos uses only one set. Either set
+      once active is appropriately churned. 
 
 ### Non-Breaking changes
 
 * Refactored signature of `LedgerPeers.ledgerPeersThread` for concision
   and use of previously created records for shunting related values around.
+* Implemented separate configurable peer selection targets for Praos and
+  Genesis consensus modes. Genesis mode may use more big ledger peers when
+  a node is syncing up.
+* Churn & OG/peer selection governor are synchronized to ensure that while
+  a churn cycle is running, a change in ledger state (in Genesis) will make
+  peer selection governor hold its target basis until churn completes its round,
+  to prevent some non-deterministic interleaving of targets. 
 
 ## 0.16.1.0 -- 2024-06-07
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -14,6 +14,11 @@
   LedgerStateJudgement = TooOld, subject to conditions in
   `LedgerPeers.ledgerPeersThread`.
 * Implemented provision of big ledger peers from the snapshot by `ledgerPeersThread`
+* Added property test checking if `ledgerPeersThread` is providing big ledger peers
+  from the snapshot when appropriate conditions are met
+* Added property tests checking if `LedgerPeerSnapshot` CBOR encoding is valid,
+  and decode/encode = id, as well as some property tests for calculating big ledger
+  peers
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -167,6 +167,7 @@ library sim-tests-lib
                        quickcheck-monoids,
                        aeson,
                        array,
+                       cardano-binary,
                        cborg,
                        containers,
                        deepseq,

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -67,12 +67,13 @@ import Ouroboros.Network.Block (MaxSlotNo (..), maxSlotNoFromWithOrigin,
            pointSlot)
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.ConnectionManager.Types (DataFlow (..))
+import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.Diffusion qualified as Diff
 import Ouroboros.Network.Diffusion.P2P qualified as Diff.P2P
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
-import Ouroboros.Network.PeerSelection.Governor (PeerSelectionTargets (..),
-           PublicPeerSelectionState (..), ConsensusModePeerTargets)
+import Ouroboros.Network.PeerSelection.Governor (ConsensusModePeerTargets,
+           PeerSelectionTargets (..), PublicPeerSelectionState (..))
 import Ouroboros.Network.PeerSelection.PeerMetric
            (PeerMetricsConfiguration (..), newPeerMetric)
 import Ouroboros.Network.Protocol.Handshake (HandshakeArguments (..))
@@ -112,7 +113,6 @@ import Test.Ouroboros.Network.Diffusion.Node.NodeKernel (NodeKernel (..),
 import Test.Ouroboros.Network.Diffusion.Node.NodeKernel qualified as Node
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS (DNSLookupDelay,
            DNSTimeout, mockDNSActions)
-import Ouroboros.Network.ConsensusMode (ConsensusMode)
 
 
 data Interfaces m = Interfaces

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -390,16 +390,17 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
     mkArgsExtra :: StrictTVar m (Script UseBootstrapPeers)
                 -> Diff.P2P.ArgumentsExtra m
     mkArgsExtra ubpVar = Diff.P2P.ArgumentsExtra
-      { Diff.P2P.daPeerSelectionTargets  = aPeerSelectionTargets na
-      , Diff.P2P.daReadLocalRootPeers    = aReadLocalRootPeers na
-      , Diff.P2P.daReadPublicRootPeers   = aReadPublicRootPeers na
-      , Diff.P2P.daReadUseBootstrapPeers = stepScriptSTM' ubpVar
-      , Diff.P2P.daOwnPeerSharing        = aOwnPeerSharing na
-      , Diff.P2P.daReadUseLedgerPeers    = aReadUseLedgerPeers na
-      , Diff.P2P.daProtocolIdleTimeout   = aProtocolIdleTimeout na
-      , Diff.P2P.daTimeWaitTimeout       = aTimeWaitTimeout na
-      , Diff.P2P.daDeadlineChurnInterval = 3300
-      , Diff.P2P.daBulkChurnInterval     = 300
+      { Diff.P2P.daPeerSelectionTargets   = aPeerSelectionTargets na
+      , Diff.P2P.daReadLocalRootPeers     = aReadLocalRootPeers na
+      , Diff.P2P.daReadPublicRootPeers    = aReadPublicRootPeers na
+      , Diff.P2P.daReadUseBootstrapPeers  = stepScriptSTM' ubpVar
+      , Diff.P2P.daOwnPeerSharing         = aOwnPeerSharing na
+      , Diff.P2P.daReadUseLedgerPeers     = aReadUseLedgerPeers na
+      , Diff.P2P.daProtocolIdleTimeout    = aProtocolIdleTimeout na
+      , Diff.P2P.daTimeWaitTimeout        = aTimeWaitTimeout na
+      , Diff.P2P.daDeadlineChurnInterval  = 3300
+      , Diff.P2P.daBulkChurnInterval      = 300
+      , Diff.P2P.daReadLedgerPeerSnapshot = pure Nothing -- ^ tested independently
       }
 
     appArgs :: Node.AppArgs BlockHeader Block m

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -188,10 +188,10 @@ prop_use_snapshot_bigledger_peers seed (MockRoots _ dnsMapScript _ _)
                                   (DelayAndTimeoutScripts dnsLookupDelayScript dnsTimeoutScript)
                                   (ArbitraryLedgerStateJudgement lsj) = property $ do
   -- snapshotSlots has duplicates removed since the test will fail when two consecutive
-  -- snapshot slot numbers are identical but the ledger pools are different (which is likely given random generation).
+  -- snapshot slot numbers are identical but the corresponding ledger pools are distinct (which is likely given random generation).
   -- When using a particular snapshot, the request function provided by withLedgerPeers caches the results for
-  -- the corresponding slot number to avoid recomputating the same things every time we request a new peer when snapshot
-  -- data is used. Furthermore, each test is limited to roughly ~10 slot changes to speed things up.
+  -- the corresponding slot number to avoid recomputing the same things every time we request a new peer when snapshot
+  -- data is used.
   (snapshotSlots, ledgerSlots)    <-     bimap nub sort . unzip
                                      <$> sized (\n -> if n <= 10
                                                       then listOf1 arbitrary

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -13,6 +13,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeApplications           #-}
+{-# LANGUAGE ViewPatterns               #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 -- TODO: remove it once #3601 is fixed
@@ -95,7 +96,8 @@ import Test.QuickCheck.Monoids
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Text.Pretty.Simple
-
+import Ouroboros.Network.ConsensusMode
+import Data.List.NonEmpty qualified as NonEmpty
 
 -- Exactly as named.
 unfHydra :: Int
@@ -178,17 +180,18 @@ tests =
       , testProperty "progresses towards active target (from above)"
                      prop_governor_target_active_big_ledger_peers_above
       ]
-    , testGroup "bootstrap peers"
+    ,
+      testGroup "bootstrap peers"
       [ testProperty "progress towards only bootstrap peers after changing to fallback state"
-                     prop_governor_only_bootstrap_peers_in_fallback_state
+                     $ prop_governor_only_bootstrap_peers_in_fallback_state . getMockEnv
       , testProperty "node does not learn about non trustable peers when in fallback state"
-                     prop_governor_no_non_trustable_peers_before_caught_up_state
+                     $ prop_governor_no_non_trustable_peers_before_caught_up_state . getMockEnv
       , testProperty "node only use bootstrap peers if in sensitive state"
-                     prop_governor_stops_using_bootstrap_peers
+                     $ prop_governor_stops_using_bootstrap_peers . getMockEnv
       , testProperty "node never uses non-trustable peers in clean state"
-                     prop_governor_only_bootstrap_peers_in_clean_state
+                     $ prop_governor_only_bootstrap_peers_in_clean_state . getMockEnv
       , testProperty "node uses ledger peers in non-sensitive mode"
-                     prop_governor_uses_ledger_peers
+                     $ prop_governor_uses_ledger_peers . getMockEnv
       ]
     , testProperty "association mode" prop_governor_association_mode
     ]
@@ -449,13 +452,34 @@ isEmptyEnv :: GovernorMockEnvironment -> Bool
 isEmptyEnv GovernorMockEnvironment {
              localRootPeers,
              publicRootPeers,
-             targets
+             targets = targets@(Script targets'),
+             consensusMode,
+             ledgerStateJudgement = Script ledgerStateJudgement'
            } =
     (LocalRootPeers.null localRootPeers
-      || all (\(t,_) -> targetNumberOfKnownPeers t == 0) targets)
+      || case consensusMode of
+           PraosMode ->
+             all (\(praosTargets -> t,_) -> targetNumberOfKnownPeers t == 0)
+                 targets
+           GenesisMode ->
+             all (\((t, _), (lsj, _)) ->
+                    case lsj of
+                      TooOld -> 0 == (targetNumberOfKnownPeers . genesisSyncTargets $ t)
+                      YoungEnough ->
+                        0 == (targetNumberOfKnownPeers . praosTargets $ t))
+                 $ NonEmpty.zip targets' ledgerStateJudgement')
  && (PublicRootPeers.null publicRootPeers
-      || all (\(t,_) -> targetNumberOfRootPeers  t == 0) targets)
-
+      || case consensusMode of
+           PraosMode ->
+             all (\(praosTargets -> t,_) -> targetNumberOfRootPeers  t == 0)
+                 targets
+           GenesisMode ->
+             all (\((t, _), (lsj, _)) ->
+                    case lsj of
+                      TooOld -> 0 == (targetNumberOfRootPeers . genesisSyncTargets $ t)
+                      YoungEnough ->
+                        0 == (targetNumberOfRootPeers . praosTargets $ t))
+                 $ NonEmpty.zip targets' ledgerStateJudgement')
 
 -- | As a basic property we run the governor to explore its state space a bit
 -- and check it does not throw any exceptions (assertions such as invariant
@@ -741,6 +765,19 @@ envEventCredits (TraceEnvSetTargets PeerSelectionTargets {
                     + 10 * (targetNumberOfKnownPeers
                           + targetNumberOfEstablishedPeers
                           + targetNumberOfActivePeers)
+                    
+-- todo: add big ledger peer terms?                    
+envEventCredits (TraceEnvGenesisLsjAndTargets (_, targets))
+  =   80
+    + 10 * (targetNumberOfKnownPeers
+    + targetNumberOfEstablishedPeers
+    + targetNumberOfActivePeers)
+  where
+    PeerSelectionTargets {
+      targetNumberOfRootPeers = _,
+      targetNumberOfKnownPeers,
+      targetNumberOfEstablishedPeers,
+      targetNumberOfActivePeers } = targets
 
 envEventCredits (TraceEnvPeersDemote Noop   _)    = 10
 envEventCredits (TraceEnvPeersDemote ToWarm _)    = 30
@@ -979,7 +1016,7 @@ prop_governor_peershare_1hr env@GovernorMockEnvironment {
   where
     -- This test is only about testing peer sharing,
     -- so do not try to establish connections:
-    targets' :: PeerSelectionTargets
+    targets' :: ConsensusModePeerTargets
     targets' = fst (scriptHead targets)
 
     knownPeersAfter1Hour :: [(Time, TestTraceEvent)] -> Maybe (Set PeerAddr)
@@ -1073,15 +1110,15 @@ prop_governor_target_root_below env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfRootPeers . Governor.targets) events
+          selectGovState (targetNumberOfRootPeers . Governor.targets) (consensusMode env) events
 
         govLocalRootPeersSig :: Signal (Set PeerAddr)
         govLocalRootPeersSig =
-          selectGovState (LocalRootPeers.keysSet . Governor.localRootPeers) events
+          selectGovState (LocalRootPeers.keysSet . Governor.localRootPeers) (consensusMode env) events
 
         govPublicRootPeersSig :: Signal (Set PeerAddr)
         govPublicRootPeersSig =
-          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers) events
+          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers) (consensusMode env) events
 
         govRootPeersSig :: Signal (Set PeerAddr)
         govRootPeersSig = Set.union <$> govLocalRootPeersSig <*> govPublicRootPeersSig
@@ -1138,18 +1175,21 @@ prop_governor_target_established_public (MaxTime maxTime) env =
         govPublicRootPeersSig :: Signal (Set PeerAddr)
         govPublicRootPeersSig =
           selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers)
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govInProgressPromoteColdSig :: Signal (Set PeerAddr)
         govInProgressPromoteColdSig =
           selectGovState
             Governor.inProgressPromoteCold
+            (consensusMode env)
             events
 
         publicInEstablished :: Signal Bool
@@ -1196,23 +1236,27 @@ prop_governor_target_established_big_ledger_peers (MaxTime maxTime) env =
         govBigLedgerPeersSig :: Signal (Set PeerAddr)
         govBigLedgerPeersSig =
           selectGovState (PublicRootPeers.getBigLedgerPeers . Governor.publicRootPeers)
+                         (consensusMode env)
                          events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
           selectGovState (Governor.ledgerStateJudgement)
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govInProgressPromoteColdSig :: Signal (Set PeerAddr)
         govInProgressPromoteColdSig =
           selectGovState
             Governor.inProgressPromoteCold
+            (consensusMode env)
             events
 
         bigLedgerPeersInEstablished :: Signal Bool
@@ -1259,11 +1303,13 @@ prop_governor_target_active_public (MaxTime maxTime) env =
 
         govPublicRootPeersSig :: Signal (Set PeerAddr)
         govPublicRootPeersSig =
-          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers) events
+          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers)
+                         (consensusMode env)
+                         events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState Governor.activePeers events
+          selectGovState Governor.activePeers (consensusMode env) events
 
         publicInActive :: Signal Bool
         publicInActive =
@@ -1471,7 +1517,7 @@ prop_governor_target_known_1_valid_subset (MaxTime maxTime) env =
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) (consensusMode env) events
 
         validState :: Set PeerAddr -> Set PeerAddr -> Bool
         validState knownPeersEnv knownPeersGov =
@@ -1525,11 +1571,11 @@ prop_governor_target_known_2_opportunity_taken (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets) events
+          selectGovState (targetNumberOfKnownPeers . Governor.targets) (consensusMode env) events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) (consensusMode env) events
 
         -- Available Established Peers are those who have correct PeerSharing
         -- permissions
@@ -1542,7 +1588,8 @@ prop_governor_target_known_2_opportunity_taken (MaxTime maxTime) env =
                                     (Governor.establishedPeers x)
                 Set.\\ (Governor.inProgressDemoteToCold x))
                 (Governor.knownPeers x))
-                events
+            (consensusMode env)
+            events
 
         -- Note that we only require that the governor try to peer share, it does
         -- not have to succeed.
@@ -1566,11 +1613,11 @@ prop_governor_target_known_2_opportunity_taken (MaxTime maxTime) env =
 
         govLedgerStateJudgementSig :: Signal LedgerStateJudgement
         govLedgerStateJudgementSig =
-          selectGovState Governor.ledgerStateJudgement events
+          selectGovState Governor.ledgerStateJudgement (consensusMode env) events
 
         govUseBootstrapPeersSig :: Signal UseBootstrapPeers
         govUseBootstrapPeersSig =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag (consensusMode env) events
 
         -- We define the governor's peer sharing opportunities at any point in time
         -- to be the governor's set of established peers, less the ones we can see
@@ -1878,11 +1925,15 @@ prop_governor_target_known_4_results_used (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets) events
+          selectGovState (targetNumberOfKnownPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
+                         events
 
         envPeerShareResultsSig :: Signal (Set PeerAddr)
         envPeerShareResultsSig =
@@ -1952,20 +2003,26 @@ prop_governor_target_known_5_no_shrink_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownPeers . Governor.targets) events
+          selectGovState (targetNumberOfKnownPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
+                         events
 
         bigLedgerPeersSig :: Signal (Set PeerAddr)
         bigLedgerPeersSig =
           selectGovState (PublicRootPeers.getBigLedgerPeers . Governor.publicRootPeers)
+                         (consensusMode env)
                          events
 
         bootstrapPeersSig :: Signal (Set PeerAddr)
         bootstrapPeersSig =
           selectGovState (PublicRootPeers.getBootstrapPeers . Governor.publicRootPeers)
+                         (consensusMode env)
                          events
 
         knownPeersShrinksSig :: Signal (Set PeerAddr)
@@ -2024,12 +2081,16 @@ prop_governor_target_known_5_no_shrink_big_ledger_peers_below (MaxTime maxTime) 
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfKnownBigLedgerPeers . Governor.targets) events
+          selectGovState (targetNumberOfKnownBigLedgerPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
           selectGovState (takeBigLedgerPeers $
-                            KnownPeers.toSet . Governor.knownPeers) events
+                            KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
+                         events
 
         knownPeersShrinksSig :: Signal (Set PeerAddr)
         knownPeersShrinksSig =
@@ -2099,27 +2160,32 @@ prop_governor_target_known_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal PeerSelectionTargets
         govTargetsSig =
-          selectGovState Governor.targets events
+          selectGovState Governor.targets (consensusMode env) events
 
         govLocalRootPeersSig :: Signal (Set PeerAddr)
         govLocalRootPeersSig =
           selectGovState (LocalRootPeers.keysSet . Governor.localRootPeers)
+                         (consensusMode env)
                          events
 
         govPublicRootPeersSig :: Signal (Set PeerAddr)
         govPublicRootPeersSig =
-          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers) events
+          selectGovState (PublicRootPeers.toSet . Governor.publicRootPeers)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
           selectGovState (dropBigLedgerPeers $
                             KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState (dropBigLedgerPeers $
                             EstablishedPeers.toSet . Governor.establishedPeers)
+                         (consensusMode env)
                          events
 
         -- There are no demotion opportunities if we're at or below target.
@@ -2189,18 +2255,20 @@ prop_governor_target_known_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal PeerSelectionTargets
         govTargetsSig =
-          selectGovState Governor.targets events
+          selectGovState Governor.targets (consensusMode env) events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
           selectGovState (takeBigLedgerPeers $
                             KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState (takeBigLedgerPeers $
                             EstablishedPeers.toSet . Governor.establishedPeers)
+                         (consensusMode env)
                          events
 
         -- There are no demotion opportunities if we're at or below target.
@@ -2279,17 +2347,22 @@ prop_governor_target_established_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedPeers . Governor.targets) events
+          selectGovState (targetNumberOfEstablishedPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
           selectGovState (dropBigLedgerPeers $
-                            KnownPeers.toSet . Governor.knownPeers) events
+                            KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govEstablishedFailuresSig :: Signal (Set PeerAddr)
@@ -2378,12 +2451,15 @@ prop_governor_target_established_big_ledger_peers_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets) events
+          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govKnownPeersSig :: Signal (Set PeerAddr)
         govKnownPeersSig =
           selectGovState (takeBigLedgerPeers $
                            KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
@@ -2391,6 +2467,7 @@ prop_governor_target_established_big_ledger_peers_below (MaxTime maxTime) env =
           selectGovState
             (takeBigLedgerPeers $
               EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govEstablishedFailuresSig :: Signal (Set PeerAddr)
@@ -2480,26 +2557,35 @@ prop_governor_target_active_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActivePeers . Governor.targets) events
+          selectGovState (targetNumberOfActivePeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
-          selectGovState Governor.localRootPeers events
+          selectGovState Governor.localRootPeers
+                         (consensusMode env)
+                         events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (dropBigLedgerPeers $
                EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (dropBigLedgerPeers Governor.activePeers) events
+          selectGovState (dropBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         govActiveFailuresSig :: Signal (Set PeerAddr)
         govActiveFailuresSig =
@@ -2597,22 +2683,27 @@ prop_governor_target_active_big_ledger_peers_below (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets) events
+          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (takeBigLedgerPeers $
               EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold (consensusMode env) events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (takeBigLedgerPeers Governor.activePeers) events
+          selectGovState (takeBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         govActiveFailuresSig :: Signal (Set PeerAddr)
         govActiveFailuresSig =
@@ -2685,26 +2776,35 @@ prop_governor_target_established_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedPeers . Governor.targets) events
+          selectGovState (targetNumberOfEstablishedPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold
+                         (consensusMode env)
+                         events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
-          selectGovState Governor.localRootPeers events
+          selectGovState Governor.localRootPeers
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (dropBigLedgerPeers $
                EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (dropBigLedgerPeers Governor.activePeers) events
+          selectGovState (dropBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         -- There are no demotion opportunities if we're at or below target.
         -- Otherwise the demotion opportunities are the established peers that
@@ -2761,22 +2861,29 @@ prop_governor_target_established_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets) events
+          selectGovState (targetNumberOfEstablishedBigLedgerPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (takeBigLedgerPeers $
               EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold
+                         (consensusMode env)
+                         events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (takeBigLedgerPeers Governor.activePeers) events
+          selectGovState (takeBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         -- There are no demotion opportunities if we're at or below target.
         -- Otherwise the demotion opportunities are the established peers that
@@ -2826,19 +2933,27 @@ prop_governor_target_active_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActivePeers . Governor.targets) events
+          selectGovState (targetNumberOfActivePeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
-          selectGovState Governor.localRootPeers events
+          selectGovState Governor.localRootPeers
+                         (consensusMode env)
+                         events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (dropBigLedgerPeers Governor.activePeers) events
+          selectGovState (dropBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold
+                         (consensusMode env)
+                         events
 
         demotionOpportunity target local active inProgressDemoteToCold
           | (Set.size active - Set.size inProgressDemoteToCold) <= target
@@ -2888,11 +3003,15 @@ prop_governor_target_active_big_ledger_peers_above (MaxTime maxTime) env =
 
         govTargetsSig :: Signal Int
         govTargetsSig =
-          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets) events
+          selectGovState (targetNumberOfActiveBigLedgerPeers . Governor.targets)
+                         (consensusMode env)
+                         events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState (takeBigLedgerPeers Governor.activePeers) events
+          selectGovState (takeBigLedgerPeers Governor.activePeers)
+                         (consensusMode env)
+                         events
 
         demotionOpportunity target active
           | Set.size active <= target
@@ -2942,18 +3061,21 @@ prop_governor_target_established_local (MaxTime maxTime) env =
         govLocalRootPeersSig :: Signal (LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
           selectGovState Governor.localRootPeers
+                         (consensusMode env)
                          events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govInProgressPromoteColdSig :: Signal (Set PeerAddr)
         govInProgressPromoteColdSig =
           selectGovState
             Governor.inProgressPromoteCold
+            (consensusMode env)
             events
 
         govEstablishedFailuresSig :: Signal (Set PeerAddr)
@@ -3047,21 +3169,26 @@ prop_governor_target_active_local_below (MaxTime maxTime) env =
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
-          selectGovState Governor.localRootPeers events
+          selectGovState Governor.localRootPeers
+                         (consensusMode env)
+                         events
 
         govEstablishedPeersSig :: Signal (Set PeerAddr)
         govEstablishedPeersSig =
           selectGovState
             (EstablishedPeers.toSet . Governor.establishedPeers)
+            (consensusMode env)
             events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState Governor.activePeers events
+          selectGovState Governor.activePeers (consensusMode env) events
 
         govInProgressDemoteToColdSig :: Signal (Set PeerAddr)
         govInProgressDemoteToColdSig =
-          selectGovState Governor.inProgressDemoteToCold events
+          selectGovState Governor.inProgressDemoteToCold
+          (consensusMode env)
+          events
 
         govActiveFailuresSig :: Signal (Set PeerAddr)
         govActiveFailuresSig =
@@ -3139,11 +3266,11 @@ prop_governor_target_active_local_above (MaxTime maxTime) env =
 
         govLocalRootPeersSig :: Signal (LocalRootPeers.LocalRootPeers PeerAddr)
         govLocalRootPeersSig =
-          selectGovState Governor.localRootPeers events
+          selectGovState Governor.localRootPeers (consensusMode env) events
 
         govActivePeersSig :: Signal (Set PeerAddr)
         govActivePeersSig =
-          selectGovState Governor.activePeers events
+          selectGovState Governor.activePeers (consensusMode env) events
 
         deomotionOpportunities :: Signal (Set PeerAddr)
         deomotionOpportunities =
@@ -3179,6 +3306,7 @@ prop_governor_target_active_local_above (MaxTime maxTime) env =
 
 -- | When in 'TooOld' state make sure we don't stay connected to non trustable
 -- peers for too long
+
 prop_governor_only_bootstrap_peers_in_fallback_state :: GovernorMockEnvironment -> Property
 prop_governor_only_bootstrap_peers_in_fallback_state env =
     let events = Signal.eventsFromListUpToTime (Time (10 * 60 * 60))
@@ -3188,22 +3316,26 @@ prop_governor_only_bootstrap_peers_in_fallback_state env =
 
         govUseBootstrapPeers :: Signal UseBootstrapPeers
         govUseBootstrapPeers =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag (consensusMode env) events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
-          selectGovState (Governor.ledgerStateJudgement) events
+          selectGovState Governor.ledgerStateJudgement (consensusMode env) events
 
         govKnownPeers :: Signal (Set PeerAddr)
         govKnownPeers =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers)
+                         (consensusMode env)
+                         events
 
         govTrustedPeers :: Signal (Set PeerAddr)
         govTrustedPeers =
           selectGovState
             (\st -> LocalRootPeers.keysSet (LocalRootPeers.clampToTrustable (Governor.localRootPeers st))
                  <> PublicRootPeers.getBootstrapPeers (Governor.publicRootPeers st)
-            ) events
+            )
+            (consensusMode env)
+            events
 
         keepNonTrustablePeersTooLong :: Signal (Set PeerAddr)
         keepNonTrustablePeersTooLong =
@@ -3236,26 +3368,30 @@ prop_governor_no_non_trustable_peers_before_caught_up_state env =
 
         govUseBootstrapPeers :: Signal UseBootstrapPeers
         govUseBootstrapPeers =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag (consensusMode env) events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
-          selectGovState (Governor.ledgerStateJudgement) events
+          selectGovState Governor.ledgerStateJudgement (consensusMode env) events
 
         govKnownPeers :: Signal (Set PeerAddr)
         govKnownPeers =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) (consensusMode env) events
 
         govTrustedPeers :: Signal (Set PeerAddr)
         govTrustedPeers =
           selectGovState
             (\st -> LocalRootPeers.keysSet (LocalRootPeers.clampToTrustable (Governor.localRootPeers st))
                  <> PublicRootPeers.getBootstrapPeers (Governor.publicRootPeers st)
-            ) events
+            )
+            (consensusMode env)
+            events
 
         govHasOnlyBootstrapPeers :: Signal Bool
         govHasOnlyBootstrapPeers =
-          selectGovState Governor.hasOnlyBootstrapPeers events
+          selectGovState Governor.hasOnlyBootstrapPeers
+                         (consensusMode env)
+                         events
 
         keepNonTrustablePeersTooLong :: Signal (Set PeerAddr)
         keepNonTrustablePeersTooLong =
@@ -3278,6 +3414,7 @@ prop_governor_no_non_trustable_peers_before_caught_up_state env =
           Set.null
           keepNonTrustablePeersTooLong
 
+
 -- NOTE: the clean state is defined as a state in which we require bootstrap
 -- peers and the governor set the `hasOnlyBootstrapPeers` flag.
 --
@@ -3290,11 +3427,15 @@ prop_governor_only_bootstrap_peers_in_clean_state env =
 
         govUseBootstrapPeers :: Signal UseBootstrapPeers
         govUseBootstrapPeers =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag
+                         (consensusMode env)
+                         events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
-          selectGovState (Governor.ledgerStateJudgement) events
+          selectGovState Governor.ledgerStateJudgement
+                         (consensusMode env)
+                         events
 
         govKnownAndTrustedPeers :: Signal (Set PeerAddr, Set PeerAddr)
         govKnownAndTrustedPeers =
@@ -3305,15 +3446,17 @@ prop_governor_only_bootstrap_peers_in_clean_state env =
                       LocalRootPeers.keysSet (LocalRootPeers.clampToTrustable (Governor.localRootPeers st))
                    <> PublicRootPeers.getBootstrapPeers (Governor.publicRootPeers st)
                 )
-            ) events
+            )
+            (consensusMode env)
+            events
 
         govHasOnlyBootstrapPeers :: Signal Bool
         govHasOnlyBootstrapPeers =
-          selectGovState Governor.hasOnlyBootstrapPeers events
+          selectGovState Governor.hasOnlyBootstrapPeers (consensusMode env) events
 
         govTargets :: Signal PeerSelectionTargets
         govTargets =
-          selectGovState Governor.targets events
+          selectGovState Governor.targets (consensusMode env) events
 
         isInCleanState :: Signal Bool
         isInCleanState =
@@ -3356,25 +3499,29 @@ prop_governor_stops_using_bootstrap_peers env =
 
         govUseBootstrapPeers :: Signal UseBootstrapPeers
         govUseBootstrapPeers =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag (consensusMode env) events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
-          selectGovState (Governor.ledgerStateJudgement) events
+          selectGovState (Governor.ledgerStateJudgement) (consensusMode env) events
 
         govKnownPeers :: Signal (Set PeerAddr)
         govKnownPeers =
-          selectGovState (KnownPeers.toSet . Governor.knownPeers) events
+          selectGovState (KnownPeers.toSet . Governor.knownPeers) (consensusMode env) events
 
         govBootstrapPeers :: Signal (Set PeerAddr)
         govBootstrapPeers =
-          selectGovState (PublicRootPeers.getBootstrapPeers . Governor.publicRootPeers) events
+          selectGovState (PublicRootPeers.getBootstrapPeers . Governor.publicRootPeers)
+                         (consensusMode env)
+                         events
 
         govTrustableLocalRootPeers :: Signal (Set PeerAddr)
         govTrustableLocalRootPeers =
           selectGovState
             (\st -> LocalRootPeers.keysSet (LocalRootPeers.clampToTrustable (Governor.localRootPeers st))
-            ) events
+            )
+            (consensusMode env)
+            events
 
         keepBootstrapPeersTooLong :: Signal (Set ())
         keepBootstrapPeersTooLong =
@@ -3411,11 +3558,11 @@ prop_governor_uses_ledger_peers env =
 
         govUseBootstrapPeers :: Signal UseBootstrapPeers
         govUseBootstrapPeers =
-          selectGovState Governor.bootstrapPeersFlag events
+          selectGovState Governor.bootstrapPeersFlag (consensusMode env) events
 
         govLedgerStateJudgement :: Signal LedgerStateJudgement
         govLedgerStateJudgement =
-          selectGovState (Governor.ledgerStateJudgement) events
+          selectGovState Governor.ledgerStateJudgement (consensusMode env) events
 
         govPublicRootPeersResultsSig :: Signal (PublicRootPeers PeerAddr)
         govPublicRootPeersResultsSig =
@@ -3453,7 +3600,7 @@ prop_governor_association_mode env =
 
         counters :: Signal (PeerSelectionSetsWithSizes PeerAddr)
         counters =
-          selectGovState peerSelectionStateToView events
+          selectGovState peerSelectionStateToView (consensusMode env) events
 
         -- accumulate local roots
         localRoots :: Signal (Set PeerAddr)
@@ -3477,7 +3624,8 @@ prop_governor_association_mode env =
               (\_ -> Set.empty)
               (\_ -> False)
           . selectGovState Governor.publicRootPeers
-          $ events
+                           (consensusMode env)
+                           $ events
 
         associationMode :: Signal AssociationMode
         associationMode =
@@ -3548,12 +3696,13 @@ selectGovAssociationMode = Signal.selectEvents
 
 selectGovState :: Eq a
                => (forall peerconn. Governor.PeerSelectionState PeerAddr peerconn -> a)
+               -> ConsensusMode
                -> Events TestTraceEvent
                -> Signal a
-selectGovState f =
+selectGovState f consensusMode =
     Signal.nub
   -- TODO: #3182 Rng seed should come from quickcheck.
-  . Signal.fromChangeEvents (f $! Governor.emptyPeerSelectionState (mkStdGen 42))
+  . Signal.fromChangeEvents (f $! Governor.emptyPeerSelectionState (mkStdGen 42) consensusMode)
   . Signal.selectEvents
       (\case GovernorDebug (TraceGovernorState _ _ st) -> Just $! f st
              _                                         -> Nothing)
@@ -3587,18 +3736,22 @@ _governorFindingPublicRoots :: Int
                             -> STM IO LedgerStateJudgement
                             -> PeerSharing
                             -> StrictTVar IO OutboundConnectionsState
+                            -> ConsensusMode
                             -> IO Void
-_governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrapPeers readLedgerStateJudgement peerSharing olocVar = do
+_governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrapPeers readLedgerStateJudgement peerSharing olocVar consensusMode = do
     countersVar <- newTVarIO emptyPeerSelectionCounters
     publicStateVar <- makePublicPeerSelectionStateVar
-    debugStateVar <- newTVarIO $ emptyPeerSelectionState (mkStdGen 42)
+    debugStateVar <- newTVarIO $ emptyPeerSelectionState (mkStdGen 42) consensusMode
     dnsSemaphore <- newLedgerAndPublicRootDNSSemaphore
+    churnMutex <- newTMVarIO ()
     let interfaces = PeerSelectionInterfaces {
             countersVar,
             publicStateVar,
             debugStateVar,
             readUseLedgerPeers = return DontUseLedgerPeers
           }
+        actions' = actions churnMutex
+          
     publicRootPeersProvider
       tracer
       (curry IP.toSockAddr)
@@ -3610,7 +3763,8 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
           tracer tracer tracer
           -- TODO: #3182 Rng seed should come from quickcheck.
           (mkStdGen 42)
-          actions
+          consensusMode
+          actions'
             { requestPublicRootPeers = \_ ->
                 transformPeerSelectionAction requestPublicRootPeers }
           policy
@@ -3619,13 +3773,16 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
     tracer :: Show a => Tracer IO a
     tracer  = Tracer (BS.putStrLn . BS.pack . show)
 
-    actions :: PeerSelectionActions SockAddr PeerSharing IO
-    actions = PeerSelectionActions {
+    actions :: StrictTMVar IO ()
+            -> PeerSelectionActions SockAddr PeerSharing IO
+    actions churnMutex = PeerSelectionActions {
+                churnMutex,
+                peerTargets,
                 readLocalRootPeers       = return [],
                 peerSharing              = peerSharing,
                 readPeerSelectionTargets = return targets,
                 requestPeerShare         = \_ _ -> return (PeerSharingResult []),
-                peerConnToPeerSharing    = \ps -> ps,
+                peerConnToPeerSharing    = id,
                 requestPublicRootPeers   = \_ _ -> return (PublicRootPeers.empty, 0),
                 peerStateActions         = PeerStateActions {
                   establishPeerConnection  = error "establishPeerConnection",
@@ -3648,6 +3805,10 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
                 targetNumberOfRootPeers  = targetNumberOfRootPeers,
                 targetNumberOfKnownPeers = targetNumberOfRootPeers
               }
+
+    peerTargets = ConsensusModePeerTargets {
+      praosTargets = targets,
+      genesisSyncTargets = targets}
 
     policy :: PeerSelectionPolicy SockAddr IO
     policy  = PeerSelectionPolicy {
@@ -3690,12 +3851,14 @@ prop_issue_3550 = prop_governor_target_established_below defaultMaxTime $
                       ]
         ),
       targets = Script
-        ((nullPeerSelectionTargets {
-           targetNumberOfRootPeers = 1,
-           targetNumberOfKnownPeers = 4,
-           targetNumberOfEstablishedPeers = 4,
-           targetNumberOfActivePeers = 3
-         },NoDelay) :| []),
+        ((ConsensusModePeerTargets {
+            praosTargets = nullPeerSelectionTargets {
+                targetNumberOfRootPeers = 1,
+                targetNumberOfKnownPeers = 4,
+                targetNumberOfEstablishedPeers = 4,
+                targetNumberOfActivePeers = 3 },
+            genesisSyncTargets = nullPeerSelectionTargets },
+         NoDelay) :| []),
       pickKnownPeersForPeerShare = Script (PickFirst :| []),
       pickColdPeersToPromote = Script (PickFirst :| []),
       pickWarmPeersToPromote = Script (PickFirst :| []),
@@ -3704,6 +3867,7 @@ prop_issue_3550 = prop_governor_target_established_below defaultMaxTime $
       pickColdPeersToForget = Script (PickFirst :| []),
       pickInboundPeers      = Script (PickFirst :| []),
       peerSharingFlag = PeerSharingEnabled,
+      consensusMode = PraosMode,
       useBootstrapPeers = Script ((DontUseBootstrapPeers, NoDelay) :| []),
       useLedgerPeers = Script ((UseLedgerPeers Always, NoDelay) :| []),
       ledgerStateJudgement = Script ((YoungEnough, NoDelay) :| [])
@@ -3728,12 +3892,7 @@ prop_issue_3515 = prop_governor_nolivelock $
                          })],
       localRootPeers = LocalRootPeers.fromGroups [(1,1,Map.fromList [(PeerAddr 10,(DoAdvertisePeer, IsNotTrustable))])],
       publicRootPeers = PublicRootPeers.empty,
-      targets = Script
-        (( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, ShortDelay)
-        :| [ ( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, ShortDelay),
-             ( nullPeerSelectionTargets, NoDelay),
-             ( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, NoDelay)
-           ]),
+      targets = Script . NonEmpty.fromList $ targets'',
       pickKnownPeersForPeerShare = Script (PickFirst :| []),
       pickColdPeersToPromote = Script (PickFirst :| []),
       pickWarmPeersToPromote = Script (PickFirst :| []),
@@ -3742,10 +3901,20 @@ prop_issue_3515 = prop_governor_nolivelock $
       pickColdPeersToForget = Script (PickFirst :| []),
       pickInboundPeers = Script (PickFirst :| []),
       peerSharingFlag = PeerSharingEnabled,
+      consensusMode = PraosMode,
       useBootstrapPeers = Script ((DontUseBootstrapPeers, NoDelay) :| []),
       useLedgerPeers = Script ((UseLedgerPeers Always, NoDelay) :| []),
       ledgerStateJudgement = Script ((YoungEnough, NoDelay) :| [])
     }
+  where
+    targets' =
+      [( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, ShortDelay),
+       ( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, ShortDelay),
+       ( nullPeerSelectionTargets, NoDelay),
+       ( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, NoDelay) ]
+    targets'' =
+      [(ConsensusModePeerTargets { praosTargets, genesisSyncTargets = nullPeerSelectionTargets }, delay)
+      | (praosTargets, delay) <- targets']  
 
 -- | issue #3494
 --
@@ -3764,14 +3933,7 @@ prop_issue_3494 = prop_governor_nofail $
                                               })],
       localRootPeers = LocalRootPeers.fromGroups [(1,1,Map.fromList [(PeerAddr 64, (DoAdvertisePeer, IsNotTrustable))])],
       publicRootPeers = PublicRootPeers.empty,
-      targets = Script
-        (( nullPeerSelectionTargets,NoDelay)
-        :| [ (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },ShortDelay),
-             (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },ShortDelay),
-             (nullPeerSelectionTargets,NoDelay),
-             (nullPeerSelectionTargets,NoDelay),
-             (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },NoDelay)
-           ]),
+      targets = Script . NonEmpty.fromList $ targets'',
       pickKnownPeersForPeerShare = Script (PickFirst :| []),
       pickColdPeersToPromote = Script (PickFirst :| []),
       pickWarmPeersToPromote = Script (PickFirst :| []),
@@ -3780,10 +3942,22 @@ prop_issue_3494 = prop_governor_nofail $
       pickColdPeersToForget = Script (PickFirst :| []),
       pickInboundPeers = Script (PickFirst :| []),
       peerSharingFlag = PeerSharingEnabled,
+      consensusMode = PraosMode,
       useBootstrapPeers = Script ((DontUseBootstrapPeers, NoDelay) :| []),
       useLedgerPeers = Script ((UseLedgerPeers Always, NoDelay) :| []),
       ledgerStateJudgement = Script ((YoungEnough, NoDelay) :| [])
     }
+  where
+    targets' =
+      [(nullPeerSelectionTargets,NoDelay),
+       (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },ShortDelay),
+       (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },ShortDelay),
+       (nullPeerSelectionTargets,NoDelay),
+       (nullPeerSelectionTargets,NoDelay),
+       (nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 },NoDelay) ]
+    targets'' =
+      [(ConsensusModePeerTargets { praosTargets, genesisSyncTargets = nullPeerSelectionTargets }, delay)
+      | (praosTargets, delay) <- targets']
 
 -- | issue #3233
 --
@@ -3811,21 +3985,7 @@ prop_issue_3233 = prop_governor_nolivelock $
         ],
       publicRootPeers = PublicRootPeers.fromPublicRootPeers
         (Map.fromList [(PeerAddr 4, DoNotAdvertisePeer)]),
-      targets = Script
-        ((nullPeerSelectionTargets,NoDelay)
-        :| [(nullPeerSelectionTargets {
-               targetNumberOfRootPeers = 1,
-               targetNumberOfKnownPeers = 3,
-               targetNumberOfEstablishedPeers = 3
-             },LongDelay),
-            (nullPeerSelectionTargets,NoDelay),
-            (nullPeerSelectionTargets,NoDelay),
-            (nullPeerSelectionTargets {
-                targetNumberOfRootPeers = 1,
-                targetNumberOfKnownPeers = 3,
-                targetNumberOfEstablishedPeers = 3,
-                targetNumberOfActivePeers = 2
-             },NoDelay)]),
+      targets = Script . NonEmpty.fromList $ targets'',
       pickKnownPeersForPeerShare = Script (PickFirst :| []),
       pickColdPeersToPromote = Script (PickFirst :| []),
       pickWarmPeersToPromote = Script (PickFirst :| []),
@@ -3834,11 +3994,30 @@ prop_issue_3233 = prop_governor_nolivelock $
       pickColdPeersToForget = Script (PickFirst :| []),
       pickInboundPeers = Script (PickFirst :| []),
       peerSharingFlag = PeerSharingEnabled,
+      consensusMode = PraosMode,
       useBootstrapPeers = Script ((DontUseBootstrapPeers, NoDelay) :| []),
       useLedgerPeers = Script ((UseLedgerPeers Always, NoDelay) :| []),
       ledgerStateJudgement = Script ((YoungEnough, NoDelay) :| [])
     }
-
+  where
+    targets' =
+      [(nullPeerSelectionTargets, NoDelay),
+       (nullPeerSelectionTargets {
+           targetNumberOfRootPeers = 1,
+           targetNumberOfKnownPeers = 3,
+           targetNumberOfEstablishedPeers = 3
+           }, LongDelay),
+       (nullPeerSelectionTargets, NoDelay),
+       (nullPeerSelectionTargets, NoDelay),
+       (nullPeerSelectionTargets {
+           targetNumberOfRootPeers = 1,
+           targetNumberOfKnownPeers = 3,
+           targetNumberOfEstablishedPeers = 3,
+           targetNumberOfActivePeers = 2
+           }, NoDelay)]
+    targets'' =
+      [(ConsensusModePeerTargets { praosTargets, genesisSyncTargets = nullPeerSelectionTargets }, delay)
+      | (praosTargets, delay) <- targets'] 
 
 -- | Verify that re-promote delay is applied with a fuzz.
 --

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -43,6 +43,7 @@ import Data.Foldable (traverse_)
 import Data.Function (on)
 import Data.IP qualified as IP
 import Data.List (foldl', groupBy, intercalate)
+import Data.List.NonEmpty qualified as NonEmpty
 import Data.List.Trace qualified as Trace
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -56,6 +57,7 @@ import System.Random (mkStdGen)
 import Network.DNS qualified as DNS (defaultResolvConf)
 import Network.Socket (SockAddr)
 
+import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..),
            requiresBootstrapPeers)
@@ -96,8 +98,6 @@ import Test.QuickCheck.Monoids
 import Test.Tasty
 import Test.Tasty.QuickCheck
 import Text.Pretty.Simple
-import Ouroboros.Network.ConsensusMode
-import Data.List.NonEmpty qualified as NonEmpty
 
 -- Exactly as named.
 unfHydra :: Int
@@ -765,8 +765,8 @@ envEventCredits (TraceEnvSetTargets PeerSelectionTargets {
                     + 10 * (targetNumberOfKnownPeers
                           + targetNumberOfEstablishedPeers
                           + targetNumberOfActivePeers)
-                    
--- todo: add big ledger peer terms?                    
+
+-- todo: add big ledger peer terms?
 envEventCredits (TraceEnvGenesisLsjAndTargets (_, targets))
   =   80
     + 10 * (targetNumberOfKnownPeers
@@ -3751,7 +3751,7 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
             readUseLedgerPeers = return DontUseLedgerPeers
           }
         actions' = actions churnMutex
-          
+
     publicRootPeersProvider
       tracer
       (curry IP.toSockAddr)
@@ -3914,7 +3914,7 @@ prop_issue_3515 = prop_governor_nolivelock $
        ( nullPeerSelectionTargets { targetNumberOfKnownPeers = 1 }, NoDelay) ]
     targets'' =
       [(ConsensusModePeerTargets { praosTargets, genesisSyncTargets = nullPeerSelectionTargets }, delay)
-      | (praosTargets, delay) <- targets']  
+      | (praosTargets, delay) <- targets']
 
 -- | issue #3494
 --
@@ -4017,7 +4017,7 @@ prop_issue_3233 = prop_governor_nolivelock $
            }, NoDelay)]
     targets'' =
       [(ConsensusModePeerTargets { praosTargets, genesisSyncTargets = nullPeerSelectionTargets }, delay)
-      | (praosTargets, delay) <- targets'] 
+      | (praosTargets, delay) <- targets']
 
 -- | Verify that re-promote delay is applied with a fuzz.
 --

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -79,6 +79,7 @@ import Ouroboros.Network.PeerSelection.State.KnownPeers qualified as KnownPeers
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootPeers (..), WarmValency (..))
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRootPeers
+import Ouroboros.Network.Point
 import Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingResult (..))
 
 import Ouroboros.Network.Testing.Data.Script
@@ -917,6 +918,7 @@ traceNum TraceOutboundGovernorCriticalFailure {}              = 53
 traceNum TraceDebugState {}                                   = 54
 traceNum TraceChurnAction {}                                  = 55
 traceNum TraceChurnTimeout {}                                 = 56
+traceNum TraceVerifyPeerSnapshot {}                           = 57
 
 allTraceNames :: Map Int String
 allTraceNames =
@@ -978,6 +980,7 @@ allTraceNames =
    , (54, "TraceDebugState")
    , (55, "TraceChurnAction")
    , (56, "TraceChurnTimeout")
+   , (57, "TraceVerifyPeerSnapshot")
    ]
 
 
@@ -3751,6 +3754,10 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
             readUseLedgerPeers = return DontUseLedgerPeers
           }
         actions' = actions churnMutex
+        consensusInterface = LedgerPeersConsensusInterface {
+          lpGetLatestSlot = pure Origin,
+          lpGetLedgerStateJudgement = pure TooOld,
+          lpGetLedgerPeers = pure [] }
 
     publicRootPeersProvider
       tracer
@@ -3769,6 +3776,8 @@ _governorFindingPublicRoots targetNumberOfRootPeers readDomains readUseBootstrap
                 transformPeerSelectionAction requestPublicRootPeers }
           policy
           interfaces
+          (pure Nothing)
+          consensusInterface
   where
     tracer :: Show a => Tracer IO a
     tracer  = Tracer (BS.putStrLn . BS.pack . show)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -26,6 +26,7 @@ import Ouroboros.Network.PeerSelection.Governor
 
 import Data.Hashable
 import Data.IP qualified as IP
+import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type (AfterSlot (..),
            UseLedgerPeers (..))
@@ -37,7 +38,6 @@ import Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
 import Ouroboros.Network.Testing.Utils (ShrinkCarefully, prop_shrink_nonequal,
            prop_shrink_valid)
 import Test.QuickCheck
-import Ouroboros.Network.ConsensusMode
 
 
 --
@@ -74,7 +74,7 @@ instance Arbitrary ConsensusMode where
   arbitrary = elements [PraosMode, GenesisMode]
   shrink GenesisMode = [PraosMode]
   shrink PraosMode   = []
-  
+
 instance Arbitrary AfterSlot where
   arbitrary = oneof [ pure Always
                     , After <$> arbitrary

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -375,7 +375,6 @@ mockPeerSelectionActions tracer
                                  connectionScript
                                }) <- adjacency
                    ]
-    churnMutex <- StrictTVar.newEmptyTMVarIO
     peerConns  <- atomically $ do
       v <- newTVar Map.empty
       traceTVar proxy
@@ -395,7 +394,6 @@ mockPeerSelectionActions tracer
                getLedgerStateJudgement
                peerConns
                onlyLocalOutboundConnsVar
-               churnMutex
   where
     proxy :: Proxy m
     proxy = Proxy
@@ -423,7 +421,6 @@ mockPeerSelectionActions' :: forall m.
                           -> STM m LedgerStateJudgement
                           -> TVar m (Map PeerAddr (TVar m PeerStatus))
                           -> TVar m OutboundConnectionsState
-                          -> StrictTVar.StrictTMVar m ()
                           -> PeerSelectionActions PeerAddr (PeerConn m) m
 mockPeerSelectionActions' tracer
                           GovernorMockEnvironment {
@@ -439,8 +436,7 @@ mockPeerSelectionActions' tracer
                           readUseLedgerPeers
                           readLedgerStateJudgement
                           connsVar
-                          outboundConnectionsStateVar
-                          churnMutex =
+                          outboundConnectionsStateVar =
     PeerSelectionActions {
       readLocalRootPeers       = return (LocalRootPeers.toGroups localRootPeers),
       peerSharing              = peerSharingFlag,
@@ -462,7 +458,6 @@ mockPeerSelectionActions' tracer
         a' <- readTVar outboundConnectionsStateVar
         when (a /= a') $
           writeTVar outboundConnectionsStateVar a,
-      churnMutex,
       peerTargets
     }
   where

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -1130,7 +1130,8 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         show a
       peerSelectionTraceMap a@TraceChurnTimeout {}                   =
         show a
-
+      peerSelectionTraceMap (TraceVerifyPeerSnapshot result)         =
+        "TraceVerifyPeerSnapshot " ++ show result
       eventsSeenNames = map peerSelectionTraceMap events
 
    -- TODO: Add checkCoverage here

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -19,6 +19,7 @@ module Test.Ouroboros.Network.Testnet.Simulation.Node
   , DiffusionSimulationTrace (..)
   , prop_diffusionScript_fixupCommands
   , prop_diffusionScript_commandScript_valid
+  , fixupCommands
   , diffusionSimulation
   , Command (..)
     -- * Tracing
@@ -50,7 +51,7 @@ import Control.Monad.IOSim (IOSim, traceM)
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BL
 import Data.IP (IP (..))
-import Data.List (delete, nubBy)
+import Data.List (delete, nubBy, intercalate)
 import Data.Map (Map)
 import Data.Map qualified as Map
 import Data.Maybe (catMaybes, fromMaybe, maybeToList)
@@ -77,7 +78,7 @@ import Ouroboros.Network.InboundGovernor (InboundGovernorTrace,
 import Ouroboros.Network.Mux (MiniProtocolLimits (..))
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-           PeerSelectionTargets (..), TracePeerSelection)
+           PeerSelectionTargets (..), TracePeerSelection, ConsensusModePeerTargets (..))
 import Ouroboros.Network.PeerSelection.Governor qualified as PeerSelection
 import Ouroboros.Network.PeerSelection.LedgerPeers (AfterSlot (..),
            LedgerPeersConsensusInterface (..), LedgerStateJudgement (..),
@@ -140,6 +141,9 @@ import Test.Ouroboros.Network.LedgerPeers (LedgerPools (..), genLedgerPoolsFrom)
 import Test.Ouroboros.Network.PeerSelection.LocalRootPeers ()
 import Test.QuickCheck
 
+import Ouroboros.Network.ConsensusMode
+import Data.List.NonEmpty qualified as NonEmpty
+
 -- | Diffusion Simulator Arguments
 --
 -- Contains all necessary randomly generated values needed to run diffusion in
@@ -192,6 +196,7 @@ data NodeArgs =
       -- ^ 'LimitsAndTimeouts' argument
     , naPublicRoots            :: Map RelayAccessPoint PeerAdvertise
       -- ^ 'Interfaces' relays auxiliary value
+    , naConsensusMode          :: ConsensusMode
     , naBootstrapPeers         :: Script UseBootstrapPeers
       -- ^ 'Interfaces' relays auxiliary value
     , naAddr                   :: NtNAddr
@@ -205,7 +210,7 @@ data NodeArgs =
                                    )]
     , naLedgerPeers            :: Script LedgerPools
       -- ^ 'Arguments' 'LocalRootPeers' values
-    , naLocalSelectionTargets  :: PeerSelectionTargets
+    , naPeerTargets            :: ConsensusModePeerTargets
       -- ^ 'Arguments' 'aLocalSelectionTargets' value
     , naDNSTimeoutScript       :: Script DNSTimeout
       -- ^ 'Arguments' 'aDNSTimeoutScript' value
@@ -218,24 +223,26 @@ data NodeArgs =
 
 instance Show NodeArgs where
     show NodeArgs { naSeed, naDiffusionMode, naMbTime, naBootstrapPeers, naPublicRoots,
-                   naAddr, naPeerSharing, naLocalRootPeers, naLocalSelectionTargets,
+                   naAddr, naPeerSharing, naLocalRootPeers, naPeerTargets,
                    naDNSTimeoutScript, naDNSLookupDelayScript, naChainSyncExitOnBlockNo,
-                   naChainSyncEarlyExit, naFetchModeScript } =
-      unwords [ "NodeArgs"
+                   naChainSyncEarlyExit, naFetchModeScript, naConsensusMode } =
+      intercalate "\n  " [ "NodeArgs"
               , "(" ++ show naSeed ++ ")"
               , show naDiffusionMode
+              , show naConsensusMode
               , "(" ++ show naMbTime ++ ")"
               , "(" ++ show naPublicRoots ++ ")"
               , "(" ++ show naBootstrapPeers ++ ")"
               , "(" ++ show naAddr ++ ")"
               , show naPeerSharing
               , show naLocalRootPeers
-              , show naLocalSelectionTargets
+              , show naPeerTargets
               , "(" ++ show naDNSTimeoutScript ++ ")"
               , "(" ++ show naDNSLookupDelayScript ++ ")"
               , "(" ++ show naChainSyncExitOnBlockNo ++ ")"
               , show naChainSyncEarlyExit
               , show naFetchModeScript
+              , "============================================\n"
               ]
 
 data Command = JoinNetwork DiffTime
@@ -387,9 +394,11 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
 
   -- Make sure our targets for active peers cover the maximum of peers
   -- one generated
-  SmallTargets peerSelectionTargets <- resize (length relays * 2) arbitrary
+  SmallTargets praosTargets <- resize (length relays * 2) arbitrary
                                        `suchThat` hasActive
-
+  SmallTargets genesisSyncTargets <- resize (length relays * 2) arbitrary
+                                       `suchThat` hasActive
+  let peerTargets = ConsensusModePeerTargets { praosTargets, genesisSyncTargets }                                       
   dnsTimeout <- arbitrary
   dnsLookupDelay <- arbitrary
   chainSyncExitOnBlockNo
@@ -422,11 +431,11 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
 
   fetchModeScript <- fmap (bool FetchModeBulkSync FetchModeDeadline) <$> arbitrary
 
-  firstBootstrapPeer <- maybe DontUseBootstrapPeers UseBootstrapPeers
-                      <$> arbitrary
-  bootstrapPeers <- listOf (maybe DontUseBootstrapPeers UseBootstrapPeers
-                           <$> arbitrary)
-  let bootstrapPeersDomain = Script (firstBootstrapPeer :| bootstrapPeers)
+  naConsensusMode <- arbitrary
+  bootstrapPeersDomain <- 
+    case naConsensusMode of
+      GenesisMode -> pure . singletonScript $ DontUseBootstrapPeers
+      PraosMode   -> Script . NonEmpty.fromList <$> listOf1 arbitrary
 
   return
    $ NodeArgs
@@ -436,11 +445,12 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
       , naPublicRoots            = publicRoots
         -- TODO: we haven't been using public root peers so far because we set
         -- `UseLedgerPeers 0`!
+      , naConsensusMode
       , naBootstrapPeers         = bootstrapPeersDomain
       , naAddr                   = makeNtNAddr relay
       , naLocalRootPeers         = localRootPeers
       , naLedgerPeers            = ledgerPeerPoolsScript
-      , naLocalSelectionTargets  = peerSelectionTargets
+      , naPeerTargets            = peerTargets
       , naDNSTimeoutScript       = dnsTimeout
       , naDNSLookupDelayScript   = dnsLookupDelay
       , naChainSyncExitOnBlockNo = chainSyncExitOnBlockNo
@@ -1052,10 +1062,11 @@ diffusionSimulation
             { naSeed                   = seed
             , naMbTime                 = mustReplyTimeout
             , naPublicRoots            = publicRoots
+            , naConsensusMode          = consensusMode
             , naBootstrapPeers         = bootstrapPeers
             , naAddr                   = addr
             , naLedgerPeers            = ledgerPeers
-            , naLocalSelectionTargets  = peerSelectionTargets
+            , naPeerTargets            = peerTargets
             , naDNSTimeoutScript       = dnsTimeout
             , naDNSLookupDelayScript   = dnsLookupDelay
             , naChainSyncExitOnBlockNo = chainSyncExitOnBlockNo
@@ -1180,11 +1191,12 @@ diffusionSimulation
               , NodeKernel.aDiffusionMode        = diffusionMode
               , NodeKernel.aKeepAliveInterval    = 10
               , NodeKernel.aPingPongInterval     = 10
-              , NodeKernel.aPeerSelectionTargets = peerSelectionTargets
+              , NodeKernel.aPeerTargets          = peerTargets
               , NodeKernel.aShouldChainSyncExit  = shouldChainSyncExit chainSyncExitVar
               , NodeKernel.aChainSyncEarlyExit   = chainSyncEarlyExit
               , NodeKernel.aReadLocalRootPeers   = readLocalRootPeers
               , NodeKernel.aReadPublicRootPeers  = readPublicRootPeers
+              , NodeKernel.aConsensusMode        = consensusMode
               , NodeKernel.aReadUseBootstrapPeers = bootstrapPeers
               , NodeKernel.aOwnPeerSharing       = peerSharing
               , NodeKernel.aReadUseLedgerPeers   = readUseLedgerPeers

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Common.hs
@@ -38,6 +38,7 @@ import Ouroboros.Network.PeerSelection.LocalRootPeers (OutboundConnectionsState)
 import Ouroboros.Network.Snocket (FileDescriptor)
 import Ouroboros.Network.Socket (SystemdSocketTracer)
 
+
 -- | The 'DiffusionTracer' logs
 --
 -- * diffusion initialisation messages

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE DataKinds           #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE KindSignatures      #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators       #-}
+{-# LANGUAGE CPP                      #-}
+{-# LANGUAGE DataKinds                #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE GADTs                    #-}
+{-# LANGUAGE KindSignatures           #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TypeOperators            #-}
 
 #if !defined(mingw32_HOST_OS)
 #define POSIX
@@ -101,14 +101,14 @@ import Ouroboros.Network.NodeToNode (AcceptedConnectionsLimit (..),
            NodeToNodeVersionData (..), RemoteAddress)
 import Ouroboros.Network.NodeToNode qualified as NodeToNode
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
-import Ouroboros.Network.PeerSelection.Churn ( PeerChurnArgs(..) )
+import Ouroboros.Network.PeerSelection.Churn (PeerChurnArgs (..))
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor
 import Ouroboros.Network.PeerSelection.Governor.Types
-           (ChurnMode (ChurnModeNormal), DebugPeerSelection (..),
-           PeerSelectionActions, PeerSelectionCounters,
+           (ChurnMode (ChurnModeNormal), ConsensusModePeerTargets (..),
+           DebugPeerSelection (..), PeerSelectionActions, PeerSelectionCounters,
            PeerSelectionInterfaces (..), PeerSelectionPolicy (..),
            PeerSelectionState, TracePeerSelection (..),
-           emptyPeerSelectionCounters, emptyPeerSelectionState, ConsensusModePeerTargets (..))
+           emptyPeerSelectionCounters, emptyPeerSelectionState)
 #ifdef POSIX
 import Ouroboros.Network.PeerSelection.Governor.Types
            (makeDebugPeerSelectionState)
@@ -248,17 +248,17 @@ nullTracers =
 data ArgumentsExtra m = ArgumentsExtra {
       -- | selection targets for the peer governor
       --
-      daPeerTargets :: ConsensusModePeerTargets
+      daPeerTargets            :: ConsensusModePeerTargets
 
-    , daReadLocalRootPeers    :: STM m (LocalRootPeers.Config RelayAccessPoint)
-    , daReadPublicRootPeers   :: STM m (Map RelayAccessPoint PeerAdvertise)
+    , daReadLocalRootPeers     :: STM m (LocalRootPeers.Config RelayAccessPoint)
+    , daReadPublicRootPeers    :: STM m (Map RelayAccessPoint PeerAdvertise)
     -- | When syncing up, ie. ledgerStateJudgement == TooOld,
     -- when this is True we will maintain connection with many big ledger peers
     -- to get a strong guarantee that when syncing up we will finish with a true
     -- ledger state. When false, we will fall back on the previous algorithms
     -- that leverage UseBootstrapPeers flag
-    , daConsensusMode :: ConsensusMode
-    , daReadUseBootstrapPeers :: STM m UseBootstrapPeers
+    , daConsensusMode          :: ConsensusMode
+    , daReadUseBootstrapPeers  :: STM m UseBootstrapPeers
     -- | Depending on configuration, node may provide us with
     -- a snapshot of big ledger peers taken at some slot on the chain.
     -- These peers may be selected by ledgerPeersThread when requested
@@ -832,7 +832,7 @@ runM Interfaces
       peerSelectionTargetsVar <- newTVarIO $
         -- because peer selection governor starts up in TooOld state
         let base = case daConsensusMode of
-                     PraosMode -> praosTargets daPeerTargets
+                     PraosMode   -> praosTargets daPeerTargets
                      GenesisMode -> genesisSyncTargets daPeerTargets
         in base {
           -- Start with a smaller number of active peers, the churn governor

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1044,6 +1044,8 @@ runM Interfaces
                 debugStateVar      = dbgVar,
                 readUseLedgerPeers = daReadUseLedgerPeers
               }
+              daReadLedgerPeerSnapshot
+              daLedgerPeersCtx
 
 
       --

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -824,11 +824,6 @@ runM Interfaces
 
       churnModeVar <- newTVarIO ChurnModeNormal
 
-      -- ensure that peer selection governor does not change targets
-      -- in the initial starting phase when churn governor should be
-      -- in control. See comment directly below.
-      churnMutex <- newEmptyTMVarIO
-
       peerSelectionTargetsVar <- newTVarIO $
         -- because peer selection governor starts up in TooOld state
         let base = case daConsensusMode of
@@ -1012,8 +1007,7 @@ runM Interfaces
                                              PeerSharingDisabled -> pure Map.empty
                                              PeerSharingEnabled  -> readInboundPeers,
                                          psUpdateOutboundConnectionsState = daUpdateOutboundConnectionsState,
-                                         peerTargets = daPeerTargets,
-                                         psChurnMutex = churnMutex }
+                                         peerTargets = daPeerTargets }
                                        WithLedgerPeersArgs {
                                          wlpRng = ledgerPeersRng,
                                          wlpConsensusInterface = daLedgerPeersCtx,
@@ -1065,8 +1059,7 @@ runM Interfaces
                                  pcaReadCounters = (readTVar countersVar),
                                  peerTargets = daPeerTargets,
                                  pcaReadUseBootstrap = daReadUseBootstrapPeers,
-                                 pcaConsensusMode = daConsensusMode,
-                                 pcaChurnMutex = churnMutex }
+                                 pcaConsensusMode = daConsensusMode }
 
       --
       -- Two functions only used in InitiatorAndResponder mode

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -245,11 +245,11 @@ nullTracers =
 data ArgumentsExtra m = ArgumentsExtra {
       -- | selection targets for the peer governor
       --
-      daPeerSelectionTargets  :: PeerSelectionTargets
+      daPeerSelectionTargets   :: PeerSelectionTargets
 
-    , daReadLocalRootPeers    :: STM m (LocalRootPeers.Config RelayAccessPoint)
-    , daReadPublicRootPeers   :: STM m (Map RelayAccessPoint PeerAdvertise)
-    , daReadUseBootstrapPeers :: STM m UseBootstrapPeers
+    , daReadLocalRootPeers     :: STM m (LocalRootPeers.Config RelayAccessPoint)
+    , daReadPublicRootPeers    :: STM m (Map RelayAccessPoint PeerAdvertise)
+    , daReadUseBootstrapPeers  :: STM m UseBootstrapPeers
     -- | Depending on configuration, node may provide us with
     -- a snapshot of big ledger peers taken at some slot on the chain.
     -- These peers may be selected by ledgerPeersThread when requested
@@ -260,8 +260,8 @@ data ArgumentsExtra m = ArgumentsExtra {
     -- | Peer's own PeerSharing value.
     --
     -- This value comes from the node's configuration file and is static.
-    , daOwnPeerSharing        :: PeerSharing
-    , daReadUseLedgerPeers    :: STM m UseLedgerPeers
+    , daOwnPeerSharing         :: PeerSharing
+    , daReadUseLedgerPeers     :: STM m UseLedgerPeers
 
       -- | Timeout which starts once all responder protocols are idle. If the
       -- responders stay idle for duration of the timeout, the connection will
@@ -272,7 +272,7 @@ data ArgumentsExtra m = ArgumentsExtra {
       --
       -- See 'serverProtocolIdleTimeout'.
       --
-    , daProtocolIdleTimeout   :: DiffTime
+    , daProtocolIdleTimeout    :: DiffTime
 
       -- | Time for which /node-to-node/ connections are kept in
       -- 'TerminatingState', it should correspond to the OS configured @TCP@
@@ -282,21 +282,21 @@ data ArgumentsExtra m = ArgumentsExtra {
       -- purpose is to be resilient for delayed packets in the same way @TCP@
       -- is using @TIME_WAIT@.
       --
-    , daTimeWaitTimeout       :: DiffTime
+    , daTimeWaitTimeout        :: DiffTime
 
       -- | Churn interval between churn events in deadline mode.  A small fuzz
       -- is added (max 10 minutes) so that not all nodes churn at the same time.
       --
       -- By default it is set to 3300 seconds.
       --
-    , daDeadlineChurnInterval :: DiffTime
+    , daDeadlineChurnInterval  :: DiffTime
 
       -- | Churn interval between churn events in bulk sync mode.  A small fuzz
       -- is added (max 1 minute) so that not all nodes churn at the same time.
       --
       -- By default it is set to 300 seconds.
       --
-    , daBulkChurnInterval     :: DiffTime
+    , daBulkChurnInterval      :: DiffTime
     }
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 #if __GLASGOW_HASKELL__ < 904
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -52,14 +52,14 @@ data ChurnRegime = ChurnDefault
                  | ChurnBootstrapPraosSync
                  -- ^ Praos targets further reduced to conserve resources
                  -- when syncing
-                 
+
 pickChurnRegime :: ConsensusMode -> ChurnMode -> UseBootstrapPeers -> ChurnRegime
 pickChurnRegime consensus churn ubp =
   case (churn, ubp, consensus) of
-    (ChurnModeNormal, _, _) -> ChurnDefault
-    (_, _, GenesisMode) -> ChurnDefault
+    (ChurnModeNormal, _, _)                     -> ChurnDefault
+    (_, _, GenesisMode)                         -> ChurnDefault
     (ChurnModeBulkSync, UseBootstrapPeers _, _) -> ChurnBootstrapPraosSync
-    (ChurnModeBulkSync, _, _) -> ChurnPraosSync
+    (ChurnModeBulkSync, _, _)                   -> ChurnPraosSync
 
 -- | Facilitates composing updates to various targets via back-to-back pipeline
 type ModifyPeerSelectionTargets = PeerSelectionTargets -> PeerSelectionTargets
@@ -70,23 +70,23 @@ data ChurnCounters = ChurnCounter ChurnAction Int
 -- | Record of arguments for peer churn governor
 --
 data PeerChurnArgs m peeraddr = PeerChurnArgs {
-  pcaPeerSelectionTracer   :: Tracer m (TracePeerSelection peeraddr),
-  pcaChurnTracer           :: Tracer m ChurnCounters,
-  pcaDeadlineInterval      :: DiffTime,
-  pcaBulkInterval          :: DiffTime,
-  pcaPeerRequestTimeout    :: DiffTime,
+  pcaPeerSelectionTracer :: Tracer m (TracePeerSelection peeraddr),
+  pcaChurnTracer         :: Tracer m ChurnCounters,
+  pcaDeadlineInterval    :: DiffTime,
+  pcaBulkInterval        :: DiffTime,
+  pcaPeerRequestTimeout  :: DiffTime,
   -- ^ the timeout for outbound governor to find new (thus
   -- cold) peers through peer sharing mechanism.
-  pcaMetrics               :: PeerMetrics m peeraddr,
-  pcaModeVar               :: StrictTVar m ChurnMode,
-  pcaRng                   :: StdGen,
-  pcaReadFetchMode         :: STM m FetchMode,
-  peerTargets              :: ConsensusModePeerTargets,
-  pcaPeerSelectionVar      :: StrictTVar m PeerSelectionTargets,
-  pcaReadCounters          :: STM m PeerSelectionCounters,
-  pcaReadUseBootstrap      :: STM m UseBootstrapPeers,
-  pcaChurnMutex            :: StrictTMVar m (),
-  pcaConsensusMode         :: ConsensusMode }
+  pcaMetrics             :: PeerMetrics m peeraddr,
+  pcaModeVar             :: StrictTVar m ChurnMode,
+  pcaRng                 :: StdGen,
+  pcaReadFetchMode       :: STM m FetchMode,
+  peerTargets            :: ConsensusModePeerTargets,
+  pcaPeerSelectionVar    :: StrictTVar m PeerSelectionTargets,
+  pcaReadCounters        :: STM m PeerSelectionCounters,
+  pcaReadUseBootstrap    :: STM m UseBootstrapPeers,
+  pcaChurnMutex          :: StrictTMVar m (),
+  pcaConsensusMode       :: ConsensusMode }
 
 -- | Churn governor.
 --
@@ -134,8 +134,8 @@ peerChurnGovernor PeerChurnArgs {
   let base =
         case (consensusMode, churnMode) of
           (GenesisMode, ChurnModeBulkSync) -> genesisSyncTargets
-          (GenesisMode, ChurnModeNormal) -> praosTargets
-          (PraosMode, _) -> praosTargets
+          (GenesisMode, ChurnModeNormal)   -> praosTargets
+          (PraosMode, _)                   -> praosTargets
 
   atomically $ do
     modifyTVar peerSelectionVar ( increaseActivePeers regime base
@@ -462,8 +462,8 @@ peerChurnGovernor PeerChurnArgs {
             base =
               case (consensusMode, churnMode) of
                 (GenesisMode, ChurnModeBulkSync) -> genesisSyncTargets
-                (GenesisMode, ChurnModeNormal) -> praosTargets
-                (PraosMode, _) -> praosTargets
+                (GenesisMode, ChurnModeNormal)   -> praosTargets
+                (PraosMode, _)                   -> praosTargets
 
         return (base, churnMode, regime)
 
@@ -551,7 +551,7 @@ peerChurnGovernor PeerChurnArgs {
                     numberOfEstablishedBigLedgerPeers
                     churnEstablishConnectionTimeout
                     (increaseEstablishedBigLedgerPeers base)
-                    checkEstablishedBigLedgerPeersIncreased                    
+                    checkEstablishedBigLedgerPeersIncreased
 
       endTs <- getMonotonicTime
 
@@ -571,7 +571,7 @@ peerChurnGovernor PeerChurnArgs {
       case (mode, consensusMode) of
         (FetchModeDeadline, _) -> longDelay rng execTime
         (_, GenesisMode)       -> longDelay rng execTime
-        _otherwise              -> shortDelay rng execTime
+        _otherwise             -> shortDelay rng execTime
 
 
     fuzzyDelay' :: DiffTime -> Double -> StdGen -> DiffTime -> m StdGen

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE MultiWayIf          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE BangPatterns          #-}
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE MultiWayIf            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
 
 #if __GLASGOW_HASKELL__ < 904
 {-# OPTIONS_GHC -Wno-name-shadowing #-}
@@ -72,8 +72,8 @@ import System.Random
 
 import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
-import Ouroboros.Network.PeerSelection.Churn (ChurnCounters (..), PeerChurnArgs (..),
-           peerChurnGovernor)
+import Ouroboros.Network.PeerSelection.Churn (ChurnCounters (..),
+           PeerChurnArgs (..), peerChurnGovernor)
 import Ouroboros.Network.PeerSelection.Governor.ActivePeers qualified as ActivePeers
 import Ouroboros.Network.PeerSelection.Governor.BigLedgerPeers qualified as BigLedgerPeers
 import Ouroboros.Network.PeerSelection.Governor.EstablishedPeers qualified as EstablishedPeers

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -19,7 +19,7 @@ module Ouroboros.Network.PeerSelection.Governor.Monitor
   , waitForSystemToQuiesce
   ) where
 
-import Data.Functor ( (<&>) )
+import Data.Functor ((<&>))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, isJust)

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -420,21 +420,21 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
 data PeerSelectionInterfaces peeraddr peerconn m = PeerSelectionInterfaces {
       -- | PeerSelectionCounters are shared with churn through a `StrictTVar`.
       --
-      countersVar                   :: StrictTVar m PeerSelectionCounters,
+      countersVar        :: StrictTVar m PeerSelectionCounters,
 
       -- | PublicPeerSelectionState var.
       --
-      publicStateVar                :: StrictTVar m (PublicPeerSelectionState peeraddr),
+      publicStateVar     :: StrictTVar m (PublicPeerSelectionState peeraddr),
 
       -- | PeerSelectionState shared for debugging purposes (to support SIGUSR1
       -- debug event tracing)
       --
-      debugStateVar                 :: StrictTVar m (PeerSelectionState peeraddr peerconn),
+      debugStateVar      :: StrictTVar m (PeerSelectionState peeraddr peerconn),
 
       -- | `UseLedgerPeers` used by `peerSelectionGovernor` to support
       -- `HiddenRelayOrBP`
       --
-      readUseLedgerPeers            :: STM m UseLedgerPeers
+      readUseLedgerPeers :: STM m UseLedgerPeers
     }
 
 

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -136,7 +136,6 @@ import Data.Set qualified as Set
 import GHC.Stack (HasCallStack)
 
 import Control.Applicative (Alternative)
-import Control.Concurrent.Class.MonadSTM.Strict.TMVar
 import Control.Concurrent.JobPool (Job)
 import Control.Exception (Exception (..), SomeException, assert)
 import Control.Monad.Class.MonadSTM
@@ -338,10 +337,6 @@ data PeerSelectionActions peeraddr peerconn m = PeerSelectionActions {
        -- from node's configuration for the current state
        --
        peerTargets :: ConsensusModePeerTargets,
-
-       -- | Mutex to avoid interleaved updates between peer sel. & churn govnrs
-       -- which could result in mixed target values
-       churnMutex     :: StrictTMVar m (),
 
        -- | Read the current set of locally or privately known root peers.
        --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -122,6 +122,7 @@ module Ouroboros.Network.PeerSelection.Governor.Types
   , DebugPeerSelection (..)
     -- * Error types
   , BootstrapPeersCriticalTimeoutError (..)
+  , BigLedgerPeerSnapshotError (..)
   ) where
 
 import Data.Map.Strict (Map)
@@ -1712,6 +1713,7 @@ data TracePeerSelection peeraddr =
      | TraceOnlyBootstrapPeers
      | TraceBootstrapPeersFlagChangedWhilstInSensitiveState
      | TraceUseBootstrapPeersChanged UseBootstrapPeers
+     | TraceVerifyPeerSnapshot Bool
 
      --
      -- Critical Failures
@@ -1748,6 +1750,14 @@ data BootstrapPeersCriticalTimeoutError =
 instance Exception BootstrapPeersCriticalTimeoutError where
    displayException BootstrapPeersCriticalTimeoutError =
      "The peer selection did not converged to a clean state in 15 minutes. Something is wrong!"
+
+data BigLedgerPeerSnapshotError = BigLedgerPeerSnapshotError
+  deriving (Eq, Show)
+
+instance Exception BigLedgerPeerSnapshotError where
+  displayException _ =    "Syncing with peer ledger peers has reached the slot"
+                       <> " where the snapshot was ostensibly taken at, but"
+                       <> " the data it contains is not consistent with the ledger"
 
 data DebugPeerSelection peeraddr where
   TraceGovernorState :: forall peeraddr peerconn.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers.hs
@@ -24,6 +24,7 @@ module Ouroboros.Network.PeerSelection.LedgerPeers
   , LedgerPeersKind (..)
     -- * Ledger Peers specific functions
   , accPoolStake
+  , accumulateBigLedgerStake
   , accBigPoolStakeMap
   , bigLedgerPeerQuota
     -- * DNS based provider for ledger root peers
@@ -59,8 +60,9 @@ import Data.Word (Word16, Word64)
 import Network.DNS qualified as DNS
 import Ouroboros.Network.PeerSelection.LedgerPeers.Common
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
-import Ouroboros.Network.PeerSelection.LedgerPeers.Utils (accBigPoolStake,
-           bigLedgerPeerQuota, reRelativeStake)
+import Ouroboros.Network.PeerSelection.LedgerPeers.Utils
+           (accumulateBigLedgerStake, bigLedgerPeerQuota,
+           recomputeRelativeStake)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint
 import Ouroboros.Network.PeerSelection.RootPeersDNS
 import Ouroboros.Network.PeerSelection.RootPeersDNS.LedgerPeers
@@ -110,7 +112,7 @@ accPoolStake :: [(PoolStake, NonEmpty RelayAccessPoint)]
 accPoolStake =
       Map.fromList
     . foldl' fn []
-    . reRelativeStake AllLedgerPeers
+    . recomputeRelativeStake AllLedgerPeers
   where
     fn :: [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))]
        -> (PoolStake, NonEmpty RelayAccessPoint)
@@ -129,7 +131,7 @@ accBigPoolStakeMap :: [(PoolStake, NonEmpty RelayAccessPoint)]
                    -> Map AccPoolStake (PoolStake, NonEmpty RelayAccessPoint)
 accBigPoolStakeMap = Map.fromAscList      -- the input list is ordered by `AccPoolStake`, thus we
                                           -- can use `fromAscList`
-                     . accBigPoolStake
+                     . accumulateBigLedgerStake
 
 -- | Try to pick n random peers using stake distribution.
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers/Common.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/LedgerPeers/Common.hs
@@ -57,6 +57,7 @@ data TraceLedgerPeers =
     | FallingBackToPublicRootPeers
     | NotEnoughBigLedgerPeers NumberOfPeers Int
     | NotEnoughLedgerPeers NumberOfPeers Int
+    | UsingBigLedgerPeerSnapshot
 
 
 instance Show TraceLedgerPeers where
@@ -102,3 +103,4 @@ instance Show TraceLedgerPeers where
       "Resolution success " ++ show domain ++ " " ++ show l
     show (TraceLedgerPeersFailure domain err) =
       "Resolution failed " ++ show domain ++ " " ++ show err
+    show UsingBigLedgerPeerSnapshot = "Using peer snapshot for big ledger peers"

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
@@ -1,11 +1,11 @@
-{-# LANGUAGE CPP                 #-}
-{-# LANGUAGE FlexibleContexts    #-}
-{-# LANGUAGE LambdaCase          #-}
-{-# LANGUAGE NamedFieldPuns      #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE CPP                      #-}
 {-# LANGUAGE DisambiguateRecordFields #-}
+{-# LANGUAGE FlexibleContexts         #-}
+{-# LANGUAGE LambdaCase               #-}
+{-# LANGUAGE NamedFieldPuns           #-}
+{-# LANGUAGE RankNTypes               #-}
+{-# LANGUAGE ScopedTypeVariables      #-}
+{-# LANGUAGE TupleSections            #-}
 
 module Ouroboros.Network.PeerSelection.PeerSelectionActions
   ( withPeerSelectionActions

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
@@ -73,10 +73,8 @@ data PeerSelectionActionsArgs peeraddr peerconn exception m = PeerSelectionActio
   psUpdateOutboundConnectionsState
                               :: OutboundConnectionsState -> STM m (),
   -- ^ Callback which updates information about outbound connections state.
-  psReadInboundPeers          :: m (Map peeraddr PeerSharing),
+  psReadInboundPeers          :: m (Map peeraddr PeerSharing)
   -- ^ inbound duplex peers
-  psChurnMutex                :: StrictTMVar m ()
-  -- ^ this is used to coordinate the actions of peer selection and churn governor
   }
 
 -- | Record of remaining parameters for withPeerSelectionActions
@@ -122,8 +120,7 @@ withPeerSelectionActions
     psPeerConnToPeerSharing = peerConnToPeerSharing,
     psReadPeerSharingController = sharingController,
     psReadInboundPeers = readInboundPeers,
-    psUpdateOutboundConnectionsState = updateOutboundConnectionsState,
-    psChurnMutex }
+    psUpdateOutboundConnectionsState = updateOutboundConnectionsState }
   ledgerPeersArgs
   PeerSelectionActionsDiffusionMode { psPeerStateActions = peerStateActions }
   k = do
@@ -145,8 +142,7 @@ withPeerSelectionActions
                                        readUseBootstrapPeers = useBootstrapped,
                                        readInboundPeers,
                                        readLedgerStateJudgement = judgement,
-                                       updateOutboundConnectionsState,
-                                       churnMutex = psChurnMutex }
+                                       updateOutboundConnectionsState }
           withAsync
             (localRootPeersProvider
               localTracer


### PR DESCRIPTION
# Description

Since churn loop code was refactored such that there's only one call site to update the peer targets TVar, it was an easy fix to ensure that the right targets basis was used for the modification.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
