### PR TITLE
BulkSync BlockFetch implementation for Genesis

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -1,22 +1,34 @@
-{-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE RankNTypes    #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveFunctor  #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE LambdaCase     #-}
+{-# LANGUAGE RankNTypes     #-}
 
 module Ouroboros.Network.BlockFetch.ConsensusInterface
   ( FetchMode (..)
+  , GenesisFetchMode (..)
   , BlockFetchConsensusInterface (..)
   , FromConsensus (..)
+  , ChainSelStarvation (..)
+  , mkReadFetchMode
   ) where
 
 import Control.Monad.Class.MonadSTM
 import Control.Monad.Class.MonadTime (UTCTime)
+import Control.Monad.Class.MonadTime.SI (Time)
+import Data.Functor ((<&>))
 
 import Data.Map.Strict (Map)
+import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
+import NoThunks.Class (NoThunks)
 
 import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import Ouroboros.Network.Block
+import Ouroboros.Network.ConsensusMode (ConsensusMode (..))
+import Ouroboros.Network.PeerSelection.LedgerPeers.Type
+           (LedgerStateJudgement (..))
 import Ouroboros.Network.SizeInBytes (SizeInBytes)
-
 
 data FetchMode =
        -- | Use this mode when we are catching up on the chain but are stil
@@ -41,6 +53,26 @@ data FetchMode =
 
   deriving (Eq, Show)
 
+-- | The fetch mode that the block fetch logic should use.
+data GenesisFetchMode = FetchModeGenesis | PraosFetchMode FetchMode
+  deriving (Eq, Show)
+
+-- | Construct 'readFetchMode' for 'BlockFetchConsensusInterface' by branching
+-- on the 'ConsensusMode'.
+mkReadFetchMode
+  :: Functor m
+  => ConsensusMode
+  -> m LedgerStateJudgement
+     -- ^ Used for 'GenesisMode'.
+  -> m FetchMode
+     -- ^ Used for 'PraosMode' for backwards compatibility.
+  -> m GenesisFetchMode
+mkReadFetchMode consensusMode getLedgerStateJudgement getFetchMode =
+    case consensusMode of
+      GenesisMode -> getLedgerStateJudgement <&> \case
+        YoungEnough -> PraosFetchMode FetchModeDeadline
+        TooOld      -> FetchModeGenesis
+      PraosMode   -> PraosFetchMode <$> getFetchMode
 
 -- | The consensus layer functionality that the block fetch logic requires.
 --
@@ -72,11 +104,14 @@ data BlockFetchConsensusInterface peer header block m =
        -- 'FetchModeDeadline' it follows a policy optimises for the latency
        -- to fetch blocks, at the expense of wasting bandwidth.
        --
+       -- 'FetchModeGenesis' should be used when the genesis node is syncing to
+       -- ensure it isn't leashed.
+       --
        -- This mode should be set so that when the node's current chain is near
        -- to \"now\" it uses the deadline mode, and when it is far away it uses
        -- the bulk sync mode.
        --
-       readFetchMode          :: STM m FetchMode,
+       readFetchMode          :: STM m GenesisFetchMode,
 
        -- | Recent, only within last K
        readFetchedBlocks      :: STM m (Point block -> Bool),
@@ -147,8 +182,29 @@ data BlockFetchConsensusInterface peer header block m =
        -- PRECONDITION: Same as 'headerForgeUTCTime'.
        --
        -- WARNING: Same as 'headerForgeUTCTime'.
-       blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime
+       blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime,
+
+       -- | Information on the ChainSel starvation status; whether it is ongoing
+       -- or has ended recently. Needed by the bulk sync decision logic.
+       readChainSelStarvation :: STM m ChainSelStarvation,
+
+       -- | Action to inform CSJ (ChainSync Jumping) that the given peer has not
+       -- been performing adequately with respect to BlockFetch, and that it
+       -- should be demoted from the dynamo role. Can be set to @const (pure
+       -- ())@ in all other scenarios.
+       demoteChainSyncJumpingDynamo :: peer -> m ()
      }
+
+
+-- | Whether ChainSel is starved or has been recently.
+--
+-- The bulk sync fetch decision logic needs to decide whether the current
+-- focused peer has starved ChainSel recently. This datatype is used to
+-- represent this piece of information.
+data ChainSelStarvation
+  = ChainSelStarvationOngoing
+  | ChainSelStarvationEndedAt Time
+  deriving (Eq, Show, NoThunks, Generic)
 
 {-------------------------------------------------------------------------------
   Syntactic indicator of key precondition about Consensus time conversions

--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -5,8 +5,8 @@
 {-# LANGUAGE RankNTypes     #-}
 
 module Ouroboros.Network.BlockFetch.ConsensusInterface
-  ( FetchMode (..)
-  , GenesisFetchMode (..)
+  ( PraosFetchMode (..)
+  , FetchMode (..)
   , BlockFetchConsensusInterface (..)
   , FromConsensus (..)
   , ChainSelStarvation (..)
@@ -30,7 +30,7 @@ import Ouroboros.Network.PeerSelection.LedgerPeers.Type
            (LedgerStateJudgement (..))
 import Ouroboros.Network.SizeInBytes (SizeInBytes)
 
-data FetchMode =
+data PraosFetchMode =
        -- | Use this mode when we are catching up on the chain but are stil
        -- well behind. In this mode the fetch logic will optimise for
        -- throughput rather than latency.
@@ -54,7 +54,7 @@ data FetchMode =
   deriving (Eq, Show)
 
 -- | The fetch mode that the block fetch logic should use.
-data GenesisFetchMode = FetchModeGenesis | PraosFetchMode FetchMode
+data FetchMode = FetchModeGenesis | PraosFetchMode PraosFetchMode
   deriving (Eq, Show)
 
 -- | Construct 'readFetchMode' for 'BlockFetchConsensusInterface' by branching
@@ -64,9 +64,9 @@ mkReadFetchMode
   => ConsensusMode
   -> m LedgerStateJudgement
      -- ^ Used for 'GenesisMode'.
-  -> m FetchMode
+  -> m PraosFetchMode
      -- ^ Used for 'PraosMode' for backwards compatibility.
-  -> m GenesisFetchMode
+  -> m FetchMode
 mkReadFetchMode consensusMode getLedgerStateJudgement getFetchMode =
     case consensusMode of
       GenesisMode -> getLedgerStateJudgement <&> \case
@@ -111,7 +111,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- to \"now\" it uses the deadline mode, and when it is far away it uses
        -- the bulk sync mode.
        --
-       readFetchMode          :: STM m GenesisFetchMode,
+       readFetchMode          :: STM m FetchMode,
 
        -- | Recent, only within last K
        readFetchedBlocks      :: STM m (Point block -> Bool),

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -75,8 +75,7 @@ import Ouroboros.Network.Protocol.BlockFetch.Type qualified as BlockFetch
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.Client
 import Ouroboros.Network.BlockFetch.ClientRegistry (FetchClientRegistry (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
-           GenesisFetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
 import Ouroboros.Network.DeltaQ (defaultGSV)
 
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -60,6 +60,8 @@ library
     Ouroboros.Network.BlockFetch.ClientRegistry
     Ouroboros.Network.BlockFetch.ClientState
     Ouroboros.Network.BlockFetch.Decision
+    Ouroboros.Network.BlockFetch.Decision.Genesis
+    Ouroboros.Network.BlockFetch.Decision.Trace
     Ouroboros.Network.BlockFetch.DeltaQ
     Ouroboros.Network.BlockFetch.State
     Ouroboros.Network.DeltaQ
@@ -151,6 +153,7 @@ library
     containers,
     contra-tracer,
     deepseq,
+    dlist,
     dns,
     hashable,
     io-classes ^>=1.5.0,
@@ -169,6 +172,7 @@ library
     si-timers,
     strict-checked-vars ^>=0.2,
     strict-stm,
+    transformers,
     typed-protocols ^>=0.3,
     typed-protocols-stateful,
 
@@ -367,6 +371,7 @@ executable demo-chain-sync
     ouroboros-network-protocols,
     random,
     serialise,
+    si-timers,
     strict-stm,
     typed-protocols,
 

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -63,7 +63,8 @@ import Ouroboros.Network.Mock.ConcreteBlock
 blockFetchExample0 :: forall m.
                       (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
                        MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
-                   => Tracer m (TraceDecisionEvent Int BlockHeader)
+                   => GenesisFetchMode
+                   -> Tracer m (TraceDecisionEvent Int BlockHeader)
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
                    -> Tracer m (TraceLabelPeer Int
@@ -74,7 +75,7 @@ blockFetchExample0 :: forall m.
                    -> AnchoredFragment Block -- ^ Fixed current chain
                    -> AnchoredFragment Block -- ^ Fixed candidate chain
                    -> m ()
-blockFetchExample0 decisionTracer clientStateTracer clientMsgTracer
+blockFetchExample0 fetchMode decisionTracer clientStateTracer clientMsgTracer
                    clientDelay serverDelay
                    controlMessageSTM
                    currentChain candidateChain = do
@@ -132,7 +133,7 @@ blockFetchExample0 decisionTracer clientStateTracer clientMsgTracer
     blockFetch registry blockHeap =
         blockFetchLogic
           decisionTracer clientStateTracer
-          (sampleBlockFetchPolicy1 headerForgeUTCTime blockHeap currentChainHeaders candidateChainHeaders)
+          (sampleBlockFetchPolicy1 fetchMode headerForgeUTCTime blockHeap currentChainHeaders candidateChainHeaders)
           registry
           (BlockFetchConfiguration {
             bfcMaxConcurrencyBulkSync = 1,
@@ -176,7 +177,8 @@ blockFetchExample0 decisionTracer clientStateTracer clientMsgTracer
 blockFetchExample1 :: forall m.
                       (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
                        MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
-                   => Tracer m (TraceDecisionEvent Int BlockHeader)
+                   => GenesisFetchMode
+                   -> Tracer m (TraceDecisionEvent Int BlockHeader)
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
                    -> Tracer m (TraceLabelPeer Int
@@ -186,7 +188,7 @@ blockFetchExample1 :: forall m.
                    -> AnchoredFragment Block   -- ^ Fixed current chain
                    -> [AnchoredFragment Block] -- ^ Fixed candidate chains
                    -> m ()
-blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
+blockFetchExample1 fetchMode decisionTracer clientStateTracer clientMsgTracer
                    clientDelay serverDelay
                    currentChain candidateChains = do
     controlMessageVar <- newTVarIO Continue
@@ -245,7 +247,7 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
     blockFetch registry blockHeap =
         blockFetchLogic
           decisionTracer clientStateTracer
-          (sampleBlockFetchPolicy1 headerForgeUTCTime blockHeap currentChainHeaders candidateChainHeaders)
+          (sampleBlockFetchPolicy1 fetchMode headerForgeUTCTime blockHeap currentChainHeaders candidateChainHeaders)
           registry
           (BlockFetchConfiguration {
             bfcMaxConcurrencyBulkSync = 1,
@@ -274,16 +276,17 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
 --
 
 sampleBlockFetchPolicy1 :: (MonadSTM m, HasHeader header, HasHeader block)
-                        => (forall x. HasHeader x => FromConsensus x -> STM m UTCTime)
+                        => GenesisFetchMode
+                        -> (forall x. HasHeader x => FromConsensus x -> STM m UTCTime)
                         -> TestFetchedBlockHeap m block
                         -> AnchoredFragment header
                         -> Map peer (AnchoredFragment header)
                         -> BlockFetchConsensusInterface peer header block m
-sampleBlockFetchPolicy1 headerFieldsForgeUTCTime blockHeap currentChain candidateChains =
+sampleBlockFetchPolicy1 fetchMode headerFieldsForgeUTCTime blockHeap currentChain candidateChains =
     BlockFetchConsensusInterface {
       readCandidateChains    = return candidateChains,
       readCurrentChain       = return currentChain,
-      readFetchMode          = return $ PraosFetchMode FetchModeBulkSync,
+      readFetchMode          = return fetchMode,
       readFetchedBlocks      = flip Set.member <$>
                                  getTestFetchedBlocks blockHeap,
       readFetchedMaxSlotNo   = List.foldl' max NoMaxSlotNo .

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -42,8 +42,7 @@ import Network.TypedProtocol.Peer.Client
 import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.Client
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
-           GenesisFetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
 import Ouroboros.Network.Channel
 import Ouroboros.Network.ControlMessage
 import Ouroboros.Network.DeltaQ
@@ -63,7 +62,7 @@ import Ouroboros.Network.Mock.ConcreteBlock
 blockFetchExample0 :: forall m.
                       (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
                        MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
-                   => GenesisFetchMode
+                   => FetchMode
                    -> Tracer m (TraceDecisionEvent Int BlockHeader)
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
@@ -177,7 +176,7 @@ blockFetchExample0 fetchMode decisionTracer clientStateTracer clientMsgTracer
 blockFetchExample1 :: forall m.
                       (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
                        MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
-                   => GenesisFetchMode
+                   => FetchMode
                    -> Tracer m (TraceDecisionEvent Int BlockHeader)
                    -> Tracer m (TraceLabelPeer Int
                                  (TraceFetchClientState BlockHeader))
@@ -276,7 +275,7 @@ blockFetchExample1 fetchMode decisionTracer clientStateTracer clientMsgTracer
 --
 
 sampleBlockFetchPolicy1 :: (MonadSTM m, HasHeader header, HasHeader block)
-                        => GenesisFetchMode
+                        => FetchMode
                         -> (forall x. HasHeader x => FromConsensus x -> STM m UTCTime)
                         -> TestFetchedBlockHeap m block
                         -> AnchoredFragment header

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -46,6 +46,7 @@ import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.ClientRegistry
 import Ouroboros.Network.BlockFetch.ClientState
+import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ
 import Ouroboros.Network.BlockFetch.Examples
 import Ouroboros.Network.Driver (TraceSendRecv)
@@ -66,17 +67,27 @@ tests :: TestTree
 tests = testGroup "BlockFetch"
   [ testGroup "BulkSync"
     [ testProperty "static chains without overlap"
-                   prop_blockFetchStaticNoOverlap
+                   prop_blockFetchStaticNoOverlapPraos
 
     , testProperty "static chains with overlap"
-                   prop_blockFetchStaticWithOverlap
+                   prop_blockFetchStaticWithOverlapPraos
 
     --TODO: test where for any given delta-Q, check that we do achieve full
     -- pipelining to keep the server busy and get decent enough batching of
     -- requests (testing the high/low watermark mechanism).
     , testProperty "termination"
-                   prop_terminate
-  ]
+                   prop_terminatePraos
+    ]
+  , testGroup "Genesis"
+    [ testProperty "static chains without overlap"
+                   prop_blockFetchStaticNoOverlapGenesis
+
+    , testProperty "static chains with overlap"
+                   prop_blockFetchStaticWithOverlapGenesis
+
+    , testProperty "termination"
+                   prop_terminateGenesis
+    ]
   , testCaseSteps "bracketSyncWithFetchClient"
                   unit_bracketSyncWithFetchClient
   , testProperty "compare comparePeerGSV" prop_comparePeerGSV
@@ -88,10 +99,24 @@ tests = testGroup "BlockFetch"
 -- Properties
 --
 
+prop_blockFetchStaticNoOverlapPraos :: TestChainFork -> Property
+prop_blockFetchStaticNoOverlapPraos =
+    prop_blockFetchStaticNoOverlap (PraosFetchMode FetchModeBulkSync)
+
+prop_blockFetchStaticNoOverlapGenesis :: TestChainFork -> Property
+prop_blockFetchStaticNoOverlapGenesis =
+    prop_blockFetchStaticNoOverlap FetchModeGenesis
+
 -- | In this test we have two candidates chains that are static throughout the
 -- run. The two chains share some common prefix (genesis in the degenerate
--- case). The test runs the block fetch logic to download all of both chain
--- candidates.
+-- case).
+--
+-- With a Praos fetch mode, the test runs the block fetch logic to download all
+-- blocks of both chain candidates.
+--
+-- With GenesisFetchMode, the test runs the block fetch logic to download all
+-- blocks of the longest candidate chain (either of them if they are of equal
+-- length).
 --
 -- In this variant we set up the common prefix of the two candidates as the
 -- \"current\" chain. This means the block fetch only has to download the
@@ -102,19 +127,23 @@ tests = testGroup "BlockFetch"
 -- This runs the block fetch and then checks that the trace of the events in
 -- that run satisfy the trace properties:
 --
--- * 'tracePropertyBlocksRequestedAndRecievedPerPeer'
+-- * 'tracePropertyBlocksRequestedAndReceivedPerPeerPraos'
 -- * 'tracePropertyClientStateSanity'
 -- * 'tracePropertyInFlight'
 --
-prop_blockFetchStaticNoOverlap :: TestChainFork -> Property
-prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
+prop_blockFetchStaticNoOverlap :: GenesisFetchMode -> TestChainFork -> Property
+prop_blockFetchStaticNoOverlap fetchMode (TestChainFork common fork1 fork2) =
     let trace = selectTraceEventsDynamic (runSimTrace simulation)
 
      in counterexample ("\nTrace:\n" ++ unlines (map show trace)) $
 
         -- For fetch reqs added and received, we observe exactly the sequence
         -- of blocks we expect, which is the whole fork suffix.
-        tracePropertyBlocksRequestedAndRecievedPerPeer fork1'' fork2'' trace
+        case fetchMode of
+          FetchModeGenesis ->
+            tracePropertyBlocksRequestedAndReceivedPerPeerGenesis fork1'' fork2'' trace
+          PraosFetchMode{} ->
+            tracePropertyBlocksRequestedAndReceivedPerPeerPraos fork1'' fork2'' trace
 
         -- state sanity check
    .&&. property (tracePropertyClientStateSanity trace)
@@ -126,6 +155,7 @@ prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
     simulation :: IOSim s ()
     simulation =
       blockFetchExample1
+        fetchMode
         (contramap TraceFetchDecision       dynamicTracer)
         (contramap TraceFetchClientState    dynamicTracer)
         (contramap TraceFetchClientSendRecv dynamicTracer)
@@ -140,6 +170,13 @@ prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
     -- And just the extensions
     Just (_, _, fork1'', fork2'') = AnchoredFragment.intersect fork1' fork2'
 
+prop_blockFetchStaticWithOverlapPraos :: TestChainFork -> Property
+prop_blockFetchStaticWithOverlapPraos =
+    prop_blockFetchStaticWithOverlap (PraosFetchMode FetchModeBulkSync)
+
+prop_blockFetchStaticWithOverlapGenesis :: TestChainFork -> Property
+prop_blockFetchStaticWithOverlapGenesis =
+    prop_blockFetchStaticWithOverlap FetchModeGenesis
 
 -- | In this test we have two candidates chains that are static throughout the
 -- run. The two chains share some common prefix (genesis in the degenerate
@@ -155,22 +192,26 @@ prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
 -- This runs the block fetch and then checks that the trace of the events in
 -- that run satisfy the trace properties:
 --
--- * 'tracePropertyBlocksRequestedAndRecievedAllPeers'
+-- * 'tracePropertyBlocksRequestedAndReceivedAllPeersPraos'
 -- * 'tracePropertyNoDuplicateBlocksBetweenPeers'
 -- * 'tracePropertyClientStateSanity'
 -- * 'tracePropertyInFlight'
 --
 -- TODO: 'prop_blockFetchBulkSyncStaticWithOverlap' fails if we introduce delays. issue #2622
 --
-prop_blockFetchStaticWithOverlap :: TestChainFork -> Property
-prop_blockFetchStaticWithOverlap (TestChainFork _common fork1 fork2) =
+prop_blockFetchStaticWithOverlap :: GenesisFetchMode -> TestChainFork -> Property
+prop_blockFetchStaticWithOverlap fetchMode (TestChainFork _common fork1 fork2) =
     let trace = selectTraceEventsDynamic (runSimTrace simulation)
 
      in counterexample ("\nTrace:\n" ++ unlines (map show trace)) $
 
         -- For fetch reqs added and received, between the two peers we observe
         -- the set of blocks we expect, which is the union of the two chains.
-        tracePropertyBlocksRequestedAndRecievedAllPeers fork1' fork2' trace
+        case fetchMode of
+          FetchModeGenesis ->
+            tracePropertyBlocksRequestedAndReceivedAllPeersGenesis fork1' fork2' trace
+          PraosFetchMode{} ->
+            tracePropertyBlocksRequestedAndReceivedAllPeersPraos fork1' fork2' trace
 
         -- For fetch reqs added, the set of blocks added for the two peers
         -- should not intersect
@@ -186,6 +227,7 @@ prop_blockFetchStaticWithOverlap (TestChainFork _common fork1 fork2) =
     simulation :: forall s. IOSim s ()
     simulation =
       blockFetchExample1
+        fetchMode
         (contramap TraceFetchDecision       dynamicTracer)
         (contramap TraceFetchClientState    dynamicTracer)
         (contramap TraceFetchClientSendRecv dynamicTracer)
@@ -227,7 +269,7 @@ instance Show Example1TraceEvent where
 -- requested and completed by both fetch clients is exactly the sequence
 -- expected. The expected sequence is exactly the chain suffixes in order.
 --
--- This property is stronger than 'tracePropertyBlocksRequestedAndRecievedAllPeers'
+-- This property is stronger than 'tracePropertyBlocksRequestedAndReceivedAllPeersPraos'
 -- since it works with sequences rather than sets and for each chain
 -- individually rather than both chains together. It only holds for the
 -- situation where the suffixes of the chains that need to be fetched are
@@ -236,12 +278,12 @@ instance Show Example1TraceEvent where
 -- It turns out that no duplicates part is not trivial. Earlier versions of the
 -- block fetch logic did not satisfy this in all cases.
 --
-tracePropertyBlocksRequestedAndRecievedPerPeer
+tracePropertyBlocksRequestedAndReceivedPerPeerPraos
   :: AnchoredFragment Block
   -> AnchoredFragment Block
   -> [Example1TraceEvent]
   -> Property
-tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
+tracePropertyBlocksRequestedAndReceivedPerPeerPraos fork1 fork2 es =
       requestedFetchPoints === requiredFetchPoints
  .&&. receivedFetchPoints  === requiredFetchPoints
   where
@@ -271,6 +313,65 @@ tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
             (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _ _ _)) <- es
         ]
 
+-- | Check the execution trace for a particular property: we observe all the
+-- blocks in the 'FetchRequest's added by the decision logic and the blocks
+-- received by the fetch clients; check that the ordered sequence of blocks
+-- requested and completed by both fetch clients is exactly the sequence
+-- expected. The expected sequence is exactly the longest chain suffix, or
+-- either of them if they are of equal length.
+--
+-- This property is stronger than 'tracePropertyBlocksRequestedAndReceivedAllPeersGenesis'
+-- since it works with sequences rather than sets and for each chain
+-- individually rather than both chains together. It only holds for the
+-- situation where the suffixes of the chains that need to be fetched are
+-- disjoint, sharing no common prefix.
+--
+-- It turns out that no duplicates part is not trivial. Earlier versions of the
+-- block fetch logic did not satisfy this in all cases.
+--
+tracePropertyBlocksRequestedAndReceivedPerPeerGenesis
+  :: AnchoredFragment Block
+  -> AnchoredFragment Block
+  -> [Example1TraceEvent]
+  -> Property
+tracePropertyBlocksRequestedAndReceivedPerPeerGenesis fork1 fork2 es =
+       counterexample "should request the expected blocks"
+         (disjoin $ map (requestedFetchPoints ===) requiredFetchPoints)
+  .&&. counterexample "should receive the expected blocks"
+         (disjoin $ map (receivedFetchPoints ===) requiredFetchPoints)
+  where
+    requiredFetchPoints =
+      if AnchoredFragment.length fork1 == AnchoredFragment.length fork2
+        then [ requiredFetchPointsFor 1 fork1
+             , requiredFetchPointsFor 2 fork2
+             , Map.union (requiredFetchPointsFor 1 fork1) (requiredFetchPointsFor 2 fork2)
+             ]
+        else if AnchoredFragment.length fork1 < AnchoredFragment.length fork2
+          then [requiredFetchPointsFor 2 fork2]
+          else [requiredFetchPointsFor 1 fork1]
+
+    requiredFetchPointsFor peer fork =
+      Map.fromList [ (peer, points) | let points = chainPoints fork
+                                    , not $ Prelude.null points ]
+
+    requestedFetchPoints :: Map Int [Point BlockHeader]
+    requestedFetchPoints =
+      Map.fromListWith (flip (++))
+        [ (peer, map blockPoint (AnchoredFragment.toOldestFirst fragment))
+        | TraceFetchClientState
+            (TraceLabelPeer peer
+              (AddedFetchRequest
+                (FetchRequest fragments) _ _ _)) <- es
+        , fragment <- fragments
+        ]
+
+    receivedFetchPoints :: Map Int [Point BlockHeader]
+    receivedFetchPoints =
+      Map.fromListWith (flip (++))
+        [ (peer, [pt])
+        | TraceFetchClientState
+            (TraceLabelPeer peer (CompletedBlockFetch pt _ _ _ _ _)) <- es
+        ]
 
 -- | Check the execution trace for a particular property: we observe all the
 -- blocks in the 'FetchRequest's added by the decision logic and the blocks
@@ -279,21 +380,77 @@ tracePropertyBlocksRequestedAndRecievedPerPeer fork1 fork2 es =
 -- set of all blocks received. The expected set of blocks is the union of the
 -- blocks on the two candidate chains.
 --
--- This property is weaker than 'tracePropertyBlocksRequestedAndRecievedPerPeer'
+-- This property is weaker than 'tracePropertyBlocksRequestedAndReceivedPerPeerPraos'
 -- since it does not involve order or frequency, but it holds for the general
 -- case of multiple chains with common prefixes.
 --
-tracePropertyBlocksRequestedAndRecievedAllPeers
+tracePropertyBlocksRequestedAndReceivedAllPeersPraos
   :: AnchoredFragment Block
   -> AnchoredFragment Block
   -> [Example1TraceEvent]
   -> Property
-tracePropertyBlocksRequestedAndRecievedAllPeers fork1 fork2 es =
+tracePropertyBlocksRequestedAndReceivedAllPeersPraos fork1 fork2 es =
       requestedFetchPoints === requiredFetchPoints
  .&&. receivedFetchPoints  === requiredFetchPoints
   where
     requiredFetchPoints =
       Set.fromList (chainPoints fork1 ++ chainPoints fork2)
+
+    requestedFetchPoints :: Set (Point BlockHeader)
+    requestedFetchPoints =
+      Set.fromList
+        [ blockPoint block
+        | TraceFetchClientState
+            (TraceLabelPeer _
+              (AddedFetchRequest
+                (FetchRequest fragments) _ _ _)) <- es
+        , fragment <- fragments
+        , block    <- AnchoredFragment.toOldestFirst fragment
+        ]
+
+    receivedFetchPoints :: Set (Point BlockHeader)
+    receivedFetchPoints =
+      Set.fromList
+        [ pt
+        | TraceFetchClientState
+            (TraceLabelPeer _ (CompletedBlockFetch pt _ _ _ _ _)) <- es
+        ]
+
+
+-- | Check the execution trace for a particular property: we observe all the
+-- blocks in the 'FetchRequest's added by the decision logic and the blocks
+-- received by the fetch clients; check that the set of all blocks requested
+-- across the two peers is the set of blocks we expect, and similarly for the
+-- set of all blocks received. The expected set of blocks is the block of the
+-- longest candidate chain, or either of them if they have the same size.
+--
+-- This property is weaker than 'tracePropertyBlocksRequestedAndReceivedPerPeerGenesis'
+-- since it does not involve order or frequency, but it holds for the general
+-- case of multiple chains with common prefixes.
+--
+tracePropertyBlocksRequestedAndReceivedAllPeersGenesis
+  :: AnchoredFragment Block
+  -> AnchoredFragment Block
+  -> [Example1TraceEvent]
+  -> Property
+tracePropertyBlocksRequestedAndReceivedAllPeersGenesis fork1 fork2 es =
+       counterexample "should request the expected blocks"
+         (disjoin $ map (requestedFetchPoints ===) requiredFetchPoints)
+  .&&. counterexample "should receive the expected blocks"
+         (disjoin $ map (receivedFetchPoints ===) requiredFetchPoints)
+  where
+    requiredFetchPoints =
+      if AnchoredFragment.length fork1 == AnchoredFragment.length fork2
+        then [ requiredFetchPointsFor fork1
+             , requiredFetchPointsFor fork2
+             , Set.union (requiredFetchPointsFor fork1) (requiredFetchPointsFor fork2)
+             ]
+        else if AnchoredFragment.length fork1 < AnchoredFragment.length fork2
+          then [requiredFetchPointsFor fork2]
+          else [requiredFetchPointsFor fork1]
+
+    requiredFetchPointsFor fork =
+      Set.fromList $ chainPoints fork
 
     requestedFetchPoints :: Set (Point BlockHeader)
     requestedFetchPoints =
@@ -748,14 +905,20 @@ unit_bracketSyncWithFetchClient step = do
                    else error "state leak"
               return (fetchRes, syncRes)
 
+prop_terminatePraos :: TestChainFork -> Positive SmallDelay -> Property
+prop_terminatePraos = prop_terminate (PraosFetchMode FetchModeBulkSync)
+
+prop_terminateGenesis :: TestChainFork -> Positive SmallDelay -> Property
+prop_terminateGenesis = prop_terminate FetchModeGenesis
+
 -- | Check that the client can terminate using `ControlMessage` mechanism.
 --
 -- The 'awaitDelay' of @100 * delay@ is a bit arbitrary.  It would be nicer to
 -- make a proper calculation what should it be.  At the moment this test shows
 -- that the block fetch protocol can exit within some large time limit.
 --
-prop_terminate :: TestChainFork -> Positive SmallDelay -> Property
-prop_terminate (TestChainFork _commonChain forkChain _forkChain) (Positive (SmallDelay delay)) =
+prop_terminate :: GenesisFetchMode -> TestChainFork -> Positive SmallDelay -> Property
+prop_terminate fetchMode (TestChainFork _commonChain forkChain _forkChain) (Positive (SmallDelay delay)) =
     let tr = runSimTrace simulation
         trace :: [FetchRequestTrace]
         trace  = selectTraceEventsDynamic tr
@@ -783,6 +946,7 @@ prop_terminate (TestChainFork _commonChain forkChain _forkChain) (Positive (Smal
             threadId <- myThreadId
             labelThread threadId "block-fetch"
             blockFetchExample0
+              fetchMode
               (contramap TraceFetchDecision       dynamicTracer)
               (contramap TraceFetchClientState    dynamicTracer)
               (contramap TraceFetchClientSendRecv dynamicTracer)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -54,6 +54,7 @@ import Ouroboros.Network.Mock.ConcreteBlock
 import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
 
+import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import Ouroboros.Network.Testing.Utils
 
 
@@ -207,8 +208,7 @@ chainPoints = map (castPoint . blockPoint)
             . AnchoredFragment.toOldestFirst
 
 data Example1TraceEvent =
-     TraceFetchDecision       [TraceLabelPeer Int
-                                (FetchDecision [Point BlockHeader])]
+     TraceFetchDecision       (TraceDecisionEvent Int BlockHeader)
    | TraceFetchClientState    (TraceLabelPeer Int
                                 (TraceFetchClientState BlockHeader))
    | TraceFetchClientSendRecv (TraceLabelPeer Int

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -46,7 +46,6 @@ import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.ClientRegistry
 import Ouroboros.Network.BlockFetch.ClientState
-import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ
 import Ouroboros.Network.BlockFetch.Examples
 import Ouroboros.Network.Driver (TraceSendRecv)
@@ -114,7 +113,7 @@ prop_blockFetchStaticNoOverlapGenesis =
 -- With a Praos fetch mode, the test runs the block fetch logic to download all
 -- blocks of both chain candidates.
 --
--- With GenesisFetchMode, the test runs the block fetch logic to download all
+-- With the Genesis fetch mode, the test runs the block fetch logic to download all
 -- blocks of the longest candidate chain (either of them if they are of equal
 -- length).
 --
@@ -131,7 +130,7 @@ prop_blockFetchStaticNoOverlapGenesis =
 -- * 'tracePropertyClientStateSanity'
 -- * 'tracePropertyInFlight'
 --
-prop_blockFetchStaticNoOverlap :: GenesisFetchMode -> TestChainFork -> Property
+prop_blockFetchStaticNoOverlap :: FetchMode -> TestChainFork -> Property
 prop_blockFetchStaticNoOverlap fetchMode (TestChainFork common fork1 fork2) =
     let trace = selectTraceEventsDynamic (runSimTrace simulation)
 
@@ -199,7 +198,7 @@ prop_blockFetchStaticWithOverlapGenesis =
 --
 -- TODO: 'prop_blockFetchBulkSyncStaticWithOverlap' fails if we introduce delays. issue #2622
 --
-prop_blockFetchStaticWithOverlap :: GenesisFetchMode -> TestChainFork -> Property
+prop_blockFetchStaticWithOverlap :: FetchMode -> TestChainFork -> Property
 prop_blockFetchStaticWithOverlap fetchMode (TestChainFork _common fork1 fork2) =
     let trace = selectTraceEventsDynamic (runSimTrace simulation)
 
@@ -917,7 +916,7 @@ prop_terminateGenesis = prop_terminate FetchModeGenesis
 -- make a proper calculation what should it be.  At the moment this test shows
 -- that the block fetch protocol can exit within some large time limit.
 --
-prop_terminate :: GenesisFetchMode -> TestChainFork -> Positive SmallDelay -> Property
+prop_terminate :: FetchMode -> TestChainFork -> Positive SmallDelay -> Property
 prop_terminate fetchMode (TestChainFork _commonChain forkChain _forkChain) (Positive (SmallDelay delay)) =
     let tr = runSimTrace simulation
         trace :: [FetchRequestTrace]

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -64,20 +64,21 @@ import Ouroboros.Network.Testing.Utils
 
 tests :: TestTree
 tests = testGroup "BlockFetch"
-  [ testProperty "static chains without overlap"
-                 prop_blockFetchStaticNoOverlap
+  [ testGroup "BulkSync"
+    [ testProperty "static chains without overlap"
+                   prop_blockFetchStaticNoOverlap
 
-  , testProperty "static chains with overlap"
-                 prop_blockFetchStaticWithOverlap
+    , testProperty "static chains with overlap"
+                   prop_blockFetchStaticWithOverlap
 
+    --TODO: test where for any given delta-Q, check that we do achieve full
+    -- pipelining to keep the server busy and get decent enough batching of
+    -- requests (testing the high/low watermark mechanism).
+    , testProperty "termination"
+                   prop_terminate
+  ]
   , testCaseSteps "bracketSyncWithFetchClient"
                   unit_bracketSyncWithFetchClient
-
-  --TODO: test where for any given delta-Q, check that we do achieve full
-  -- pipelining to keep the server busy and get decent enough batching of
-  -- requests (testing the high/low watermark mechanism).
-  , testProperty "termination"
-                 prop_terminate
   , testProperty "compare comparePeerGSV" prop_comparePeerGSV
   , testProperty "eq comparePeerGSV" prop_comparePeerGSVEq
   ]
@@ -159,7 +160,7 @@ prop_blockFetchStaticNoOverlap (TestChainFork common fork1 fork2) =
 -- * 'tracePropertyClientStateSanity'
 -- * 'tracePropertyInFlight'
 --
--- TODO: 'prop_blockFetchStaticWithOverlap' fails if we introduce delays. issue #2622
+-- TODO: 'prop_blockFetchBulkSyncStaticWithOverlap' fails if we introduce delays. issue #2622
 --
 prop_blockFetchStaticWithOverlap :: TestChainFork -> Property
 prop_blockFetchStaticWithOverlap (TestChainFork _common fork1 fork2) =

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -45,7 +45,8 @@ import System.Random (mkStdGen)
 import Network.DNS.Types qualified as DNS
 
 import Ouroboros.Network.Block (BlockNo (..))
-import Ouroboros.Network.BlockFetch (FetchMode (..), TraceFetchClientState (..))
+import Ouroboros.Network.BlockFetch (PraosFetchMode (..),
+           TraceFetchClientState (..))
 import Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace)
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.ConnectionManager.Core qualified as CM

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Internal.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Internal.hs
@@ -122,7 +122,7 @@ import Test.Ouroboros.Network.Testnet.Node.Kernel (BlockGeneratorArgs, NtCAddr,
 import Data.Bool (bool)
 import Data.Function (on)
 import Data.Typeable (Typeable)
-import Ouroboros.Network.BlockFetch (FetchMode (..), TraceFetchClientState,
+import Ouroboros.Network.BlockFetch (PraosFetchMode (..), TraceFetchClientState,
            TraceLabelPeer (..))
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..))
 import Ouroboros.Network.PeerSelection.LocalRootPeers
@@ -219,7 +219,7 @@ data NodeArgs =
       -- ^ 'Arguments' 'aDNSLookupDelayScript' value
     , naChainSyncExitOnBlockNo :: Maybe BlockNo
     , naChainSyncEarlyExit     :: Bool
-    , naFetchModeScript        :: Script FetchMode
+    , naFetchModeScript        :: Script PraosFetchMode
     }
 
 instance Show NodeArgs where

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
@@ -66,8 +66,7 @@ import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.Block (MaxSlotNo (..), maxSlotNoFromWithOrigin,
            pointSlot)
 import Ouroboros.Network.BlockFetch
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
-           GenesisFetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
 import Ouroboros.Network.ConnectionManager.Types (DataFlow (..))
 import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.Diffusion qualified as Diff

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
@@ -263,7 +263,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
                        (\ _ (_ :: SomeException) -> ShutdownNode)
               , Diff.P2P.daPeerMetrics            = peerMetrics
                 -- fetch mode is not used (no block-fetch mini-protocol)
-              , Diff.P2P.daBlockFetchMode         = pure FetchModeDeadline
+              , Diff.P2P.daBlockFetchMode         = pure $ PraosFetchMode FetchModeDeadline
               , Diff.P2P.daReturnPolicy           = \_ -> config_REPROMOTE_DELAY
               , Diff.P2P.daPeerSharingRegistry    = nkPeerSharingRegistry nodeKernel
               }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric       #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
@@ -84,6 +85,7 @@ module Ouroboros.Network.BlockFetch
   ( blockFetchLogic
   , BlockFetchConfiguration (..)
   , BlockFetchConsensusInterface (..)
+  , GenesisBlockFetchConfiguration (..)
     -- ** Tracer types
   , FetchDecision
   , TraceFetchClientState (..)
@@ -108,6 +110,8 @@ import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer (Tracer)
 
+import GHC.Generics (Generic)
+
 import Ouroboros.Network.Block
 import Ouroboros.Network.SizeInBytes (SizeInBytes)
 
@@ -118,8 +122,8 @@ import Ouroboros.Network.BlockFetch.ClientRegistry (FetchClientPolicy (..),
            setFetchClientContext)
 import Ouroboros.Network.BlockFetch.ConsensusInterface
            (BlockFetchConsensusInterface (..), FromConsensus (..))
+import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import Ouroboros.Network.BlockFetch.State
-
 
 
 -- | Configuration for FetchDecisionPolicy.
@@ -127,21 +131,38 @@ import Ouroboros.Network.BlockFetch.State
 data BlockFetchConfiguration =
      BlockFetchConfiguration {
          -- | Maximum concurrent downloads during bulk syncing.
-         bfcMaxConcurrencyBulkSync :: !Word,
+         bfcMaxConcurrencyBulkSync      :: !Word,
 
          -- | Maximum concurrent downloads during deadline syncing.
-         bfcMaxConcurrencyDeadline :: !Word,
+         bfcMaxConcurrencyDeadline      :: !Word,
 
          -- | Maximum requests in flight per each peer.
-         bfcMaxRequestsInflight    :: !Word,
+         bfcMaxRequestsInflight         :: !Word,
 
          -- | Desired interval between calls to fetchLogicIteration
-         bfcDecisionLoopInterval   :: !DiffTime,
+         -- in Genesis fetch mode
+         bfcDecisionLoopIntervalGenesis :: !DiffTime,
+
+         -- | Desired interval between calls to fetchLogicIteration
+         -- in Praos fetch modes
+         bfcDecisionLoopIntervalPraos   :: !DiffTime,
 
          -- | Salt used when comparing peers
-         bfcSalt                   :: !Int
+         bfcSalt                        :: !Int,
+
+         -- | Genesis-specific parameters
+         bfcGenesisBFConfig             :: !GenesisBlockFetchConfiguration
      }
      deriving (Show)
+
+-- | BlockFetch configuration parameters specific to Genesis.
+data GenesisBlockFetchConfiguration =
+     GenesisBlockFetchConfiguration
+      { -- | Grace period when starting to talk to a peer in genesis mode
+        -- during which it is fine if the chain selection gets starved.
+        gbfcGracePeriod :: !DiffTime
+      }
+      deriving (Eq, Generic, Show)
 
 -- | Execute the block fetch logic. It monitors the current chain and candidate
 -- chains. It decided which block bodies to fetch and manages the process of
@@ -155,11 +176,11 @@ blockFetchLogic :: forall addr header block m.
                    , HasHeader block
                    , HeaderHash header ~ HeaderHash block
                    , MonadDelay m
-                   , MonadSTM m
+                   , MonadTimer m
                    , Ord addr
                    , Hashable addr
                    )
-                => Tracer m [TraceLabelPeer addr (FetchDecision [Point header])]
+                => Tracer m (TraceDecisionEvent addr header)
                 -> Tracer m (TraceLabelPeer addr (TraceFetchClientState header))
                 -> BlockFetchConsensusInterface addr header block m
                 -> FetchClientRegistry addr header block m
@@ -177,6 +198,7 @@ blockFetchLogic decisionTracer clientStateTracer
       fetchDecisionPolicy
       fetchTriggerVariables
       fetchNonTriggerVariables
+      demoteChainSyncJumpingDynamo
   where
     mkFetchClientPolicy :: STM m (FetchClientPolicy header block m)
     mkFetchClientPolicy = do
@@ -191,11 +213,13 @@ blockFetchLogic decisionTracer clientStateTracer
     fetchDecisionPolicy :: FetchDecisionPolicy header
     fetchDecisionPolicy =
       FetchDecisionPolicy {
-        maxInFlightReqsPerPeer   = bfcMaxRequestsInflight,
-        maxConcurrencyBulkSync   = bfcMaxConcurrencyBulkSync,
-        maxConcurrencyDeadline   = bfcMaxConcurrencyDeadline,
-        decisionLoopInterval     = bfcDecisionLoopInterval,
-        peerSalt                 = bfcSalt,
+        maxInFlightReqsPerPeer      = bfcMaxRequestsInflight,
+        maxConcurrencyBulkSync      = bfcMaxConcurrencyBulkSync,
+        maxConcurrencyDeadline      = bfcMaxConcurrencyDeadline,
+        decisionLoopIntervalGenesis = bfcDecisionLoopIntervalGenesis,
+        decisionLoopIntervalPraos   = bfcDecisionLoopIntervalPraos,
+        peerSalt                    = bfcSalt,
+        bulkSyncGracePeriod         = gbfcGracePeriod bfcGenesisBFConfig,
 
         plausibleCandidateChain,
         compareCandidateChains,
@@ -213,9 +237,10 @@ blockFetchLogic decisionTracer clientStateTracer
     fetchNonTriggerVariables :: FetchNonTriggerVariables addr header block m
     fetchNonTriggerVariables =
       FetchNonTriggerVariables {
-        readStateFetchedBlocks    = readFetchedBlocks,
-        readStatePeerStateVars    = readFetchClientsStateVars registry,
-        readStatePeerGSVs         = readPeerGSVs registry,
-        readStateFetchMode        = readFetchMode,
-        readStateFetchedMaxSlotNo = readFetchedMaxSlotNo
+        readStateFetchedBlocks      = readFetchedBlocks,
+        readStatePeerStateVars      = readFetchClientsStateVars registry,
+        readStatePeerGSVs           = readPeerGSVs registry,
+        readStateFetchMode          = readFetchMode,
+        readStateFetchedMaxSlotNo   = readFetchedMaxSlotNo,
+        readStateChainSelStarvation = readChainSelStarvation
       }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -97,6 +97,7 @@ module Ouroboros.Network.BlockFetch
   , bracketSyncWithFetchClient
   , bracketKeepAliveClient
     -- * Re-export types used by 'BlockFetchConsensusInterface'
+  , PraosFetchMode (..)
   , FetchMode (..)
   , FromConsensus (..)
   , SizeInBytes

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -31,11 +31,13 @@ module Ouroboros.Network.BlockFetch.ClientState
   , ChainRange (..)
     -- * Ancillary
   , FromConsensus (..)
+  , PeersOrder (..)
   ) where
 
 import Data.List as List (foldl')
 import Data.Maybe (mapMaybe)
 import Data.Semigroup (Last (..))
+import Data.Sequence (Seq)
 import Data.Set (Set)
 import Data.Set qualified as Set
 
@@ -749,3 +751,15 @@ takeTFetchRequestVar :: MonadSTM m
                                PeerFetchInFlightLimits)
 takeTFetchRequestVar v = (\(r,g,l) -> (r, getLast g, getLast l))
                      <$> takeTMergeVar v
+
+-- | The order of peers for bulk sync fetch decisions.
+data PeersOrder peer = PeersOrder
+  { peersOrderCurrent :: Maybe peer
+    -- ^ The current peer we are fetching from, if there is one.
+  , peersOrderAll     :: Seq peer
+    -- ^ All the peers, from most preferred to least preferred.
+    --
+    -- INVARIANT: If there is a current peer, it is always the head of this list.
+  , peersOrderStart   :: Time
+    -- ^ The time at which we started talking to the current peer.
+  }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -9,7 +9,7 @@ module Ouroboros.Network.BlockFetch.Decision
   ( -- * Deciding what to fetch
     fetchDecisions
   , FetchDecisionPolicy (..)
-  , FetchMode (..)
+  , PraosFetchMode (..)
   , PeerInfo
   , peerInfoPeer
   , FetchDecision
@@ -49,7 +49,7 @@ import Ouroboros.Network.Point (withOriginToMaybe)
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeerFetchStatus (..))
 import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..),
-           GenesisFetchMode (..))
+           PraosFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (PeerFetchInFlightLimits (..),
            PeerGSV (..), SizeInBytes, calculatePeerFetchInFlightLimits,
            comparePeerGSV, comparePeerGSV', estimateExpectedResponseDuration,
@@ -234,7 +234,7 @@ data FetchDecline =
      -- * the corresponding configured limit constant, either
      --   'maxConcurrencyBulkSync' or 'maxConcurrencyDeadline'
      --
-   | FetchDeclineConcurrencyLimit   !GenesisFetchMode !Word
+   | FetchDeclineConcurrencyLimit   !FetchMode !Word
   deriving (Eq, Show)
 
 
@@ -264,7 +264,7 @@ fetchDecisions
       HasHeader header,
       HeaderHash header ~ HeaderHash block)
   => FetchDecisionPolicy header
-  -> FetchMode
+  -> PraosFetchMode
   -> AnchoredFragment header
   -> (Point block -> Bool)
   -> MaxSlotNo
@@ -640,7 +640,7 @@ filterNotAlreadyInFlightWithPeer chains =
 --
 filterNotAlreadyInFlightWithOtherPeers
   :: HasHeader header
-  => FetchMode
+  => PraosFetchMode
   -> [( FetchDecision [AnchoredFragment header]
       , PeerFetchStatus header
       , PeerFetchInFlight header
@@ -724,7 +724,7 @@ prioritisePeerChains
    , Hashable peer
    , Ord peer
    )
-  => FetchMode
+  => PraosFetchMode
   -> Int
   -> (AnchoredFragment header -> AnchoredFragment header -> Ordering)
   -> (header -> SizeInBytes)
@@ -906,7 +906,7 @@ fetchRequestDecisions
       , Ord peer
       )
   => FetchDecisionPolicy header
-  -> FetchMode
+  -> PraosFetchMode
   -> [( FetchDecision [AnchoredFragment header]
       , PeerFetchStatus header
       , PeerFetchInFlight header
@@ -1021,7 +1021,7 @@ fetchRequestDecisions fetchDecisionPolicy fetchMode chains =
 fetchRequestDecision
   :: HasHeader header
   => FetchDecisionPolicy header
-  -> FetchMode
+  -> PraosFetchMode
   -> Word
   -> PeerFetchInFlightLimits
   -> PeerFetchInFlight header

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -48,7 +48,8 @@ import Ouroboros.Network.Point (withOriginToMaybe)
 
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeerFetchStatus (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..),
+           GenesisFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (PeerFetchInFlightLimits (..),
            PeerGSV (..), SizeInBytes, calculatePeerFetchInFlightLimits,
            comparePeerGSV, comparePeerGSV', estimateExpectedResponseDuration,
@@ -233,7 +234,7 @@ data FetchDecline =
      -- * the corresponding configured limit constant, either
      --   'maxConcurrencyBulkSync' or 'maxConcurrencyDeadline'
      --
-   | FetchDeclineConcurrencyLimit   !FetchMode !Word
+   | FetchDeclineConcurrencyLimit   !GenesisFetchMode !Word
   deriving (Eq, Show)
 
 
@@ -1084,7 +1085,7 @@ fetchRequestDecision FetchDecisionPolicy {
                                     FetchModeDeadline -> maxConcurrencyDeadline
   , nConcurrentFetchPeers > maxConcurrentFetchPeers
   = Left $ FetchDeclineConcurrencyLimit
-             fetchMode maxConcurrentFetchPeers
+             (PraosFetchMode fetchMode) maxConcurrentFetchPeers
 
     -- If we're at the concurrency limit refuse any additional peers.
   | peerFetchReqsInFlight == 0
@@ -1093,7 +1094,7 @@ fetchRequestDecision FetchDecisionPolicy {
                                     FetchModeDeadline -> maxConcurrencyDeadline
   , nConcurrentFetchPeers == maxConcurrentFetchPeers
   = Left $ FetchDeclineConcurrencyLimit
-             fetchMode maxConcurrentFetchPeers
+             (PraosFetchMode fetchMode) maxConcurrentFetchPeers
 
     -- We've checked our request limit and our byte limit. We are then
     -- guaranteed to get at least one non-empty request range.

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
@@ -149,7 +149,8 @@ import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeersOrder (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
+           GenesisFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (calculatePeerFetchInFlightLimits)
 
 import Cardano.Slotting.Slot (WithOrigin)
@@ -515,7 +516,7 @@ selectThePeer
     go grossRequest (c@(candidate, peerInfo) : xs) = do
       if grossRequest `requestHeadInCandidate` candidate then do
         tell $ DList.fromList
-          [(FetchDeclineConcurrencyLimit FetchModeBulkSync 1, pInfo)
+          [(FetchDeclineConcurrencyLimit FetchModeGenesis 1, pInfo)
           | (_, pInfo) <- xs
           ]
         pure (Just c)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
@@ -150,7 +150,7 @@ import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeersOrder (..))
 import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
-           GenesisFetchMode (..))
+           FetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (calculatePeerFetchInFlightLimits)
 
 import Cardano.Slotting.Slot (WithOrigin)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
@@ -1,0 +1,613 @@
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+
+-- | Genesis decision logic
+--
+-- This module contains the part of the block fetch decisions process that is
+-- specific to the bulk sync mode. This logic reuses parts of the logic for the
+-- deadline mode, but it is inherently different.
+--
+-- Definitions:
+--
+-- - Let @inflight :: peer -> Set blk@ be the outstanding blocks, those that
+--   have been requested and are expected to arrive but have not yet.
+--
+-- - Let @peersOrder@ be an order of preference among the peers. This order is
+--   not set in stone and will evolve as we go.
+--
+-- - Let @currentPeer :: Maybe peer@ be the “current peer” with which we are
+--   interacting. If it exists, this peer must be the best according to
+--   @peersOrder@, and the last fetch request must have been sent to them.
+--
+-- - Let @currentStart :: Time@ be the latest time a fetch request was sent
+--   while there were no outstanding blocks.
+--
+-- - Let @gracePeriod@ be a small duration (eg. 10s), during which a “cold” peer
+--   is allowed to warm up (eg. grow the TCP window) before being expected to
+--   feed blocks faster than we can validate them.
+--
+-- One iteration of this decision logic:
+--
+-- 0. If @inflight(currentPeer)@ is non-empty and the block validation component
+--    has idled at any point after @currentStart@ plus @gracePeriod@, then the
+--    peer @currentPeer@ has failed to promptly serve @inflight(currentPeer)@,
+--    and:
+--
+--   - If @currentPeer@ is the ChainSync Jumping dynamo, then it must
+--     immediately be replaced as the dynamo.
+--
+--   - Stop considering the peer “current” and make them the worst according to
+--     the @peersOrder@.
+--
+-- 1. Select @theCandidate :: AnchoredFragment (Header blk)@. This is the best
+--    candidate header chain among the ChainSync clients (eg. best raw
+--    tiebreaker among the longest).
+--
+-- 2. Select @thePeer :: peer@.
+--
+--    - Let @grossRequest@ be the oldest block on @theCandidate@ that has not
+--      already been downloaded.
+--
+--    - If @grossRequest@ is empty, then terminate this iteration. Otherwise,
+--      pick the best peer (according to @peersOrder@) offering the block in
+--      @grossRequest@.
+--
+-- 3. Craft the actual request to @thePeer@ asking blocks of @theCandidate@:
+--
+--    - If the byte size of @inflight(thePeer)@ is below the low-water mark,
+--      then terminate this iteration.
+--
+--    - Decide and send the actual next batch request, as influenced by exactly
+--      which blocks are actually already currently in-flight with @thePeer@.
+--
+-- 4. If we went through the election of a new peer, replace @currentPeer@ and
+--    put the new peer at the front of @peersOrder@. Also reset @currentStart@
+--    if @inflights(thePeer)@ is empty.
+--
+-- Terminate this iteration.
+--
+-- About the influence of in-flight requests
+-- -----------------------------------------
+--
+-- One can note that in-flight requests are ignored when finding a new peer, but
+-- considered when crafting the actual request to a chosen peer. This is by
+-- design. We explain the rationale here.
+--
+-- If a peer proves too slow, then we give up on it (see point 0. above), even
+-- if it has requests in-flight. In subsequent selections of peers (point 2.),
+-- the blocks in these requests will not be removed from @theCandidate@ as, as
+-- far as we know, these requests might not return (until the connection to that
+-- peer is terminated by the mini protocol timeout).
+--
+-- When crafting the actual request, we do need to consider the in-flight
+-- requests of the peer, to avoid clogging our network. If some of these
+-- in-flight requests date from when the peer was previously “current”, this
+-- means that we cycled through all the peers that provided @theCandidate@ and
+-- they all failed to serve our blocks promptly.
+--
+-- This is a degenerate case of the algorithm that might happen but only be
+-- transient. Soon enough, @theCandidate@ should be honest (if the consensus
+-- layer does its job correctly), and there should exist an honest peer ready to
+-- serve @theCandidate@ promptly.
+--
+-- Interactions with ChainSync Jumping (CSJ)
+-- -----------------------------------------
+--
+-- Because we always require our peers to be able to serve a gross request
+-- with an old block, peers with longer chains have a better chance to pass
+-- this criteria and to be selected as current peer. The CSJ dynamo, being
+-- always ahead of jumpers, has therefore more chances to be selected as the
+-- current peer. It is still possible for a jumper or a disengaged peer to be
+-- selected.
+--
+-- If the current peer is the CSJ dynamo and it is a dishonest peer that retains
+-- blocks, it will get multiple opportunities to do so since it will be selected
+-- as the current peer more often. We therefore rotate the dynamo every time it
+-- is the current peer and it fails to serve blocks promptly.
+--
+-- About the gross request
+-- -----------------------
+--
+-- We want to select a peer that is able to serve us a batch of oldest blocks
+-- of @theCandidate@. However, not every peer will be able to deliver these
+-- batches as they might be on different chains. We therefore select a peer only
+-- if its candidate fragment contains the block in the gross request. In this
+-- way, we ensure that the peer can serve at least one block that we wish to
+-- fetch.
+--
+-- If the peer cannot offer any more blocks after that, it will be rotated out
+-- soon.
+--
+module Ouroboros.Network.BlockFetch.Decision.Genesis (fetchDecisionsGenesisM) where
+
+import Control.Exception (assert)
+import Control.Monad (guard)
+import Control.Monad.Class.MonadTime.SI (MonadMonotonicTime (getMonotonicTime),
+           addTime)
+import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
+import Control.Monad.Trans.Writer.CPS (Writer, runWriter, tell)
+import Control.Tracer (Tracer, traceWith)
+import Data.Bifunctor (Bifunctor (..), first)
+import Data.DList (DList)
+import Data.DList qualified as DList
+import Data.Foldable (find, toList)
+import Data.List qualified as List
+import Data.Maybe (maybeToList)
+import Data.Sequence (Seq (..), (<|), (><), (|>))
+import Data.Sequence qualified as Sequence
+import Data.Set qualified as Set
+
+import Cardano.Prelude (partitionEithers)
+
+import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
+import Ouroboros.Network.AnchoredFragment qualified as AF
+import Ouroboros.Network.Block
+import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
+           PeerFetchInFlight (..), PeersOrder (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
+import Ouroboros.Network.BlockFetch.DeltaQ (calculatePeerFetchInFlightLimits)
+
+import Cardano.Slotting.Slot (WithOrigin)
+import Ouroboros.Network.BlockFetch.Decision
+import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent (..))
+
+type WithDeclined peer = Writer (DList (FetchDecline, peer))
+
+runWithDeclined :: WithDeclined peer a -> (a, DList (FetchDecline, peer))
+runWithDeclined = runWriter
+
+fetchDecisionsGenesisM
+  :: forall peer header block m extra.
+     (Ord peer,
+      HasHeader header,
+      HeaderHash header ~ HeaderHash block, MonadMonotonicTime m)
+  => Tracer m (TraceDecisionEvent peer header)
+  -> FetchDecisionPolicy header
+  -> AnchoredFragment header
+  -> (Point block -> Bool)
+     -- ^ Whether the block has been fetched (only if recent, i.e. within @k@).
+  -> MaxSlotNo
+  -> ChainSelStarvation
+  -> ( PeersOrder peer
+     , PeersOrder peer -> m ()
+     , peer -> m ()
+     )
+  -> [(AnchoredFragment header, PeerInfo header peer extra)]
+  -> m [(FetchDecision (FetchRequest header), PeerInfo header peer extra)]
+fetchDecisionsGenesisM
+  tracer
+  fetchDecisionPolicy@FetchDecisionPolicy {bulkSyncGracePeriod}
+  currentChain
+  fetchedBlocks
+  fetchedMaxSlotNo
+  chainSelStarvation
+  ( peersOrder0,
+    writePeersOrder,
+    demoteCSJDynamo
+    )
+  candidatesAndPeers = do
+    peersOrder1 <- checkLastChainSelStarvation peersOrder0
+
+    let (peersOrder, orderedCandidatesAndPeers) =
+          alignPeersOrderWithActualPeers
+            (peerInfoPeer . snd)
+            (Sequence.fromList candidatesAndPeers)
+            peersOrder1
+
+    -- Compute the actual block fetch decision. This contains only declines and
+    -- at most one request. 'theDecision' is therefore a 'Maybe'.
+    let (theDecision, declines) =
+          fetchDecisionsGenesis
+            fetchDecisionPolicy
+            currentChain
+            fetchedBlocks
+            fetchedMaxSlotNo
+            (toList orderedCandidatesAndPeers)
+
+        newCurrentPeer = peerInfoPeer . snd <$> theDecision
+
+    case theDecision of
+      Just (_, (_, inflight, _, _, _))
+        | Set.null (peerFetchBlocksInFlight inflight)
+       -- If there were no blocks in flight, then this will be the first request,
+       -- so we take a new current time.
+       -> do
+          peersOrderStart <- getMonotonicTime
+          writePeersOrder $ setCurrentPeer newCurrentPeer peersOrder
+            { peersOrderStart }
+        | newCurrentPeer /= peersOrderCurrent peersOrder0
+       -- If the new current peer is not the old one, then we update the current
+       -- peer
+       ->
+          writePeersOrder $ setCurrentPeer newCurrentPeer peersOrder
+      _ -> pure ()
+
+    pure $
+      map (first Right) (maybeToList theDecision)
+        ++ map (first Left) declines
+    where
+      -- Align the peers order with the actual peers; this consists in removing
+      -- all peers from the peers order that are not in the actual peers list and
+      -- adding at the end of the peers order all the actual peers that were not
+      -- there before.
+      alignPeersOrderWithActualPeers
+        :: forall d.
+           (d -> peer)
+        -> Seq d
+        -> PeersOrder peer
+        -> (PeersOrder peer, Seq d)
+      alignPeersOrderWithActualPeers
+        peerOf
+        actualPeers
+        PeersOrder {peersOrderStart, peersOrderCurrent, peersOrderAll} =
+          let peersOrderAll' :: Seq d
+              peersOrderAll' =
+                    foldr (\p ds ->
+                            case find ((p ==) . peerOf) actualPeers of
+                              Just d  -> d <| ds
+                              Nothing -> ds
+                          )
+                          Sequence.empty
+                          peersOrderAll
+                 >< Sequence.filter ((`notElem` peersOrderAll) . peerOf) actualPeers
+              -- Set the current peer to Nothing if it is not at the front of
+              -- the list.
+              peersOrderCurrent' :: Maybe peer
+              peersOrderCurrent' = do
+                peer <- peersOrderCurrent
+                guard $ case peersOrderAll' of
+                  d Sequence.:<| _ -> peerOf d == peer
+                  Sequence.Empty   -> False
+                pure peer
+           in (PeersOrder
+                { peersOrderCurrent = peersOrderCurrent',
+                  -- INVARIANT met: Current peer is at the front if it exists
+                  peersOrderAll = fmap peerOf peersOrderAll',
+                  peersOrderStart
+                }
+              , peersOrderAll'
+              )
+
+      -- If the chain selection has been starved recently, that is after the
+      -- current peer started (and a grace period), then the current peer is
+      -- bad. We push it at the end of the queue, demote it from CSJ dynamo,
+      -- and ignore its in-flight blocks for the future.
+      checkLastChainSelStarvation :: PeersOrder peer -> m (PeersOrder peer)
+      checkLastChainSelStarvation
+        peersOrder@PeersOrder {peersOrderStart, peersOrderCurrent, peersOrderAll} = do
+          lastStarvationTime <- case chainSelStarvation of
+            ChainSelStarvationEndedAt time -> pure time
+            ChainSelStarvationOngoing      -> getMonotonicTime
+          case peersOrderCurrent of
+            Just peer
+              | lastStarvationTime >= addTime bulkSyncGracePeriod peersOrderStart -> do
+                  traceWith tracer (PeerStarvedUs peer)
+                  demoteCSJDynamo peer
+                  pure PeersOrder
+                         {
+                           peersOrderCurrent = Nothing,
+                           -- INVARIANT met: there is no current peer
+                           peersOrderAll = Sequence.drop 1 peersOrderAll |> peer,
+                           peersOrderStart
+                         }
+            _ -> pure peersOrder
+
+      setCurrentPeer :: Maybe peer -> PeersOrder peer -> PeersOrder peer
+      setCurrentPeer Nothing peersOrder = peersOrder {peersOrderCurrent = Nothing}
+      setCurrentPeer (Just peer) peersOrder =
+        case Sequence.breakl (peer ==) (peersOrderAll peersOrder) of
+          (xs, p :<| ys) ->
+            peersOrder
+              { peersOrderCurrent = Just p,
+                -- INVARIANT met: Current peer is at the front
+                peersOrderAll = p <| xs >< ys
+              }
+          (_, Empty) -> peersOrder {peersOrderCurrent = Nothing}
+
+-- | Given a list of candidate fragments and their associated peers, choose what
+-- to sync from who in the bulk sync mode.
+fetchDecisionsGenesis
+  :: forall header block peer extra.
+     ( HasHeader header
+     , HeaderHash header ~ HeaderHash block
+     )
+  => FetchDecisionPolicy header
+  -> AnchoredFragment header
+     -- ^ The current chain, anchored at the immutable tip.
+  -> (Point block -> Bool)
+     -- ^ Whether the block has been fetched (only if recent, i.e. within @k@).
+  -> MaxSlotNo
+  -> [(AnchoredFragment header, PeerInfo header peer extra)]
+     -- ^ Association list of the candidate fragments and their associated peers.
+     -- The candidate fragments are anchored in the current chain (not necessarily
+     -- at the tip; and not necessarily forking off immediately).
+  -> ( Maybe (FetchRequest header, PeerInfo header peer extra),
+       [(FetchDecline, PeerInfo header peer extra)]
+     )
+     -- ^ Association list of the requests and their associated peers. There is at
+     -- most one accepted request; everything else is declined. Morally, this is a
+     -- map from peers to @'FetchDecision' ('FetchRequest' header)@ with at most
+     -- one @'FetchRequest' header@.
+fetchDecisionsGenesis
+  fetchDecisionPolicy
+  currentChain
+  fetchedBlocks
+  fetchedMaxSlotNo
+  candidatesAndPeers = combineWithDeclined $ do
+    -- Step 1: Select the candidate to sync from. This already eliminates peers
+    -- that have an implausible candidate. It returns the remaining candidates
+    -- (with their corresponding peer) as suffixes of the immutable tip.
+    ( theCandidate :: ChainSuffix header,
+      candidatesAndPeers' :: [(ChainSuffix header, PeerInfo header peer extra)]
+      ) <-
+      MaybeT $
+        selectTheCandidate
+          fetchDecisionPolicy
+          currentChain
+          candidatesAndPeers
+
+    -- Step 2: Filter out from the chosen candidate fragment the blocks that
+    -- have already been downloaded. NOTE: if not declined, @theFragments@ is
+    -- guaranteed to be non-empty.
+    theFragments :: CandidateFragments header
+      <- MaybeT $ dropAlreadyFetchedBlocks candidatesAndPeers' theCandidate
+
+    -- Step 3: Select the peer to sync from. This eliminates peers that cannot
+    -- serve a reasonable batch of the candidate, then chooses the peer to sync
+    -- from, then again declines the others.
+    ( thePeerCandidate :: ChainSuffix header,
+      thePeer :: PeerInfo header peer extra
+      ) <-
+      MaybeT $ selectThePeer theFragments candidatesAndPeers'
+
+    -- Step 4: Fetch the candidate from the selected peer, potentially declining
+    -- it (eg. if the peer is already too busy).
+    MaybeT $
+      makeFetchRequest
+        fetchDecisionPolicy
+        theFragments
+        thePeer
+        thePeerCandidate
+    where
+      combineWithDeclined
+        :: forall peerInfo a.
+           MaybeT (WithDeclined peerInfo) (a, peerInfo)
+        -> ( Maybe (a, peerInfo),
+             [(FetchDecline, peerInfo)]
+           )
+      combineWithDeclined = second DList.toList . runWithDeclined . runMaybeT
+
+      dropAlreadyFetchedBlocks
+        :: forall peerInfo.
+           [(ChainSuffix header, peerInfo)]
+        -> ChainSuffix header
+        -> WithDeclined peerInfo (Maybe (CandidateFragments header))
+      dropAlreadyFetchedBlocks candidatesAndPeers' theCandidate =
+        case dropAlreadyFetched fetchedBlocks fetchedMaxSlotNo theCandidate of
+          Left reason -> do
+            tell (DList.fromList [(reason, peerInfo) | (_, peerInfo) <- candidatesAndPeers'])
+            pure Nothing
+          Right theFragments -> pure (Just theFragments)
+
+-- | Find the fragments of the chain suffix that we still need to fetch because
+-- they are covering blocks that have not yet been fetched.
+--
+-- Typically this is a single fragment forming a suffix of the chain, but in
+-- the general case we can get a bunch of discontiguous chain fragments.
+--
+-- See also 'dropAlreadyInFlightWithPeer'.
+-- Similar to 'filterNotAlreadyFetched'.
+dropAlreadyFetched
+  :: (HasHeader header, HeaderHash header ~ HeaderHash block)
+  => (Point block -> Bool)
+     -- ^ Whether the block has been fetched (only if recent, i.e. within @k@).
+  -> MaxSlotNo
+  -> ChainSuffix header
+  -> FetchDecision (CandidateFragments header)
+dropAlreadyFetched alreadyDownloaded fetchedMaxSlotNo candidate =
+  if null fragments
+    then Left FetchDeclineAlreadyFetched
+    else Right (candidate, fragments)
+  where
+    fragments = filterWithMaxSlotNo notAlreadyFetched fetchedMaxSlotNo (getChainSuffix candidate)
+    notAlreadyFetched = not . alreadyDownloaded . castPoint . blockPoint
+
+-- | Given a list of candidate fragments and their associated peers, select the
+-- candidate to sync from. Return this fragment, the list of peers that are
+-- still in race to serve it, and the list of peers that are already being
+-- declined.
+selectTheCandidate
+  :: forall header peerInfo.
+     HasHeader header
+  => FetchDecisionPolicy header
+  -> AnchoredFragment header
+     -- ^ The current chain.
+  -> [(AnchoredFragment header, peerInfo)]
+     -- ^ The candidate fragments and their associated peers.
+  -> WithDeclined
+       peerInfo
+       (Maybe (ChainSuffix header, [(ChainSuffix header, peerInfo)]))
+     -- ^ The pair of: (a) a list of peers that we have decided are not right,
+     -- eg. because they presented us with a chain forking too deep, and (b) the
+     -- selected candidate that we choose to sync from and a list of peers that
+     -- are still in the race to serve that candidate.
+selectTheCandidate
+  FetchDecisionPolicy {compareCandidateChains, plausibleCandidateChain}
+  currentChain =
+        separateDeclinedAndStillInRace
+        -- Select the suffix up to the intersection with the current chain. This can
+        -- eliminate candidates that fork too deep.
+      . selectForkSuffixes currentChain
+        -- Filter to keep chains the consensus layer tells us are plausible.
+      . filterPlausibleCandidates plausibleCandidateChain currentChain
+    where
+      -- Write all of the declined peers, and find the longest candidate
+      -- fragment if there is any.
+      separateDeclinedAndStillInRace
+        :: [(FetchDecision (ChainSuffix header), peerInfo)]
+        -> WithDeclined peerInfo (Maybe (ChainSuffix header, [(ChainSuffix header, peerInfo)]))
+      separateDeclinedAndStillInRace decisions = do
+        let (declined, inRace) = partitionEithers
+              [ bimap (,p) (,p) d | (d, p) <- decisions ]
+        tell (DList.fromList declined)
+        case inRace of
+          [] -> pure Nothing
+          _ : _ -> do
+            let maxChainOn f c0 c1 = case compareCandidateChains (f c0) (f c1) of
+                  LT -> c1
+                  _  -> c0
+                -- maximumBy yields the last element in case of a tie while we
+                -- prefer the first one
+                chainSfx = fst $
+                  List.foldl1' (maxChainOn (getChainSuffix . fst)) inRace
+            pure $ Just (chainSfx, inRace)
+
+-- | Given _the_ candidate fragment to sync from, and a list of peers (with
+-- their corresponding candidate fragments), choose which peer to sync _the_
+-- candidate fragment from.
+--
+-- We first filter out all the peers that cannot even serve a reasonable batch
+-- of _the_ candidate fragment, and then we choose the first one according to
+-- the ordering passed as argument.
+--
+-- PRECONDITION: The set of peers must be included in the peer order queue.
+-- PRECONDITION: The given candidate fragments must not be empty.
+selectThePeer
+  :: forall header peer extra.
+     HasHeader header
+  => CandidateFragments header
+  -> [(ChainSuffix header, PeerInfo header peer extra)]
+     -- ^ The candidate fragment that we have selected to sync from, as suffix
+     -- of the immutable tip.
+  -> WithDeclined
+       (PeerInfo header peer extra)
+       (Maybe (ChainSuffix header, PeerInfo header peer extra))
+     -- ^ Association list of candidate fragments (as suffixes of the immutable
+     -- tip) and their associated peers.
+selectThePeer
+  theFragments
+  candidates = do
+    -- Create a fetch request for the blocks in question. The request has exactly
+    -- 1 block. It will only be used to choose the peer to fetch from, but we will
+    -- later craft a more refined request for that peer. See [About the gross
+    -- request] in the module documentation. Because @theFragments@ is not
+    -- empty, and does not contain empty fragments, @grossRequest@ will not be empty.
+    let firstBlock :: [AF.AnchoredSeq (WithOrigin SlotNo) (AF.Anchor header) header]
+                   -> [AF.AnchoredSeq (WithOrigin SlotNo) (AF.Anchor header) header]
+        firstBlock = map (AF.takeOldest 1) . take 1 . filter (not . AF.null)
+
+        fetchRequestFragments :: [AF.AnchoredSeq (WithOrigin SlotNo) (AF.Anchor header) header]
+        fetchRequestFragments = firstBlock $ snd theFragments
+
+        grossRequest :: FetchRequest header
+        grossRequest = assert (all (not . AF.null) fetchRequestFragments)
+                     $ FetchRequest { fetchRequestFragments }
+
+    -- Return the first peer that can serve the gross request and decline
+    -- the other peers.
+    go grossRequest candidates
+  where
+    go grossRequest (c@(candidate, peerInfo) : xs) = do
+      if grossRequest `requestHeadInCandidate` candidate then do
+        tell $ DList.fromList
+          [(FetchDeclineConcurrencyLimit FetchModeBulkSync 1, pInfo)
+          | (_, pInfo) <- xs
+          ]
+        pure (Just c)
+      else do
+        tell $ DList.fromList [(FetchDeclineAlreadyFetched, peerInfo)]
+        go grossRequest xs
+    go _grossRequest [] = pure Nothing
+
+
+    requestHeadInCandidate :: FetchRequest header -> ChainSuffix header -> Bool
+    requestHeadInCandidate request candidate =
+      case fetchRequestFragments request of
+        fragments@(_:_)
+          | AF.withinFragmentBounds
+              (AF.headPoint $ last fragments)
+              (getChainSuffix candidate)
+          ->
+            True
+        _ ->
+            False
+
+-- | Given a candidate and a peer to sync from, create a request for that
+-- specific peer. We might take the 'FetchDecision' to decline the request, but
+-- only for “good” reasons, eg. if the peer is already too busy.
+makeFetchRequest
+  :: HasHeader header
+  => FetchDecisionPolicy header
+  -> CandidateFragments header
+     -- ^ The candidate fragment that we have selected to sync from, as suffix of
+     -- the immutable tip.
+  -> PeerInfo header peer extra
+     -- ^ The peer that we have selected to sync from.
+  -> ChainSuffix header
+     -- ^ Its candidate fragment as suffix of the immutable tip.
+  -> WithDeclined
+       (PeerInfo header peer extra)
+       (Maybe (FetchRequest header, PeerInfo header peer extra))
+makeFetchRequest
+  fetchDecisionPolicy
+  theFragments
+  thePeer@(status, inflight, gsvs, _, _)
+  thePeerCandidate =
+    let theDecision = do
+          -- Drop blocks that are already in-flight with this peer.
+          fragments <- dropAlreadyInFlightWithPeer inflight theFragments
+
+          -- Trim the fragments to the peer's candidate, keeping only blocks that
+          -- they may actually serve.
+          trimmedFragments <- snd fragments `trimFragmentsToCandidate` thePeerCandidate
+
+          -- Try to create a request for those fragments.
+          fetchRequestDecision
+            fetchDecisionPolicy
+            FetchModeBulkSync
+            0 -- bypass all concurrency limits.
+            (calculatePeerFetchInFlightLimits gsvs)
+            inflight
+            status
+            (Right trimmedFragments)
+     in case theDecision of
+          Left reason -> tell (DList.fromList [(reason, thePeer)]) >> pure Nothing
+          Right theRequest -> pure $ Just (theRequest, thePeer)
+    where
+      trimFragmentsToCandidate fragments candidate =
+        let trimmedFragments =
+              [ prefix
+              | fragment <- fragments
+              , Just (_, prefix, _, _) <- [AF.intersect (getChainSuffix candidate) fragment]
+              , not (AF.null prefix)
+              ]
+         in if null trimmedFragments
+              then Left FetchDeclineAlreadyFetched
+              else Right trimmedFragments
+
+-- | Find the fragments of the chain suffix that we still need to fetch because
+-- they are covering blocks that are not currently in the process of being
+-- fetched from this peer.
+--
+-- Typically this is a single fragment forming a suffix of the chain, but in
+-- the general case we can get a bunch of discontiguous chain fragments.
+--
+-- See also 'dropAlreadyFetched'
+-- Similar to 'filterNotAlreadyInFlightWithPeer'.
+dropAlreadyInFlightWithPeer ::
+  (HasHeader header) =>
+  PeerFetchInFlight header ->
+  CandidateFragments header ->
+  FetchDecision (CandidateFragments header)
+dropAlreadyInFlightWithPeer inflight (candidate, chainfragments) =
+  if null fragments
+    then Left FetchDeclineInFlightThisPeer
+    else Right (candidate, fragments)
+  where
+    fragments = concatMap (filterWithMaxSlotNo notAlreadyInFlight (peerFetchMaxSlotNo inflight)) chainfragments
+    notAlreadyInFlight b = blockPoint b `Set.notMember` peerFetchBlocksInFlight inflight

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Trace.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Trace.hs
@@ -1,0 +1,10 @@
+module Ouroboros.Network.BlockFetch.Decision.Trace where
+
+import Ouroboros.Network.Block (Point)
+import Ouroboros.Network.BlockFetch.ClientState (TraceLabelPeer)
+import Ouroboros.Network.BlockFetch.Decision (FetchDecision)
+
+data TraceDecisionEvent peer header
+  = PeersFetch [TraceLabelPeer peer (FetchDecision [Point header])]
+  | PeerStarvedUs peer
+  deriving (Show)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/State.hs
@@ -13,6 +13,7 @@ module Ouroboros.Network.BlockFetch.State
   , FetchDecision
   , FetchDecline (..)
   , FetchMode (..)
+  , PraosFetchMode (..)
   , TraceLabelPeer (..)
   , TraceFetchClientState (..)
   ) where
@@ -43,10 +44,10 @@ import Ouroboros.Network.BlockFetch.ClientState (FetchClientStateVars (..),
            PeersOrder (..), TraceFetchClientState (..), TraceLabelPeer (..),
            addNewFetchRequest, readFetchClientState)
 import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation,
-           GenesisFetchMode (..))
+           FetchMode (..))
 import Ouroboros.Network.BlockFetch.Decision (FetchDecision,
-           FetchDecisionPolicy (..), FetchDecline (..), FetchMode (..),
-           PeerInfo, fetchDecisions)
+           FetchDecisionPolicy (..), FetchDecline (..), PeerInfo,
+           PraosFetchMode (..), fetchDecisions)
 import Ouroboros.Network.BlockFetch.Decision.Genesis (fetchDecisionsGenesisM)
 import Ouroboros.Network.BlockFetch.Decision.Trace
 import Ouroboros.Network.BlockFetch.DeltaQ (PeerGSV (..))
@@ -129,7 +130,7 @@ fetchLogicIteration
   -> FetchStateFingerprint peer header block
   -> StrictTVar m (PeersOrder peer)
   -> (peer -> m ()) -- ^ Action to call to demote the dynamo of ChainSync jumping.
-  -> m (FetchStateFingerprint peer header block, GenesisFetchMode)
+  -> m (FetchStateFingerprint peer header block, FetchMode)
 fetchLogicIteration decisionTracer clientStateTracer
                     fetchDecisionPolicy
                     fetchTriggerVariables
@@ -312,7 +313,7 @@ data FetchNonTriggerVariables peer header block m = FetchNonTriggerVariables {
        readStateFetchedBlocks    :: STM m (Point block -> Bool),
        readStatePeerStateVars    :: STM m (Map peer (FetchClientStateVars m header)),
        readStatePeerGSVs         :: STM m (Map peer PeerGSV),
-       readStateFetchMode        :: STM m GenesisFetchMode,
+       readStateFetchMode        :: STM m FetchMode,
        readStateFetchedMaxSlotNo :: STM m MaxSlotNo,
        readStateChainSelStarvation :: STM m ChainSelStarvation
      }
@@ -356,7 +357,7 @@ data FetchStateSnapshot peer header block m = FetchStateSnapshot {
                                                FetchClientStateVars m header),
        fetchStatePeerGSVs         :: Map peer PeerGSV,
        fetchStateFetchedBlocks    :: Point block -> Bool,
-       fetchStateFetchMode        :: GenesisFetchMode,
+       fetchStateFetchMode        :: FetchMode,
        fetchStateFetchedMaxSlotNo :: MaxSlotNo,
        fetchStateChainSelStarvation :: ChainSelStarvation
      }

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
@@ -44,7 +44,8 @@ module Ouroboros.Network.Diffusion.Configuration
 import Control.Monad.Class.MonadTime.SI
 import System.Random (randomRIO)
 
-import Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..))
+import Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
+           GenesisBlockFetchConfiguration (..))
 import Ouroboros.Network.ConnectionManager.Core (defaultProtocolIdleTimeout,
            defaultResetTimeout, defaultTimeWaitTimeout)
 import Ouroboros.Network.ConsensusMode
@@ -144,7 +145,10 @@ defaultBlockFetchConfiguration bfcSalt =
     bfcMaxConcurrencyBulkSync = 1,
     bfcMaxConcurrencyDeadline = 1,
     bfcMaxRequestsInflight    = fromIntegral $ blockFetchPipeliningMax defaultMiniProtocolParameters,
-    bfcDecisionLoopInterval   = 0.01, -- 10ms
+    bfcDecisionLoopIntervalGenesis = 0.04,  -- 40ms
+    bfcDecisionLoopIntervalPraos = 0.01,  -- 10ms
+    bfcGenesisBFConfig        = GenesisBlockFetchConfiguration
+      { gbfcGracePeriod = 10 },  -- seconds
     bfcSalt }
 
 defaultChainSyncTimeout :: IO ChainSyncTimeout

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -71,7 +71,7 @@ import Ouroboros.Network.Snocket (FileDescriptor, LocalAddress,
            makeLocalBearer, makeSocketBearer)
 import Ouroboros.Network.Snocket qualified as Snocket
 
-import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode)
+import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode)
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.Context (ExpandedInitiatorContext, ResponderContext)
 import Ouroboros.Network.Protocol.Handshake
@@ -361,7 +361,7 @@ data ApplicationsExtra ntnAddr m a =
 
     -- | Used by churn-governor
     --
-    , daBlockFetchMode      :: STM m GenesisFetchMode
+    , daBlockFetchMode      :: STM m FetchMode
 
     -- | Used for peer sharing protocol
     --

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -71,7 +71,7 @@ import Ouroboros.Network.Snocket (FileDescriptor, LocalAddress,
            makeLocalBearer, makeSocketBearer)
 import Ouroboros.Network.Snocket qualified as Snocket
 
-import Ouroboros.Network.BlockFetch
+import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode)
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.Context (ExpandedInitiatorContext, ResponderContext)
 import Ouroboros.Network.Protocol.Handshake
@@ -361,7 +361,7 @@ data ApplicationsExtra ntnAddr m a =
 
     -- | Used by churn-governor
     --
-    , daBlockFetchMode      :: STM m FetchMode
+    , daBlockFetchMode      :: STM m GenesisFetchMode
 
     -- | Used for peer sharing protocol
     --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
@@ -31,6 +31,7 @@ import Control.Applicative (Alternative)
 import Data.Functor (($>))
 import Data.Monoid.Synchronisation (FirstToFinish (..))
 import Ouroboros.Network.BlockFetch (FetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode (..))
 import Ouroboros.Network.ConsensusMode (ConsensusMode (..))
 import Ouroboros.Network.Diffusion.Policies (churnEstablishConnectionTimeout,
            closeConnectionTimeout, deactivateTimeout)
@@ -90,7 +91,7 @@ data PeerChurnArgs m peeraddr = PeerChurnArgs {
   pcaMetrics             :: PeerMetrics m peeraddr,
   pcaModeVar             :: StrictTVar m ChurnMode,
   pcaRng                 :: StdGen,
-  pcaReadFetchMode       :: STM m FetchMode,
+  pcaReadFetchMode       :: STM m GenesisFetchMode,
   peerTargets            :: ConsensusModePeerTargets,
   pcaPeerSelectionVar    :: StrictTVar m PeerSelectionTargets,
   pcaReadCounters        :: STM m PeerSelectionCounters,
@@ -156,8 +157,9 @@ peerChurnGovernor PeerChurnArgs {
     updateChurnMode = do
         fm <- getFetchMode
         let mode = case fm of
-                     FetchModeDeadline -> ChurnModeNormal
-                     FetchModeBulkSync -> ChurnModeBulkSync
+                     PraosFetchMode FetchModeDeadline -> ChurnModeNormal
+                     PraosFetchMode FetchModeBulkSync -> ChurnModeBulkSync
+                     FetchModeGenesis                 -> ChurnModeBulkSync
         writeTVar churnModeVar mode
         return mode
 
@@ -593,9 +595,9 @@ peerChurnGovernor PeerChurnArgs {
       mode <- atomically getFetchMode
       -- todo: is this right?
       case (mode, consensusMode) of
-        (FetchModeDeadline, _) -> longDelay rng execTime
-        (_, GenesisMode)       -> longDelay rng execTime
-        _otherwise             -> shortDelay rng execTime
+        (PraosFetchMode FetchModeDeadline, _) -> longDelay rng execTime
+        (_, GenesisMode)                      -> longDelay rng execTime
+        _otherwise                            -> shortDelay rng execTime
 
 
     fuzzyDelay' :: DiffTime -> Double -> StdGen -> DiffTime -> m StdGen

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Churn.hs
@@ -30,8 +30,8 @@ import System.Random
 import Control.Applicative (Alternative)
 import Data.Functor (($>))
 import Data.Monoid.Synchronisation (FirstToFinish (..))
-import Ouroboros.Network.BlockFetch (FetchMode (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (GenesisFetchMode (..))
+import Ouroboros.Network.BlockFetch (PraosFetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..))
 import Ouroboros.Network.ConsensusMode (ConsensusMode (..))
 import Ouroboros.Network.Diffusion.Policies (churnEstablishConnectionTimeout,
            closeConnectionTimeout, deactivateTimeout)
@@ -91,7 +91,7 @@ data PeerChurnArgs m peeraddr = PeerChurnArgs {
   pcaMetrics             :: PeerMetrics m peeraddr,
   pcaModeVar             :: StrictTVar m ChurnMode,
   pcaRng                 :: StdGen,
-  pcaReadFetchMode       :: STM m GenesisFetchMode,
+  pcaReadFetchMode       :: STM m FetchMode,
   peerTargets            :: ConsensusModePeerTargets,
   pcaPeerSelectionVar    :: StrictTVar m PeerSelectionTargets,
   pcaReadCounters        :: STM m PeerSelectionCounters,


### PR DESCRIPTION
This pull request implements a BlockFetch logic to use when synchronizing peers with Genesis.

BlockFetch needs to penalize peers that are slow enough to delay syncing in order to fend from attacks targeting the synchronizing nodes.

The penalization consists in switching the serving peer when blocks are in flight long enough that the syncing node is idle while waiting for more blocks to validate.

Switching peers, in turn, requires organizing peers in a queue, where blocks are retrieved from the first peer in the queue that can serve them, and any time a peer is penalized, it is moved to the end of the queue. 

Most of the implementation is in the first commit where the implementation of BulkSync mode is replaced. Probably the best file to approach the implementation is `ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/BulkSync.hs`. There are supporting commits to split large modules into smaller ones, and to update the tests related to the BulkSync mode.
