### PR TITLE
Expose transaction size to tx submission

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -23,6 +23,9 @@
 * Added `daMinBigLedgerPeersForTrustedState` to `ArgumentsExtra` when starting diffusion.
   It is used by `outboundConnectionsState` when signaling trust state when syncing in
   Genesis mode. Default value is provided by the Configuration module.
+* `txSubmissionInbound` takes an additional callback which exposes
+  CBOR-encoded transaction size as it is when transmitted over the
+  network, except for some top level wrapping (cf. PR#4926 description)
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Outbound.hs
@@ -27,6 +27,7 @@ import Ouroboros.Network.ControlMessage (ControlMessage, ControlMessageSTM,
            timeoutWithControlMessage)
 import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.TxSubmission2.Client
+import Ouroboros.Network.SizeInBytes
 import Ouroboros.Network.Protocol.TxSubmission2.Type
 import Ouroboros.Network.TxSubmission.Mempool.Reader (MempoolSnapshot (..),
            TxSubmissionMempoolReader (..))


### PR DESCRIPTION
# Description

A callback, exposing CBOR-encoded transaction size as it is when transmitted over the network, is provided to 
tx submission inbound and outbound handlers. The size returned by this function does not take into account some additional wrapping that happens when a transaction is sent across the network. Namely, it does not include header data for CBOR-in-CBOR encoding (a tag + it's value to indicate a blob payload, and an encodeBytes tag ~ so roughly 3 words) neither the top level header which consists of EncodeListLen tag + it's value, era word tag + era index word, so ~4 words).

IntersectMBO/cardano-ledger#4521
IntersectMBO/ouroboros-consensus#1211

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
