### PR TITLE
Fix nightly test failure

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## next release
 
+### Breaking changes
+
+### Non-breaking changes
+
+* Added tracing on CM connVars for testing purposes.
+
 ## 0.13.2.4 -- 2024-08-27
 
 ### Breaking changes

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -67,6 +67,7 @@ import Ouroboros.Network.InboundGovernor.Event (NewConnectionInfo (..))
 import Ouroboros.Network.MuxMode
 import Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import Ouroboros.Network.Snocket
+import Ouroboros.Network.Testing.Utils (WithName (..))
 
 
 -- | Arguments for a 'ConnectionManager' which are independent of 'MuxMode'.
@@ -227,14 +228,16 @@ newMutableConnState peerAddr freshIdSupply connState = do
                     let prevAbs = abstractState (Known prev)
                   , prevAbs /= currAbs -> pure
                                        $ TraceDynamic
+                                       $ WithName connStateId
                                        $ TransitionTrace peerAddr
-                                       $ mkTransition prevAbs
-                                                      currAbs
+                                       $ mkAbsTransition prevAbs
+                                                         currAbs
                 Nothing                -> pure
                                        $ TraceDynamic
+                                       $ WithName connStateId
                                        $ TransitionTrace peerAddr
-                                       $ mkTransition TerminatedSt
-                                                      currAbs
+                                       $ mkAbsTransition TerminatedSt
+                                                         currAbs
                 _                      -> pure DontTrace
         )
       return $ MutableConnState { connStateId, connVar }
@@ -482,7 +485,6 @@ abstractState = \case
     go DuplexState {}                 = DuplexSt
     go TerminatingState {}            = TerminatingSt
     go TerminatedState {}             = TerminatedSt
-
 
 -- | The default value for 'cmTimeWaitTimeout'.
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -214,11 +214,6 @@ newMutableConnState peerAddr freshIdSupply connState = do
       -- capabilities. These trace messages won't be reordered by IOSimPOR
       -- since these happen atomically in STM.
       --
-      -- Another thing to note is that this trace differs from the IO one in
-      -- the fact that all connections terminate with a trace to
-      -- 'UnknownConnectionSt', since we can't do that here we limit ourselves
-      -- to 'TerminatedSt'.
-      --
       traceTVar
         (Proxy @m) connVar
         (\mbPrev curr ->

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -152,6 +152,7 @@ module Ouroboros.Network.ConnectionManager.Types
   , Transition
   , AbstractTransition
   , mkTransition
+  , mkAbsTransition
   , TransitionTrace
   , TransitionTrace' (..)
   , AbstractTransitionTrace
@@ -909,6 +910,10 @@ mkTransition from to = Transition { fromState = Known from
                                   , toState   = Known to
                                   }
 
+mkAbsTransition :: AbstractState -> AbstractState -> AbstractTransition
+mkAbsTransition from to = Transition { fromState = from
+                                     , toState   = to
+                                     }
 
 data TransitionTrace' peerAddr state = TransitionTrace
     { ttPeerAddr   :: peerAddr

--- a/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
+++ b/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
@@ -284,6 +284,14 @@ abstractStateIsFinalTransition :: Transition' AbstractState -> Bool
 abstractStateIsFinalTransition (Transition _ UnknownConnectionSt) = True
 abstractStateIsFinalTransition _                                  = False
 
+-- | This function is necessary to check tests that only read from the
+-- `traceTVar` logging output. These `traceTVar` logs do not transition to
+-- 'UnknownConnectionSt'.
+--
+abstractStateIsFinalTransitionTVarTracing :: Transition' AbstractState -> Bool
+abstractStateIsFinalTransitionTVarTracing (Transition _ UnknownConnectionSt) = True
+abstractStateIsFinalTransitionTVarTracing _                                  = False
+
 
 connectionManagerTraceMap
   :: ConnectionManagerTrace

--- a/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
+++ b/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
@@ -292,7 +292,6 @@ abstractStateIsFinalTransitionTVarTracing :: Transition' AbstractState -> Bool
 abstractStateIsFinalTransitionTVarTracing (Transition _ UnknownConnectionSt) = True
 abstractStateIsFinalTransitionTVarTracing _                                  = False
 
-
 connectionManagerTraceMap
   :: ConnectionManagerTrace
       ntnAddr

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
 #if defined(mingw32_HOST_OS)
@@ -77,7 +78,8 @@ import Ouroboros.Network.ConnectionManager.Test.Timeouts (TestProperty (..),
            classifyNegotiatedDataFlow, classifyPrunings, classifyTermination,
            groupConns, mkProperty, ppTransition, verifyAllTimeouts)
 import Ouroboros.Network.ConnectionManager.Test.Utils
-           (abstractStateIsFinalTransition, connectionManagerTraceMap,
+           (abstractStateIsFinalTransition,
+           abstractStateIsFinalTransitionTVarTracing, connectionManagerTraceMap,
            validTransitionMap, verifyAbstractTransition,
            verifyAbstractTransitionOrder)
 import Ouroboros.Network.ConsensusMode
@@ -99,6 +101,8 @@ import Ouroboros.Network.PeerSharing (PeerSharingResult (..))
 import Test.Ouroboros.Network.LedgerPeers (LedgerPools (..))
 
 import Control.Monad.Class.MonadTest (exploreRaces)
+import Data.Dynamic (fromDynamic)
+import Ouroboros.Network.Block (BlockNo (..))
 import Ouroboros.Network.PeerSelection.Bootstrap (requiresBootstrapPeers)
 import Ouroboros.Network.PeerSelection.LedgerPeers
 
@@ -162,6 +166,8 @@ tests =
       , nightlyTest $ testProperty "steps"
                         (testWithIOSimPOR prop_churn_steps 10000)
       ]
+    , testGroup "unit"
+      [ testProperty "unit cm" unit_cm_valid_transitions ]
     ]
   , testGroup "IOSim"
     [ testProperty "no failure"
@@ -287,6 +293,155 @@ testWithIOSimPOR f traceNumber bi ds =
    in labelDiffusionScript ds
     $ exploreSimTrace id sim $ \_ ioSimTrace ->
         f ioSimTrace  traceNumber
+
+-- | This test checks a IOSimPOR false positive bug with the connection
+-- manager state transition traces no longer happens.
+--
+unit_cm_valid_transitions :: Property
+unit_cm_valid_transitions =
+  let bi = AbsBearerInfo
+            { abiConnectionDelay         = SmallDelay
+            , abiInboundAttenuation      = NoAttenuation FastSpeed
+            , abiOutboundAttenuation     = NoAttenuation FastSpeed
+            , abiInboundWriteFailure     = Nothing
+            , abiOutboundWriteFailure    = Just 0
+            , abiAcceptFailure           = Nothing
+            , abiSDUSize                 = LargeSDU
+            }
+      ds = DiffusionScript
+            (SimArgs 1 10)
+            (Script ((Map.empty, ShortDelay) :| [(Map.empty, LongDelay)]))
+            [ ( NodeArgs
+                  (-2)
+                  InitiatorAndResponderDiffusionMode
+                  (Just 269)
+                  (Map.fromList [(RelayAccessAddress "0:71:0:1:0:1:0:1" 65534,
+                                  DoAdvertisePeer)])
+                  GenesisMode
+                  (Script (DontUseBootstrapPeers :| []))
+                  (TestAddress (IPAddr (read "0:79::1:0:0") 3))
+                  PeerSharingDisabled
+                  [ (HotValency {getHotValency = 1},
+                     WarmValency {getWarmValency = 1},
+                     Map.fromList [(RelayAccessAddress "0:71:0:1:0:1:0:1" 65534,
+                                    (DoAdvertisePeer, IsTrustable))])
+                   ]
+                  (Script (LedgerPools [] :| []))
+                  (ConsensusModePeerTargets
+                    { deadlineTargets = PeerSelectionTargets
+                        { targetNumberOfRootPeers                 = 4
+                        , targetNumberOfKnownPeers                = 4
+                        , targetNumberOfEstablishedPeers          = 3
+                        , targetNumberOfActivePeers               = 2
+                        , targetNumberOfKnownBigLedgerPeers       = 4
+                        , targetNumberOfEstablishedBigLedgerPeers = 1
+                        , targetNumberOfActiveBigLedgerPeers      = 1
+                        }
+                    , syncTargets = PeerSelectionTargets
+                        { targetNumberOfRootPeers                 = 0
+                        , targetNumberOfKnownPeers                = 4
+                        , targetNumberOfEstablishedPeers          = 0
+                        , targetNumberOfActivePeers               = 0
+                        , targetNumberOfKnownBigLedgerPeers       = 4
+                        , targetNumberOfEstablishedBigLedgerPeers = 4
+                        , targetNumberOfActiveBigLedgerPeers      = 3
+                        }
+                    })
+                  (Script (DNSTimeout {getDNSTimeout = 0.325} :| []))
+                  (Script (DNSLookupDelay {getDNSLookupDelay = 0.1} :|
+                    [DNSLookupDelay {getDNSLookupDelay = 0.072}]))
+                  Nothing
+                  False
+                  (Script (FetchModeBulkSync :| [FetchModeBulkSync]))
+                  , [JoinNetwork 0.5]
+                )
+              , ( NodeArgs
+                  0
+                  InitiatorAndResponderDiffusionMode
+                  (Just 90)
+                  Map.empty
+                  GenesisMode
+                  (Script (DontUseBootstrapPeers :| []))
+                  (TestAddress (IPAddr (read "0:71:0:1:0:1:0:1") 65534))
+                  PeerSharingEnabled
+                  [ (HotValency {getHotValency = 1},
+                     WarmValency {getWarmValency = 1},
+                     Map.fromList [(RelayAccessAddress "0:79::1:0:0" 3,
+                                    (DoNotAdvertisePeer, IsTrustable))])
+                   ]
+                  (Script (LedgerPools [] :| []))
+                  (ConsensusModePeerTargets
+                    { deadlineTargets = PeerSelectionTargets
+                        { targetNumberOfRootPeers                 = 1
+                        , targetNumberOfKnownPeers                = 1
+                        , targetNumberOfEstablishedPeers          = 1
+                        , targetNumberOfActivePeers               = 1
+                        , targetNumberOfKnownBigLedgerPeers       = 4
+                        , targetNumberOfEstablishedBigLedgerPeers = 3
+                        , targetNumberOfActiveBigLedgerPeers      = 3
+                        }
+                    , syncTargets = PeerSelectionTargets
+                        { targetNumberOfRootPeers                 = 0
+                        , targetNumberOfKnownPeers                = 1
+                        , targetNumberOfEstablishedPeers          = 1
+                        , targetNumberOfActivePeers               = 1
+                        , targetNumberOfKnownBigLedgerPeers       = 4
+                        , targetNumberOfEstablishedBigLedgerPeers = 2
+                        , targetNumberOfActiveBigLedgerPeers      = 2
+                        }
+                    })
+                  (Script (DNSTimeout {getDNSTimeout = 0.18} :| []))
+                  (Script (DNSLookupDelay {getDNSLookupDelay = 0.125} :| []))
+                  (Just (BlockNo 2))
+                  False
+                  (Script (FetchModeDeadline :| []))
+                  , [JoinNetwork 1.484848484848]
+                )
+            ]
+      s = ControlAwait
+            [ ScheduleMod
+                (RacyThreadId [3,1,3,1,2,3,2,1], 7)
+                ControlDefault
+                [ (RacyThreadId [3,1,3,1,2,3,2], 32)
+                , (RacyThreadId [3,1,3,1,2,3,2], 33)
+                , (RacyThreadId [2,1,3,1,4], 8)
+                , (RacyThreadId [2,1,3,1,4], 9)
+                , (RacyThreadId [2,1,3,1,4], 10)
+                , (RacyThreadId [2,1,3,1,4], 11)
+                , (RacyThreadId [2,1,3,1,4], 12)
+                , (RacyThreadId [2,1,3,1,4,1], 0)
+                , (RacyThreadId [2,1,3,1,4,1], 1)
+                , (RacyThreadId [2,1,3,1,4,1], 2)
+                , (RacyThreadId [2,1,3,1,4,1], 3)
+                , (RacyThreadId [2,1,3,1,4,1], 4)
+                , (RacyThreadId [2,1,3,1,4,1], 5)
+                , (RacyThreadId [2,1,3,1,4,1], 6)
+                , (RacyThreadId [2,1,3,1,4,1], 7)
+                , (RacyThreadId [2,1,3,1,4,1], 8)
+                , (RacyThreadId [2,1,3,1,4,1,1], 0)
+                , (RacyThreadId [2,1,3,1,4,1,1], 1)
+                , (RacyThreadId [2,1,3,1,4,1,1], 2)
+                , (RacyThreadId [2,1,3,1,4,1,1], 3)
+                , (RacyThreadId [2,1,3,1,4,1], 9)
+                , (RacyThreadId [2,1,3,1,4,1], 10)
+                , (RacyThreadId [2,1,3,1,4,1], 11)
+                , (RacyThreadId [2,1,3,1,4,1], 12)
+                , (RacyThreadId [2,1,3,1,4,1], 13)
+                , (RacyThreadId [2,1,3,1,4,1], 14)
+                , (RacyThreadId [2,1,3,1,4,1], 15)
+                , (RacyThreadId [2,1,3,1,4], 13)
+                , (RacyThreadId [2,1,3,1,4], 14)
+                , (RacyThreadId [2,1,3,1,4], 15)
+                , (RacyThreadId [2,1,3,1,4], 16)
+                , (RacyThreadId [3,1,3,1,2,3,2], 34)
+                ]
+            ]
+      sim :: forall s. IOSim s Void
+      sim = do
+        exploreRaces
+        diffusionSimulation (toBearerInfo bi) ds iosimTracer
+  in exploreSimTrace (\a -> a { explorationReplay = Just s }) sim $ \_ ioSimTrace ->
+       prop_diffusion_cm_valid_transition_order ioSimTrace 10000
 
 -- | As a basic property we run the governor to explore its state space a bit
 -- and check it does not throw any exceptions (assertions such as invariant
@@ -2673,17 +2828,18 @@ prop_diffusion_cm_valid_transition_order :: SimTrace Void
                                          -> Int
                                          -> Property
 prop_diffusion_cm_valid_transition_order ioSimTrace traceNumber =
-    let events :: [Trace () (WithName NtNAddr (WithTime DiffusionTestTrace))]
+    let events :: [Trace () (WithName NtNAddr (WithTime (AbstractTransitionTrace NtNAddr)))]
         events = Trace.toList
-               . fmap (Trace.fromList ())
-               . splitWithNameTrace
-               . fmap (\(WithTime t (WithName name b))
-                       -> WithName name (WithTime t b))
-               . withTimeNameTraceEvents
-                  @DiffusionTestTrace
-                  @NtNAddr
-               . Trace.take traceNumber
-               $ ioSimTrace
+            . fmap (Trace.fromList ())
+            . splitWithNameTrace
+            . fmap (\(t, tr@(TransitionTrace n _)) -> WithName n (WithTime t (fmap getKnown tr)))
+            . traceSelectTraceEvents
+                (\t se ->
+                  case se of
+                    EventLog dyn -> (t,) <$> fromDynamic dyn
+                    _            -> Nothing)
+            . Trace.take traceNumber
+            $ ioSimTrace
 
      in conjoin
       $ (\ev ->
@@ -2691,7 +2847,8 @@ prop_diffusion_cm_valid_transition_order ioSimTrace traceNumber =
             lastTime = (\(WithName _ (WithTime t _)) -> t)
                      . last
                      $ evsList
-         in classifySimulatedTime lastTime
+         in counterexample (intercalate "\n" $ map show $ Trace.toList $ ev)
+          $ classifySimulatedTime lastTime
           $ classifyNumberOfEvents (length evsList)
           $ verify_cm_valid_transition_order
           $ (\(WithName _ (WithTime _ b)) -> b)
@@ -2699,19 +2856,18 @@ prop_diffusion_cm_valid_transition_order ioSimTrace traceNumber =
         )
       <$> events
   where
-    verify_cm_valid_transition_order :: Trace () DiffusionTestTrace -> Property
-    verify_cm_valid_transition_order events =
-      let abstractTransitionEvents :: Trace () (AbstractTransitionTrace NtNAddr)
-          abstractTransitionEvents =
-            selectDiffusionConnectionManagerTransitionEvents events
+    getKnown :: MaybeUnknown a -> a
+    getKnown (Known a) = a
+    getKnown _         = error "impossible happened"
 
-       in  property
-         . bifoldMap
-            (const mempty)
-            (verifyAbstractTransitionOrder False)
-         . fmap (map ttTransition)
-         . groupConns id abstractStateIsFinalTransition
-         $ abstractTransitionEvents
+    verify_cm_valid_transition_order :: Trace () (AbstractTransitionTrace NtNAddr) -> Property
+    verify_cm_valid_transition_order =
+         property
+       . bifoldMap
+          (const mempty)
+          (verifyAbstractTransitionOrder False)
+       . fmap (map ttTransition)
+       . groupConns id abstractStateIsFinalTransitionTVarTracing
 
 -- | Unit test that checks issue 4258
 -- https://github.com/intersectmbo/ouroboros-network/issues/4258

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -2830,6 +2830,11 @@ prop_diffusion_cm_valid_transitions ioSimTrace traceNumber =
 -- We can't reliably check for transitions to UnknownState but the IOSim tests
 -- already give us quite a lot confidence that there isn't any bugs there.
 --
+-- Another thing to note is that this trace differs from the IO one in
+-- the fact that all connections terminate with a trace to
+-- 'UnknownConnectionSt', since we can't do that here we limit ourselves
+-- to 'TerminatedSt'.
+--
 prop_diffusion_cm_valid_transition_order_iosim_por :: SimTrace Void
                                                    -> Int
                                                    -> Property


### PR DESCRIPTION
This commit adds tracing on connection manager TVar so that IOSimPOR doesn't find any wrong false positives.

Closes #4946 