### PR TITLE
Account for trusted local root peers when churning

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Non-Breaking changes
 
+## 0.16.1.1 -- 2024-06-28
+
+### Breaking changes
+
+### Non-Breaking changes
+
 - Increase the target number of active peers during bulk sync to account for hot
   trusted localroot peers.
 

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Non-Breaking changes
 
+- Increase the target number of active peers during bulk sync to account for hot
+  trusted localroot peers.
+
 ## 0.16.1.0 -- 2024-06-07
 
 ### Breaking changes

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network
-version:                0.16.1.0
+version:                0.16.1.1
 synopsis:               A networking layer for the Ouroboros blockchain protocol
 description:            A networking layer for the Ouroboros blockchain protocol.
 license:                Apache-2.0

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -809,12 +809,7 @@ runM Interfaces
 
       localRootsVar <- newTVarIO mempty
 
-      peerSelectionTargetsVar <- newTVarIO $ daPeerSelectionTargets {
-          -- Start with a smaller number of active peers, the churn governor
-          -- will increase it to the configured value after a delay.
-          targetNumberOfActivePeers =
-            min 2 (targetNumberOfActivePeers daPeerSelectionTargets)
-        }
+      peerSelectionTargetsVar <- newTVarIO $ daPeerSelectionTargets
 
       countersVar <- newTVarIO emptyPeerSelectionCounters
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -807,6 +807,8 @@ runM Interfaces
 
       churnModeVar <- newTVarIO ChurnModeNormal
 
+      localRootsVar <- newTVarIO mempty
+
       peerSelectionTargetsVar <- newTVarIO $ daPeerSelectionTargets {
           -- Start with a smaller number of active peers, the churn governor
           -- will increase it to the configured value after a delay.
@@ -965,7 +967,7 @@ runM Interfaces
             -- (only if local root peers were non-empty).
             -> m c
           withPeerSelectionActions' readInboundPeers =
-              withPeerSelectionActions PeerActionsDNS {
+              withPeerSelectionActions localRootsVar PeerActionsDNS {
                                          paToPeerAddr = diNtnToPeerAddr,
                                          paDnsActions = diDnsActions lookupReqs,
                                          paDnsSemaphore = dnsSemaphore }
@@ -1032,6 +1034,7 @@ runM Interfaces
                                  peerSelectionTargetsVar
                                  (readTVar countersVar)
                                  daReadUseBootstrapPeers
+                                 ((LocalRootPeers.hotTarget . LocalRootPeers.clampToTrustable . LocalRootPeers.fromGroups) <$> (readTVar localRootsVar))
 
       --
       -- Two functions only used in InitiatorAndResponder mode

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerSelectionActions.hs
@@ -93,7 +93,8 @@ withPeerSelectionActions
      , Ord peeraddr
      , Exception exception
      )
-  => PeerActionsDNS peeraddr resolver exception m
+  => StrictTVar m (Config peeraddr)
+  -> PeerActionsDNS peeraddr resolver exception m
   -> PeerSelectionActionsArgs peeraddr peerconn exception m
   -> WithLedgerPeersArgs m
   -> PeerSelectionActionsDiffusionMode peeraddr peerconn m
@@ -104,6 +105,7 @@ withPeerSelectionActions
   -- (only if local root peers were non-empty).
   -> m a
 withPeerSelectionActions
+  localRootsVar
   paDNS@PeerActionsDNS { paToPeerAddr = toPeerAddr, paDnsActions = dnsActions, paDnsSemaphore = dnsSemaphore }
   PeerSelectionActionsArgs {
     psLocalRootPeersTracer = localTracer,
@@ -121,8 +123,6 @@ withPeerSelectionActions
   ledgerPeersArgs
   PeerSelectionActionsDiffusionMode { psPeerStateActions = peerStateActions }
   k = do
-    localRootsVar <- newTVarIO mempty
-
     withLedgerPeers
       paDNS
       ledgerPeersArgs


### PR DESCRIPTION
# Description

During ChurnModeBulkSync the churn governor limited the number of active peers to 2 due to the heavy cost of running chainsync when far behind the tip. When consensus started to pick churn mode based on `OutboundConnectionsState` if bootstrap peers was enabled the 2 connection limit wont do. Nodes configured with 2 or more trusted localroot peers would never connect to a bootstrap peer. This cause the outbound governor to report `UntrustedState` to consensus which causes consensus to signal ChurnModeBulkSync even when we are on tip.
    
This change increases the target number of active peers to 1 + the configured number of hot trusted localroot peers during bulk sync.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
