### PR TITLE
check-stylish: use git but not on hydra (nix)

### DIFF
--- a/nix/check-stylish.nix
+++ b/nix/check-stylish.nix
@@ -10,7 +10,7 @@ runCommand "check-stylish" {
 } ''
   unpackPhase
   cd $sourceRoot
-  bash ./scripts/ci/check-stylish.sh
+  bash ./scripts/ci/check-stylish.sh -g
   diff -ru $src .
 
   EXIT_CODE=$?

--- a/scripts/ci/check-stylish.sh
+++ b/scripts/ci/check-stylish.sh
@@ -9,19 +9,24 @@ function usage {
   echo "        -u                        only check files uncommitted"
   echo "        -c                        only check files committed in HEAD"
   echo "        -h                        this help message"
+  echo "        -g                        don't use git"
   exit
 }
 
 export LC_ALL=C.UTF-8
 
 STYLISH_HASKELL_ARGS="-c .stylish-haskell-network.yaml -i"
+USE_GIT=1
 
-optstring=":uch"
+optstring=":uchg"
 while getopts ${optstring} arg; do
   case ${arg} in
     h)
       usage;
       exit 0
+      ;;
+    g)
+      USE_GIT=0
       ;;
     c)
       PATHS=$(git show --pretty='' --name-only HEAD)
@@ -35,6 +40,9 @@ while getopts ${optstring} arg; do
           fi
         fi
       done
+      if [ $USE_GIT == 1 ]; then
+        git --no-pager diff --exit-code
+      fi
       exit 0
       ;;
     u)
@@ -49,6 +57,9 @@ while getopts ${optstring} arg; do
           fi
         fi
       done
+      if [ $USE_GIT == 1 ]; then
+        git --no-pager diff --exit-code
+      fi
       exit 0
       ;;
     ?)
@@ -69,3 +80,7 @@ fd . './ouroboros-network-mock'      $FD_OPTS
 fd . './ouroboros-network-protocols' $FD_OPTS
 fd . './ouroboros-network'           $FD_OPTS
 fd . './cardano-client'              $FD_OPTS
+
+if [ $USE_GIT == 1 ]; then
+git --no-pager diff --exit-code
+fi


### PR DESCRIPTION
# Description

Our `./scripts/ci/check-stylish.sh` script can show the diff, but only if it
doesn't run through `nix` where repo is not cloned / checked out.  Now it will
also exit with non-zero exit code if the diff is non-empty.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
