### PR TITLE
Fix for CI failure

### DIFF
--- a/quickcheck-monoids/CHANGELOG.md
+++ b/quickcheck-monoids/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next version
 
 * Make it build with ghc-9.10
+  * fix base upper bound
 
 ## 0.1.0.0 -- 2024-06-07
 

--- a/quickcheck-monoids/quickcheck-monoids.cabal
+++ b/quickcheck-monoids/quickcheck-monoids.cabal
@@ -20,7 +20,7 @@ common warnings
 library
     import:           warnings
     exposed-modules:  Test.QuickCheck.Monoids
-    build-depends:    base,
+    build-depends:    base < 4.21,
                       QuickCheck
     hs-source-dirs:   src
     default-language: Haskell2010


### PR DESCRIPTION
# Description

Fixes regression where upper bound on base was removed for building with ghc-9.10 (cf. make it build with ghc-9.10)

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
