### PR TITLE
TxSubmission, part 1: code refactoring

### DIFF
--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -67,6 +67,7 @@ library
                        nothunks,
                        serialise         >=0.2   && <0.3,
                        text              >=1.2 && <2.2,
+                       quiet,
 
                        cardano-slotting,
                        cardano-strict-containers,

--- a/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
@@ -7,12 +8,15 @@ module Ouroboros.Network.SizeInBytes (SizeInBytes (..)) where
 import Control.DeepSeq (NFData (..))
 import Data.Monoid (Sum (..))
 import Data.Word (Word32)
+import GHC.Generics
 
 import Data.Measure qualified as Measure
 import NoThunks.Class (NoThunks (..))
+import Quiet (Quiet (..))
 
 newtype SizeInBytes = SizeInBytes { getSizeInBytes :: Word32 }
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord)
+  deriving Show      via Quiet SizeInBytes
   deriving Enum      via Word32
   deriving Num       via Word32
   deriving Real      via Word32
@@ -20,6 +24,7 @@ newtype SizeInBytes = SizeInBytes { getSizeInBytes :: Word32 }
   deriving NoThunks  via Word32
   deriving Semigroup via Sum Word32
   deriving Monoid    via Sum Word32
+  deriving Generic
   deriving newtype NFData
   deriving Measure.Measure        via Word32
   deriving Measure.BoundedMeasure via Word32

--- a/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/SizeInBytes.hs
@@ -5,6 +5,7 @@
 module Ouroboros.Network.SizeInBytes (SizeInBytes (..)) where
 
 import Control.DeepSeq (NFData (..))
+import Data.Monoid (Sum (..))
 import Data.Word (Word32)
 
 import Data.Measure qualified as Measure
@@ -12,11 +13,13 @@ import NoThunks.Class (NoThunks (..))
 
 newtype SizeInBytes = SizeInBytes { getSizeInBytes :: Word32 }
   deriving (Show, Eq, Ord)
-  deriving Enum     via Word32
-  deriving Num      via Word32
-  deriving Real     via Word32
-  deriving Integral via Word32
-  deriving NoThunks via Word32
+  deriving Enum      via Word32
+  deriving Num       via Word32
+  deriving Real      via Word32
+  deriving Integral  via Word32
+  deriving NoThunks  via Word32
+  deriving Semigroup via Sum Word32
+  deriving Monoid    via Sum Word32
   deriving newtype NFData
   deriving Measure.Measure        via Word32
   deriving Measure.BoundedMeasure via Word32

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -91,6 +91,7 @@ library
                      , si-timers
                      , strict-stm
 
+                     , nothunks       ^>=0.2
                      , psqueues
                      -- ^ only to derive nothunk instances
 

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -25,6 +25,8 @@
 * Refactored CBOR mini-protocols codecs to a more modular structure
 * Added `deepseq` dependency and implemented `NFData` for `testlib` types.
 * Added miniprotocols codec benchmarks
+* Use `SizeInBytes` newtype instead of the `TxSizeInBytes` type aliase.
+  `TxSizeInBytes` is now deprecated.
 
 ## 0.8.0.0 -- 2024-02-21
 

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -98,8 +98,10 @@ library
                        bytestring        >=0.10 && <0.13,
                        cborg             >=0.2.1 && <0.3,
                        deepseq,
+                       quiet,
 
                        io-classes       ^>=1.5.0,
+                       nothunks,
                        si-timers,
 
                        ouroboros-network-api

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Client.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Client.hs
@@ -27,8 +27,6 @@ module Ouroboros.Network.Protocol.TxSubmission2.Client
   , txSubmissionClientPeer
   ) where
 
-import Data.Word (Word16)
-
 import Network.TypedProtocol.Core
 
 import Ouroboros.Network.Protocol.TxSubmission2.Type
@@ -56,8 +54,8 @@ data ClientStIdle txid tx m a = ClientStIdle {
 
     recvMsgRequestTxIds      :: forall blocking.
                                 TokBlockingStyle blocking
-                             -> Word16
-                             -> Word16
+                             -> NumTxIdsToAck
+                             -> NumTxIdsToReq
                              -> m (ClientStTxIds blocking txid tx m a),
 
     recvMsgRequestTxs        :: [txid]

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Client.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Client.hs
@@ -65,7 +65,7 @@ data ClientStIdle txid tx m a = ClientStIdle {
   }
 
 data ClientStTxIds blocking txid tx m a where
-  SendMsgReplyTxIds :: BlockingReplyList blocking (txid, TxSizeInBytes)
+  SendMsgReplyTxIds :: BlockingReplyList blocking (txid, SizeInBytes)
                     -> ClientStIdle           txid tx m a
                     -> ClientStTxIds blocking txid tx m a
 

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
@@ -102,7 +102,10 @@ encodeTxSubmission2 encodeTxId encodeTx = encode
     encode (ClientAgency TokInit)  MsgInit =
         CBOR.encodeListLen 1
      <> CBOR.encodeWord 6
-    encode (ServerAgency TokIdle) (MsgRequestTxIds blocking ackNo reqNo) =
+    encode (ServerAgency TokIdle) (MsgRequestTxIds
+                                     blocking
+                                     (NumTxIdsToAck ackNo)
+                                     (NumTxIdsToReq reqNo)) =
         CBOR.encodeListLen 4
      <> CBOR.encodeWord 0
      <> CBOR.encodeBool (case blocking of
@@ -167,8 +170,8 @@ decodeTxSubmission2 decodeTxId decodeTx = decode
           return (SomeMessage MsgInit)
         (ServerAgency TokIdle,       4, 0) -> do
           blocking <- CBOR.decodeBool
-          ackNo    <- CBOR.decodeWord16
-          reqNo    <- CBOR.decodeWord16
+          ackNo    <- NumTxIdsToAck <$> CBOR.decodeWord16
+          reqNo    <- NumTxIdsToReq <$> CBOR.decodeWord16
           return $!
             if blocking
             then SomeMessage (MsgRequestTxIds TokBlocking    ackNo reqNo)

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Server.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Server.hs
@@ -24,7 +24,6 @@ module Ouroboros.Network.Protocol.TxSubmission2.Server
   ) where
 
 import Data.List.NonEmpty (NonEmpty)
-import Data.Word (Word16)
 
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Pipelined
@@ -45,7 +44,7 @@ data TxSubmissionServerPipelined txid tx m a where
 data Collect txid tx =
        -- | The result of 'SendMsgRequestTxIdsPipelined'. It also carries
        -- the number of txids originally requested.
-       CollectTxIds Word16 [(txid, SizeInBytes)]
+       CollectTxIds NumTxIdsToReq [(txid, SizeInBytes)]
 
        -- | The result of 'SendMsgRequestTxsPipelined'. The actual reply only
        -- contains the transactions sent, but this pairs them up with the
@@ -59,8 +58,8 @@ data ServerStIdle (n :: N) txid tx m a where
   -- |
   --
   SendMsgRequestTxIdsBlocking
-    :: Word16                               -- ^ number of txids to acknowledge
-    -> Word16                               -- ^ number of txids to request
+    :: NumTxIdsToAck                        -- ^ number of txids to acknowledge
+    -> NumTxIdsToReq                        -- ^ number of txids to request
     -> m a                                  -- ^ Result if done
     -> (NonEmpty (txid, SizeInBytes)
         -> m (ServerStIdle Z txid tx m a))
@@ -69,8 +68,8 @@ data ServerStIdle (n :: N) txid tx m a where
   -- |
   --
   SendMsgRequestTxIdsPipelined
-    :: Word16
-    -> Word16
+    :: NumTxIdsToAck
+    -> NumTxIdsToReq
     -> m (ServerStIdle (S n) txid tx m a)
     -> ServerStIdle       n  txid tx m a
 

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Server.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Server.hs
@@ -17,9 +17,10 @@ module Ouroboros.Network.Protocol.TxSubmission2.Server
     TxSubmissionServerPipelined (..)
   , ServerStIdle (..)
   , Collect (..)
-  , TxSizeInBytes
     -- * Execution as a typed protocol
   , txSubmissionServerPeerPipelined
+    -- * deprecated API
+  , TxSizeInBytes
   ) where
 
 import Data.List.NonEmpty (NonEmpty)
@@ -44,7 +45,7 @@ data TxSubmissionServerPipelined txid tx m a where
 data Collect txid tx =
        -- | The result of 'SendMsgRequestTxIdsPipelined'. It also carries
        -- the number of txids originally requested.
-       CollectTxIds Word16 [(txid, TxSizeInBytes)]
+       CollectTxIds Word16 [(txid, SizeInBytes)]
 
        -- | The result of 'SendMsgRequestTxsPipelined'. The actual reply only
        -- contains the transactions sent, but this pairs them up with the
@@ -61,7 +62,7 @@ data ServerStIdle (n :: N) txid tx m a where
     :: Word16                               -- ^ number of txids to acknowledge
     -> Word16                               -- ^ number of txids to request
     -> m a                                  -- ^ Result if done
-    -> (NonEmpty (txid, TxSizeInBytes)
+    -> (NonEmpty (txid, SizeInBytes)
         -> m (ServerStIdle Z txid tx m a))
     -> ServerStIdle        Z txid tx m a
 

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Type.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Type.hs
@@ -11,20 +11,35 @@
 --
 -- This is used to relay transactions between nodes.
 --
-module Ouroboros.Network.Protocol.TxSubmission2.Type where
+module Ouroboros.Network.Protocol.TxSubmission2.Type
+  ( TxSubmission2 (..)
+  , Message (..)
+  , ClientHasAgency (..)
+  , ServerHasAgency (..)
+  , NobodyHasAgency (..)
+  , TokBlockingStyle (..)
+  , StBlockingStyle (..)
+  , BlockingReplyList (..)
+    -- re-exports
+  , SizeInBytes (..)
+    -- deprecated API
+  , TxSizeInBytes
+  ) where
 
+import Control.DeepSeq
 import Data.List.NonEmpty (NonEmpty)
-import Data.Word (Word16, Word32)
+import Data.Word (Word16)
 
 import Network.TypedProtocol.Core
 
-import Control.DeepSeq
+import Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 import Ouroboros.Network.Util.ShowProxy
 
 -- | Transactions are typically not big, but in principle in future we could
 -- have ones over 64k large.
 --
-type TxSizeInBytes = Word32
+type TxSizeInBytes = SizeInBytes
+{-# DEPRECATED TxSizeInBytes "Use 'Ouroboros.Network.SizeInBytes.SizeInBytes' instead" #-}
 
 -- | The kind of the transaction-submission protocol, and the types of the
 -- states in the protocol state machine.

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Examples.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Examples.hs
@@ -30,6 +30,7 @@ import Network.TypedProtocol.Pipelined (N, Nat (..))
 
 import Ouroboros.Network.Protocol.TxSubmission2.Client
 import Ouroboros.Network.Protocol.TxSubmission2.Server
+import Ouroboros.Network.SizeInBytes (SizeInBytes)
 
 
 --
@@ -57,7 +58,7 @@ txSubmissionClient
      (Ord txid, Show txid, Monad m)
   => Tracer m (TraceEventClient txid tx)
   -> (tx -> txid)
-  -> (tx -> TxSizeInBytes)
+  -> (tx -> SizeInBytes)
   -> Word16  -- ^ Maximum number of unacknowledged txids allowed
   -> [tx]
   -> TxSubmissionClient txid tx m ()
@@ -182,7 +183,7 @@ data ServerState txid tx = ServerState {
        -- requested. This is not ordered to illustrate the fact that we can
        -- request txs out of order. We also remember the sizes, though this
        -- example does not make use of the size information.
-       availableTxids         :: Map txid TxSizeInBytes,
+       availableTxids         :: Map txid SizeInBytes,
 
        -- | Transactions we have successfully downloaded but have not yet added
        -- to the mempool or acknowledged. This is needed because we request

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
@@ -17,6 +17,7 @@ module Ouroboros.Network.Protocol.TxSubmission2.Test
   , TxId (..)
   ) where
 
+import Data.Bifunctor (second)
 import Data.ByteString.Lazy (ByteString)
 import Data.List (nub)
 import Data.List.NonEmpty qualified as NonEmpty
@@ -255,11 +256,12 @@ instance Arbitrary (AnyMessageAndAgency (TxSubmission2 TxId Tx)) where
 
     , AnyMessageAndAgency (ClientAgency (TokTxIds TokBlocking)) <$>
         MsgReplyTxIds <$> (BlockingReply . NonEmpty.fromList
+                                         . map (second SizeInBytes)
                                          . QC.getNonEmpty
                                        <$> arbitrary)
 
     , AnyMessageAndAgency (ClientAgency (TokTxIds TokNonBlocking)) <$>
-        MsgReplyTxIds <$> (NonBlockingReply <$> arbitrary)
+        MsgReplyTxIds <$> (NonBlockingReply . map (second SizeInBytes) <$> arbitrary)
 
     , AnyMessageAndAgency (ServerAgency TokIdle) <$>
         MsgRequestTxs <$> arbitrary

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds                  #-}
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GADTs                      #-}
@@ -7,6 +8,7 @@
 {-# LANGUAGE PolyKinds                  #-}
 {-# LANGUAGE QuantifiedConstraints      #-}
 {-# LANGUAGE RankNTypes                 #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TypeFamilies               #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
@@ -239,6 +241,10 @@ prop_channel_IO params =
 prop_pipe_IO :: TxSubmissionTestParams -> Property
 prop_pipe_IO params =
     ioProperty (prop_channel createPipeConnectedChannels params)
+
+
+deriving newtype instance Arbitrary NumTxIdsToAck
+deriving newtype instance Arbitrary NumTxIdsToReq
 
 
 instance Arbitrary (AnyMessageAndAgency (TxSubmission2 TxId Tx)) where

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -28,6 +28,7 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
+                       Control.Concurrent.Class.MonadSTM.Strict.TMergeVar
                        Ouroboros.Network.BlockFetch
                        Ouroboros.Network.BlockFetch.Client
                        Ouroboros.Network.BlockFetch.ClientRegistry

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -6,7 +6,10 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Test.Ouroboros.Network.BlockFetch (tests) where
+module Test.Ouroboros.Network.BlockFetch
+  ( PeerGSVT (..)
+  , tests
+  ) where
 
 import Test.ChainGenerators (TestChainFork (..))
 import Test.QuickCheck
@@ -798,6 +801,8 @@ prop_terminate (TestChainFork _commonChain forkChain _forkChain) (Positive (Smal
 
     fork'  = chainToAnchoredFragment forkChain
 
+-- TODO: moved to some shared place (cannot be moved to
+-- `ouroboros-network-testing` which doesn't depend on `ouroboros-network`)
 newtype PeerGSVT = PeerGSVT {
       unPeerGSVT :: PeerGSV
     } deriving Show

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -119,7 +119,7 @@ newMempool = fmap Mempool
            . Seq.fromList
 
 readMempool :: MonadSTM m => Mempool m txid -> m [Tx txid]
-readMempool (Mempool mempool) = toList <$> atomically (readTVar mempool)
+readMempool (Mempool mempool) = toList <$> readTVarIO mempool
 
 
 getMempoolReader :: forall txid m.
@@ -236,7 +236,7 @@ txSubmissionSimulation maxUnacked outboundTxs
                 txSubmissionCodec2
                 (byteLimitsTxSubmission2 (fromIntegral . BSL.length))
                 timeLimitsTxSubmission2
-                (fromMaybe id (delayChannel <$> outboundDelay) outboundChannel)
+                (maybe id delayChannel outboundDelay outboundChannel)
                 (txSubmissionClientPeer (outboundPeer outboundMempool))
 
     inboundAsync <-
@@ -245,7 +245,7 @@ txSubmissionSimulation maxUnacked outboundTxs
                 txSubmissionCodec2
                 (byteLimitsTxSubmission2 (fromIntegral . BSL.length))
                 timeLimitsTxSubmission2
-                (fromMaybe id (delayChannel <$> inboundDelay) inboundChannel)
+                (maybe id delayChannel inboundDelay inboundChannel)
                 (txSubmissionServerPeerPipelined (inboundPeer inboundMempool))
 
     _ <- waitAnyCancel [ outboundAsync, inboundAsync ]

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -88,10 +88,20 @@ instance ShowProxy txid => ShowProxy (Tx txid) where
 instance Arbitrary txid => Arbitrary (Tx txid) where
     arbitrary =
       Tx <$> arbitrary
-         <*> (SizeInBytes <$> arbitrary)
+         <*> chooseEnum (0, maxTxSize)
+             -- note:
+             -- generating small tx sizes avoids overflow error when semigroup
+             -- instance of `SizeInBytes` is used (summing up all inflight tx
+             -- sizes).
          <*> frequency [ (3, pure True)
                        , (1, pure False)
                        ]
+
+
+-- maximal tx size
+maxTxSize :: SizeInBytes
+maxTxSize = 65536
+
 
 newtype Mempool m txid = Mempool (TVar m (Seq (Tx txid)))
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -217,7 +217,7 @@ txSubmissionSimulation
 
      , txid ~ Int
      )
-  => Word16
+  => NumTxIdsToAck
   -> [Tx txid]
   -> ControlMessageSTM m
   -> Maybe DiffTime
@@ -299,7 +299,7 @@ prop_txSubmission (Positive maxUnacked) (NonEmpty outboundTxs) delay =
                     * realToFrac (length outboundTxs `div` 4))
                 atomically (writeTVar controlMessageVar Terminate)
             txSubmissionSimulation
-              maxUnacked outboundTxs
+              (NumTxIdsToAck maxUnacked) outboundTxs
               (readTVar controlMessageVar)
               mbDelayTime mbDelayTime
             ) in

--- a/ouroboros-network/src/Control/Concurrent/Class/MonadSTM/Strict/TMergeVar.hs
+++ b/ouroboros-network/src/Control/Concurrent/Class/MonadSTM/Strict/TMergeVar.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE BangPatterns #-}
+
+-- | STM TMergeVar mini-abstraction
+--
+module Control.Concurrent.Class.MonadSTM.Strict.TMergeVar
+  ( TMergeVar
+  , newTMergeVar
+  , writeTMergeVar
+  , takeTMergeVar
+  , tryReadTMergeVar
+  ) where
+
+import Control.Concurrent.Class.MonadSTM.Strict
+
+-- | The 'TMergeVar' is like a 'TMVar' in that we take it, leaving it empty.
+-- Unlike an ordinary 'TMVar' with a blocking \'put\' operation, it has a
+-- non-blocking combining write operation: if a value is already present then
+-- the values are combined using the 'Semigroup' operator.
+--
+-- This is used much like a 'TMVar' as a one-place queue between threads but
+-- with the property that we can \"improve\" the current value (if any).
+--
+newtype TMergeVar m a = TMergeVar (StrictTMVar m a)
+
+newTMergeVar :: MonadSTM m => STM m (TMergeVar m a)
+newTMergeVar = TMergeVar <$> newEmptyTMVar
+
+-- | Merge the current value with the given one and store it, return the updated
+-- value.
+--
+writeTMergeVar :: (MonadSTM m, Semigroup a) => TMergeVar m a -> a -> STM m a
+writeTMergeVar (TMergeVar v) x = do
+    mx0 <- tryTakeTMVar v
+    case mx0 of
+      Nothing -> x  <$ putTMVar v x
+      Just x0 -> x' <$ putTMVar v x' where !x' = x0 <> x
+
+takeTMergeVar :: MonadSTM m => TMergeVar m a -> STM m a
+takeTMergeVar (TMergeVar v) = takeTMVar v
+
+tryReadTMergeVar :: MonadSTM m
+                 => TMergeVar m a
+                 -> STM m (Maybe a)
+tryReadTMergeVar (TMergeVar v) = tryReadTMVar v

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -41,6 +41,7 @@ import Data.Set (Set)
 import Data.Set qualified as Set
 
 import Control.Concurrent.Class.MonadSTM.Strict
+import Control.Concurrent.Class.MonadSTM.Strict.TMergeVar
 import Control.Exception (assert)
 import Control.Monad (when)
 import Control.Monad.Class.MonadTime.SI
@@ -750,38 +751,3 @@ takeTFetchRequestVar :: MonadSTM m
                                PeerFetchInFlightLimits)
 takeTFetchRequestVar v = (\(r,g,l) -> (r, getLast g, getLast l))
                      <$> takeTMergeVar v
-
---
--- STM TMergeVar mini-abstraction
---
-
--- | The 'TMergeVar' is like a 'TMVar' in that we take it, leaving it empty.
--- Unlike an ordinary 'TMVar' with a blocking \'put\' operation, it has a
--- non-blocking combining write operation: if a value is already present then
--- the values are combined using the 'Semigroup' operator.
---
--- This is used much like a 'TMVar' as a one-place queue between threads but
--- with the property that we can \"improve\" the current value (if any).
---
-newtype TMergeVar m a = TMergeVar (StrictTMVar m a)
-
-newTMergeVar :: MonadSTM m => STM m (TMergeVar m a)
-newTMergeVar = TMergeVar <$> newEmptyTMVar
-
--- | Merge the current value with the given one and store it, return the updated
--- value.
---
-writeTMergeVar :: (MonadSTM m, Semigroup a) => TMergeVar m a -> a -> STM m a
-writeTMergeVar (TMergeVar v) x = do
-    mx0 <- tryTakeTMVar v
-    case mx0 of
-      Nothing -> x  <$ putTMVar v x
-      Just x0 -> x' <$ putTMVar v x' where !x' = x0 <> x
-
-takeTMergeVar :: MonadSTM m => TMergeVar m a -> STM m a
-takeTMergeVar (TMergeVar v) = takeTMVar v
-
-tryReadTMergeVar :: MonadSTM m
-                 => TMergeVar m a
-                 -> STM m (Maybe a)
-tryReadTMergeVar (TMergeVar v) = tryReadTMVar v

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -40,6 +40,7 @@ import Network.TypedProtocol.Pipelined (N, Nat (..), natToInt)
 
 import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.TxSubmission2.Server
+import Ouroboros.Network.SizeInBytes (SizeInBytes)
 import Ouroboros.Network.TxSubmission.Mempool.Reader (MempoolSnapshot (..),
            TxSubmissionMempoolReader (..))
 
@@ -118,7 +119,7 @@ data ServerState txid tx = ServerState {
        -- are a subset of the 'unacknowledgedTxIds' that we have not yet
        -- requested. This is not ordered to illustrate the fact that we can
        -- request txs out of order. We also remember the size.
-       availableTxids         :: !(Map txid TxSizeInBytes),
+       availableTxids         :: !(Map txid SizeInBytes),
 
        -- | Transactions we have successfully downloaded but have not yet added
        -- to the mempool or acknowledged. This needed because we can request
@@ -187,7 +188,7 @@ txSubmissionInbound tracer maxUnacked mpReader mpWriter _version =
       continueWithStateM (serverIdle Zero) initialServerState
   where
     -- TODO #1656: replace these fixed limits by policies based on
-    -- TxSizeInBytes and delta-Q and the bandwidth/delay product.
+    -- SizeInBytes and delta-Q and the bandwidth/delay product.
     -- These numbers are for demo purposes only, the throughput will be low.
     maxTxIdsToRequest = 3 :: Word16
     maxTxToRequest    = 2 :: Word16
@@ -378,7 +379,7 @@ txSubmissionInbound tracer maxUnacked mpReader mpWriter _version =
     --
     acknowledgeTxIds :: ServerState txid tx
                      -> StrictSeq txid
-                     -> Map txid TxSizeInBytes
+                     -> Map txid SizeInBytes
                      -> MempoolSnapshot txid tx idx
                      -> ServerState txid tx
     acknowledgeTxIds st txidsSeq _ _ | Seq.null txidsSeq  = st

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Inbound.hs
@@ -343,12 +343,13 @@ txSubmissionInbound tracer maxUnacked mpReader mpWriter _version =
             bufferedTxs2 = Foldable.foldl' (flip Map.delete)
                                    bufferedTxs1 acknowledgedTxIds
 
-            -- If we are acknowleding transactions that are still in unacknowledgedTxIds'
-            -- we need to re-add them so that we also can acknowledge them again later.
-            -- This will happen incase of duplicate txids within the same window.
+            -- If we are acknowledging transactions that are still in
+            -- unacknowledgedTxIds' we need to re-add them so that we also can
+            -- acknowledge them again later. This will happen in case of
+            -- duplicate txids within the same window.
             live = filter (`elem` unacknowledgedTxIds') $ toList acknowledgedTxIds
             bufferedTxs3 = forceElemsToWHNF $ bufferedTxs2 <>
-                               (Map.fromList (zip live (repeat Nothing)))
+                               Map.fromList (zip live (repeat Nothing))
 
         let !collected = length txs
         traceWith tracer $
@@ -447,7 +448,7 @@ txSubmissionInbound tracer maxUnacked mpReader mpWriter _version =
         -- We will also uses the size of txs in bytes as our limit for
         -- upper and lower watermarks for pipelining. We'll also use the
         -- amount in flight and delta-Q to estimate when we're in danger of
-        -- becomming idle, and need to request stalled txs.
+        -- becoming idle, and need to request stalled txs.
         --
         let (txsToRequest, availableTxids') =
               Map.splitAt (fromIntegral maxTxToRequest) (availableTxids st)

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Mempool/Reader.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Mempool/Reader.hs
@@ -6,8 +6,7 @@ module Ouroboros.Network.TxSubmission.Mempool.Reader
   ) where
 
 import Control.Monad.Class.MonadSTM (MonadSTM, STM)
-
-import Ouroboros.Network.Protocol.TxSubmission2.Client (TxSizeInBytes)
+import Ouroboros.Network.SizeInBytes (SizeInBytes)
 
 -- | The consensus layer functionality that the inbound and outbound side of
 -- the tx submission logic requires.
@@ -53,7 +52,7 @@ mapTxSubmissionMempoolReader f rdr =
 --
 data MempoolSnapshot txid tx idx =
      MempoolSnapshot {
-       mempoolTxIdsAfter :: idx -> [(txid, idx, TxSizeInBytes)],
+       mempoolTxIdsAfter :: idx -> [(txid, idx, SizeInBytes)],
        mempoolLookupTx   :: idx -> Maybe tx,
        mempoolHasTx      :: txid -> Bool
      }

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -27,6 +27,7 @@ import Ouroboros.Network.ControlMessage (ControlMessage, ControlMessageSTM,
            timeoutWithControlMessage)
 import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.TxSubmission2.Client
+import Ouroboros.Network.SizeInBytes (SizeInBytes)
 import Ouroboros.Network.TxSubmission.Mempool.Reader (MempoolSnapshot (..),
            TxSubmissionMempoolReader (..))
 
@@ -119,7 +120,7 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} _version co
                       !lastIdx'
                         | null txs  = lastIdx
                         | otherwise = idx where (_, idx, _) = last txs
-                      txs'         :: [(txid, TxSizeInBytes)]
+                      txs'         :: [(txid, SizeInBytes)]
                       txs'          = [ (txid, size) | (txid, _, size) <- txs ]
                       client'       = client unackedSeq'' lastIdx'
                   in  (txs', client')

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -12,7 +12,7 @@ module Ouroboros.Network.TxSubmission.Outbound
 
 import Data.Foldable (find)
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.Maybe (catMaybes, isNothing)
+import Data.Maybe (catMaybes, isNothing, mapMaybe)
 import Data.Sequence.Strict (StrictSeq)
 import Data.Sequence.Strict qualified as Seq
 import Data.Word (Word16)
@@ -184,7 +184,7 @@ txSubmissionOutbound tracer maxUnacked TxSubmissionMempoolReader{..} _version co
           -- The 'mempoolLookupTx' will return nothing if the transaction is no
           -- longer in the mempool. This is good. Neither the sending nor
           -- receiving side wants to forward txs that are no longer of interest.
-          let txs          = catMaybes (map mempoolLookupTx txidxs')
+          let txs          = mapMaybe mempoolLookupTx txidxs'
               client'      = client unackedSeq lastIdx
 
           -- Trace the transactions to be sent in the response.

--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -2,13 +2,70 @@
 
 set -euo pipefail
 
+function usage {
+  echo "Usage $(basename "$0") [-ch]"
+  echo "Check files with 'stylish-haskell'; by default check all files."
+  echo
+  echo "        -u                        only check files uncommitted"
+  echo "        -c                        only check files committed in HEAD"
+  echo "        -h                        this help message"
+  exit
+}
+
 export LC_ALL=C.UTF-8
+
+STYLISH_HASKELL_ARGS="-c .stylish-haskell-network.yaml -i"
+
+optstring=":uch"
+while getopts ${optstring} arg; do
+  case ${arg} in
+    h)
+      usage;
+      exit 0
+      ;;
+    c)
+      PATHS=$(git show --pretty='' --name-only HEAD)
+      for path in $PATHS; do
+        if [ "${path##*.}" == "hs" ]; then
+          if grep -qE '^#' $path; then
+            echo "$path contains CPP.  Skipping."
+          else
+            echo $path
+            stylish-haskell $STYLISH_HASKELL_ARGS $path
+          fi
+        fi
+      done
+      exit 0
+      ;;
+    u)
+      PATHS=$(git diff --name-only HEAD)
+      for path in $PATHS; do
+        if [ "${path##*.}" == "hs" ]; then
+          if grep -qE '^#' $path; then
+            echo "$path contains CPP.  Skipping."
+          else
+            echo $path
+            stylish-haskell $STYLISH_HASKELL_ARGS $path
+          fi
+        fi
+      done
+      exit 0
+      ;;
+    ?)
+      echo "Invalid argument ${arg}"
+      exit 1
+      ;;
+  esac
+done
+
 # TODO CPP pragmas in export lists are not supported by stylish-haskell
-fd . './quickcheck-monoids' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './network-mux' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './ouroboros-network-api' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './ouroboros-network-framework' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './ouroboros-network-mock' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './ouroboros-network-protocols' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './ouroboros-network' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
-fd . './cardano-client' -e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell -c .stylish-haskell-network.yaml -i
+FD_OPTS="-e hs --ignore-file ./scripts/ci/check-stylish-ignore -X stylish-haskell $STYLISH_HASKELL_ARGS"
+
+fd . './quickcheck-monoids'          $FD_OPTS
+fd . './network-mux'                 $FD_OPTS
+fd . './ouroboros-network-api'       $FD_OPTS
+fd . './ouroboros-network-framework' $FD_OPTS
+fd . './ouroboros-network-mock'      $FD_OPTS
+fd . './ouroboros-network-protocols' $FD_OPTS
+fd . './ouroboros-network'           $FD_OPTS
+fd . './cardano-client'              $FD_OPTS


### PR DESCRIPTION
# Description

This PR is preparation work for #3311. It includes code refactoring, fixes some warnings, and adds newtype wrappers. 

- **nothunks: updated to `^>=0.2`**
- **ouroboros-network-api: added monoid instance for SizeInBytes**
- **ouroboros-network-api: SizeInBytes Show instance**
- **block-fetch: moved TMergeVar to its own module**
- **block-fetch-tests: export PeerGSVT**
- **tx-submission: use SizeInBytes**
- **tx-submission: Tx arbitrary generator**
- **tx-submission: code style**
- **tx-submission: fixed warnings**
- **tx-submission: newtype wrappers NumTxIdsTo{Ack,Req}**

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated; see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
