### PR TITLE
Release o-n-0.17.1.1 & co

### DIFF
--- a/cardano-client/CHANGELOG.md
+++ b/cardano-client/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next version
 
+## 0.3.1.5 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.3.1.4
+
 ## 0.3.1.4 -- 2024-08-22
 
 ### Breaking changes

--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                   cardano-client
-version:                0.3.1.4
+version:                0.3.1.5
 synopsis:               An API for ouroboros-network
 description:            An API for ouroboros-network.
 license:                Apache-2.0

--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next version
 
+## 0.4.0.1 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.4.0.0
+
 ## 0.4.0.0 -- 2024-08-21
 
 ### Breaking changes

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   cardano-ping
-version:                0.4.0.0
+version:                0.4.0.1
 synopsis:               Utility for pinging cardano nodes
 description:            Utility for pinging cardano nodes.
 license:                Apache-2.0

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next release
 
+## 0.9.0.1 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.9.0.0
+
 ## 0.9.0.0 -- 2024-08-13
 
 ### Breaking changes

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network-api
-version:                0.9.0.0
+version:                0.9.0.1
 synopsis:               A networking api shared with ouroboros-consensus
 description:            A networking api shared with ouroboros-consensus.
 license:                Apache-2.0

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next release
 
+## 0.13.2.4 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.13.2.3
+
 ## 0.13.2.3 -- 2024-08-22
 
 ### Breaking changes

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network-framework
-version:                0.13.2.3
+version:                0.13.2.4
 synopsis:               Ouroboros network framework
 description:            Ouroboros network framework.
 license:                Apache-2.0

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next release
 
+## 0.10.0.2 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.10.0.1
+
 ## 0.10.0.1 -- 2024-08-22
 
 ### Breaking changes

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network-protocols
-version:                0.10.0.1
+version:                0.10.0.2
 synopsis:               Ouroboros Network Protocols
 description:            Ouroboros Network Protocols.
 license:                Apache-2.0

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next version
 
+## 0.17.1.1 -- 2024-08-27
+
+### Breaking changes
+
+### Non-breaking changes
+
+* bump for bad ref in chap for 0.17.1.0
+
 ## 0.17.1.0 -- 2024-08-21
 
 ### Breaking changes

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -1,6 +1,6 @@
 cabal-version:          3.0
 name:                   ouroboros-network
-version:                0.17.1.0
+version:                0.17.1.1
 synopsis:               A networking layer for the Ouroboros blockchain protocol
 description:            A networking layer for the Ouroboros blockchain protocol.
 license:                Apache-2.0


### PR DESCRIPTION
# Description

By accident, the references in CHaP for o-n-0.17.1.0 & accompanying packages point at a non-existent branch in our repo. This patch bumps patch versions for the packages that should be released so that a fresh complimentary CHaP PR can be made to point at the correct ref.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
