### PR TITLE
Add  `NodeToClientV_18`

### DIFF
--- a/cardano-ping/CHANGELOG.md
+++ b/cardano-ping/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next version
 
+### Breaking changes
+
+* Added `NodeToClientVersionV18`
+
 ## 0.4.0.1 -- 2024-08-27
 
 ### Breaking changes

--- a/cardano-ping/src/Cardano/Network/Ping.hs
+++ b/cardano-ping/src/Cardano/Network/Ping.hs
@@ -146,6 +146,7 @@ supportedNodeToClientVersions magic =
   , NodeToClientVersionV15 magic
   , NodeToClientVersionV16 magic
   , NodeToClientVersionV17 magic
+  , NodeToClientVersionV18 magic
   ]
 
 data InitiatorOnly = InitiatorOnly | InitiatorAndResponder
@@ -180,6 +181,7 @@ data NodeVersion
   | NodeToClientVersionV15 Word32
   | NodeToClientVersionV16 Word32
   | NodeToClientVersionV17 Word32
+  | NodeToClientVersionV18 Word32
   | NodeToNodeVersionV1    Word32
   | NodeToNodeVersionV2    Word32
   | NodeToNodeVersionV3    Word32
@@ -207,6 +209,7 @@ instance ToJSON NodeVersion where
       NodeToClientVersionV15 m -> go2 "NodeToClientVersionV15" m
       NodeToClientVersionV16 m -> go2 "NodeToClientVersionV16" m
       NodeToClientVersionV17 m -> go2 "NodeToClientVersionV17" m
+      NodeToClientVersionV18 m -> go2 "NodeToClientVersionV18" m
       NodeToNodeVersionV1    m -> go2 "NodeToNodeVersionV1" m
       NodeToNodeVersionV2    m -> go2 "NodeToNodeVersionV2" m
       NodeToNodeVersionV3    m -> go2 "NodeToNodeVersionV3" m
@@ -341,6 +344,9 @@ handshakeReqEnc versions query =
       <>  nodeToClientDataWithQuery magic
     encodeVersion (NodeToClientVersionV17 magic) =
           CBOR.encodeWord (17 `setBit` nodeToClientVersionBit)
+      <>  nodeToClientDataWithQuery magic
+    encodeVersion (NodeToClientVersionV18 magic) =
+          CBOR.encodeWord (18 `setBit` nodeToClientVersionBit)
       <>  nodeToClientDataWithQuery magic
 
     -- node-to-node
@@ -486,6 +492,7 @@ handshakeDec = do
         (15, True)  -> Right . NodeToClientVersionV15 <$> (CBOR.decodeListLen *> CBOR.decodeWord32 <* (modeFromBool <$> CBOR.decodeBool))
         (16, True)  -> Right . NodeToClientVersionV16 <$> (CBOR.decodeListLen *> CBOR.decodeWord32 <* (modeFromBool <$> CBOR.decodeBool))
         (17, True)  -> Right . NodeToClientVersionV17 <$> (CBOR.decodeListLen *> CBOR.decodeWord32 <* (modeFromBool <$> CBOR.decodeBool))
+        (18, True)  -> Right . NodeToClientVersionV18 <$> (CBOR.decodeListLen *> CBOR.decodeWord32 <* (modeFromBool <$> CBOR.decodeBool))
         _           -> return $ Left $ UnknownVersionInRsp version
 
     decodeWithMode :: (Word32 -> InitiatorOnly -> NodeVersion) -> CBOR.Decoder s (Either HandshakeFailure NodeVersion)
@@ -806,6 +813,7 @@ isSameVersionAndMagic v1 v2 = extract v1 == extract v2
         extract (NodeToClientVersionV15 m) = (-15, m)
         extract (NodeToClientVersionV16 m) = (-16, m)
         extract (NodeToClientVersionV17 m) = (-17, m)
+        extract (NodeToClientVersionV18 m) = (-18, m)
         extract (NodeToNodeVersionV1 m)    = (1, m)
         extract (NodeToNodeVersionV2 m)    = (2, m)
         extract (NodeToNodeVersionV3 m)    = (3, m)

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -7,14 +7,15 @@
 * Renamed:
   * `accBigPoolStake` -> `accumulateBigLedgerStake`
      and `reRelativeStake` -> `recomputeRelativeStake`
+- Added `NodeToClientVersionV18`
 
 ### Non-breaking changes
 
 * Added `ConsensusMode` which must be passed to start diffusion in the
-  appropriate mode 
+  appropriate mode
 * added `compareLedgerPeerSnapshotApproximate` function which compares
   two snapshots for approximate equality wrt stake distribution and
-  fully qualified domain names. 
+  fully qualified domain names.
 * Added `MinBigLedgerPeersForTrustedState` type of values indicating
   the minimum number of active big ledger peers needed to signal
   trusted state when finishing syncing in Genesis mode.

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -40,11 +40,13 @@ data NodeToClientVersion
     | NodeToClientV_15
     -- ^ added `query` to NodeToClientVersionData
     | NodeToClientV_16
-    -- ^ add @ImmutableTip@ to @LocalStateQuery@, enabled
+    -- ^ added @ImmutableTip@ to @LocalStateQuery@, enabled
     -- @CardanoNodeToClientVersion11@, i.e., Conway and
     -- @GetStakeDelegDeposits@.
     | NodeToClientV_17
-    -- ^ add @GetProposals@ and @GetRatifyState@ queries
+    -- ^ added @GetProposals@ and @GetRatifyState@ queries
+    | NodeToClientV_18
+    -- ^ added @GetFuturePParams@ query
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable, Generic, NFData)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
@@ -66,6 +68,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
       encodeTerm NodeToClientV_15 = CBOR.TInt (15 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_16 = CBOR.TInt (16 `setBit` nodeToClientVersionBit)
       encodeTerm NodeToClientV_17 = CBOR.TInt (17 `setBit` nodeToClientVersionBit)
+      encodeTerm NodeToClientV_18 = CBOR.TInt (18 `setBit` nodeToClientVersionBit)
 
       decodeTerm (CBOR.TInt tag) =
        case ( tag `clearBit` nodeToClientVersionBit
@@ -80,6 +83,7 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
         (15, True) -> Right NodeToClientV_15
         (16, True) -> Right NodeToClientV_16
         (17, True) -> Right NodeToClientV_17
+        (18, True) -> Right NodeToClientV_18
         (n, _)     -> Left ( T.pack "decode NodeToClientVersion: unknown tag: " <> T.pack (show tag)
                             , Just n)
       decodeTerm _  = Left ( T.pack "decode NodeToClientVersion: unexpected term"

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## next release
 
+### Breaking changes
+
+* Adapt the `versionNumber` cddl definition to account for `NodeToClientVersionV18`.
+
 ## 0.10.0.2 -- 2024-08-27
 
 ### Breaking changes

--- a/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/test-cddl/specs/handshake-node-to-client.cddl
@@ -23,7 +23,7 @@ versionTable = { * oldVersionNumber => oldNodeToClientVersionData
 ; Version 15 introduces the version query flag
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
 ;               15    / 16    / 17
-versionNumber = 32783 / 32784 / 32785
+versionNumber = 32783 / 32784 / 32785 / 32786
 
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
 ;                  9     / 10    / 11    / 12    / 13    / 14


### PR DESCRIPTION
# Description

Add  `NodeToClientV_18` which is required to support the `GetFuturePParams` query.

See https://github.com/IntersectMBO/ouroboros-consensus/issues/1204

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
