### PR TITLE
ouroboros-network-api has to have a major version bump

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -22,7 +22,7 @@ library
   build-depends:       base              >=4.14 && <4.21,
                        bytestring        >=0.10 && <0.13,
                        containers,
-                       ouroboros-network-api        >= 0.5.2 && < 0.8,
+                       ouroboros-network-api        >= 0.5.2 && < 0.9,
                        ouroboros-network            >= 0.9 && < 0.18,
                        ouroboros-network-framework  >= 0.8 && < 0.14,
                        network-mux                 ^>= 0.4.5,

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## next release
 
-## 0.7.4.0 -- 2024-08
+## 0.8.0.0 -- 2024-08
 
 ### Breaking changes
+
+* `LedgerPeersKind` was transplanted here from o-network because this
+  functionality needs to be exposed in support of Genesis work and
+  generation of a big ledger peer snapshot.
 
 ### Non-Breaking changes
 

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network-api
-version:                0.7.4.0
+version:                0.8.0.0
 synopsis:               A networking api shared with ouroboros-consensus
 description:            A networking api shared with ouroboros-consensus.
 license:                Apache-2.0

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -100,7 +100,7 @@ library
                      , network        ^>=3.1.4
                      , network-mux    ^>=0.4.5
                      , ouroboros-network-api
-                                      ^>=0.7.0
+                                      ^>=0.8.0
                      , ouroboros-network-testing
                      , typed-protocols ^>=0.1.1
                      , typed-protocols-cborg

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -105,7 +105,7 @@ library
                        si-timers,
 
                        ouroboros-network-api
-                                        ^>=0.7.0,
+                                        ^>=0.8.0,
                        serialise,
                        typed-protocols  ^>=0.1.1,
                        typed-protocols-cborg

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -134,7 +134,7 @@ library
                        io-classes-mtl   ^>=0.1,
                        network-mux,
                        si-timers,
-                       ouroboros-network-api       ^>=0.7.4,
+                       ouroboros-network-api       ^>=0.8.0,
                        ouroboros-network-framework ^>=0.13.2.2,
                        ouroboros-network-protocols ^>=0.10,
                        strict-stm,


### PR DESCRIPTION
# Description

LedgerPeersKind was transplanted from ouroboros-network into o-n-api.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
