### PR TITLE
Fix inbound counters

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## next release
 
-- Fix `InboundGovernorCounters`
+### Breaking changes
 
+### Non-breaking changes
+
+- Fix `InboundGovernorCounters`
 ## 0.13.2.0 -- 2024-06-07
 
 ### Breaking changes

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## next release
 
+- Fix `InboundGovernorCounters`
+
 ## 0.13.2.0 -- 2024-06-07
 
 ### Breaking changes

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -163,14 +163,6 @@ withInboundGovernor trTracer tracer debugTracer inboundInfoChannel
       -> InboundGovernorState muxMode initiatorCtx peerAddr versionData m a b
       -> m Void
     inboundGovernorLoop var !state = do
-      mapTraceWithCache TrInboundGovernorCounters
-                        tracer
-                        (igsCountersCache state)
-                        (inboundGovernorCounters state)
-      traceWith tracer $ TrRemoteState $
-            mkRemoteSt . csRemoteState
-        <$> igsConnections state
-
       time <- getMonotonicTime
       inactivityVar <- registerDelay inactionTimeout
 
@@ -525,6 +517,14 @@ withInboundGovernor trTracer tracer debugTracer inboundInfoChannel
         case mbConnId of
           Just cid -> traceWith trTracer (mkRemoteTransitionTrace cid state state')
           Nothing  -> pure ()
+
+      mapTraceWithCache TrInboundGovernorCounters
+                        tracer
+                        (igsCountersCache state')
+                        (inboundGovernorCounters state')
+      traceWith tracer $ TrRemoteState $
+            mkRemoteSt . csRemoteState
+        <$> igsConnections state'
 
       -- Update Inbound Governor Counters cache values
       let newCounters       = inboundGovernorCounters state'


### PR DESCRIPTION
# Description

Makes it so that we log counter changes once before updating the cache.

This fixes a bug where cardano_node_metrics_inboundGovernor_cold,
cardano_node_metrics_inboundGovernor_hot, 
cardano_node_metrics_inboundGovernor_idle, and 
cardano_node_metrics_inboundGovernor_warm went missing


# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
