### PR TITLE
TxSubmission - add initial delay before requesting transactions

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -40,6 +40,7 @@
   a mismatch detected. 
 * Added `defaultDeadlineChurnInterval` and `defaultBulkChurnInterval` to Configuration
   module. Previously these were hard coded in node.
+* Added initial delay before requesting transactions in TxSubmission protocol
 
 ## 0.17.0.0 -- 2024-08-07
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -18,6 +18,11 @@ flag asserts
   manual:      False
   default:     False
 
+flag txsubmission-delay
+  description: Delay initial request for transactions from outbound/client peer
+  manual:      True
+  default:     True
+
 source-repository head
   type:     git
   location: https://github.com/intersectmbo/ouroboros-network
@@ -154,6 +159,9 @@ library
                        -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
+
+  if flag(txsubmission-delay)
+    cpp-options:       -DTXSUBMISSION_DELAY
 
 
 -- Simulation Test Library


### PR DESCRIPTION
# Description

We delay initial request for transactions from a client to conserve network resources in case he disconnects relatively quickly for reasons in the referenced issue.

resolves #4927 

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
