### PR TITLE
ouroboros-network.cabal

### DIFF
--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -16,7 +16,7 @@ import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as LBS
 import Data.Foldable (traverse_)
 import Data.Functor (void)
-import Data.List
+import Data.List (maximumBy)
 import Data.List.Infinite (Infinite ((:<)))
 import Data.List.Infinite qualified as Inf
 import Data.Map qualified as Map
@@ -34,8 +34,6 @@ import Control.Monad (when)
 import Control.Tracer
 
 import System.Directory
-import System.Exit
-import System.IO
 import System.Random
 
 import Options.Applicative qualified as Opts
@@ -188,15 +186,8 @@ main = do
     parserInfo = Opts.info (optionsParser Opts.<**> Opts.helper)
                            (Opts.fullDesc <> Opts.progDesc "Run chain-sync / block-fetch demo")
 
-usage :: IO ()
-usage = do
-    hPutStrLn stderr "usage: demo-chain-sync [chainsync|blockfetch] {client|server} [addr]"
-    exitFailure
 
 defaultLocalSocketAddrPath :: FilePath
-
-
-
 defaultLocalSocketAddrPath =  "./demo-chain-sync.sock"
 
 defaultLocalSocketAddr :: LocalAddress

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -27,7 +27,26 @@ source-repository head
   type:     git
   location: https://github.com/intersectmbo/ouroboros-network
 
+common ghc-options
+  ghc-options:         -Wall
+                       -Wno-unticked-promoted-constructors
+                       -Wcompat
+                       -Wincomplete-uni-patterns
+                       -Wincomplete-record-updates
+                       -Wpartial-fields
+                       -Widentities
+                       -Wredundant-constraints
+                       -Wunused-packages
+
+-- in tests librararies redundant constraints are sometimes useful (e.g.
+-- by default truned off debug tracing might require extra constraints like
+-- `Show` or `MonadSay`).
+common ghc-options-tests
+  import:              ghc-options
+  ghc-options:        -Wno-redundant-constraints
+
 library
+  import:              ghc-options
   hs-source-dirs:      src
 
   -- At this experiment/prototype stage everything is exposed.
@@ -147,16 +166,6 @@ library
   if !os(windows)
     build-depends:     directory,
                        unix
-
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
-                       -Wredundant-constraints
-                       -Wunused-packages
   if flag(asserts)
     ghc-options:       -fno-ignore-asserts
 
@@ -166,6 +175,7 @@ library
 
 -- Simulation Test Library
 library sim-tests-lib
+  import:              ghc-options-tests
   default-language:    Haskell2010
   default-extensions:  ImportQualifiedPost
   visibility:          public
@@ -248,20 +258,11 @@ library sim-tests-lib
                        Test.Ouroboros.Network.TxSubmission
                        Test.Ouroboros.Network.Version
 
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
-                       -Wunused-packages
-                       -fno-ignore-asserts
-
 -- Simulation tests, and IO tests which don't require native system calls.
 -- (i.e. they don't require system call API provided by `Win32-network` or
 -- `network` dependency).  test-suite sim-tests
 test-suite sim-tests
+  import:              ghc-options-tests
   default-language:    Haskell2010
   default-extensions:  ImportQualifiedPost
   type:                exitcode-stdio-1.0
@@ -269,15 +270,11 @@ test-suite sim-tests
   main-is:             Main.hs
   build-depends:       base >=4.14 && <4.21,
                        tasty,
-                       tasty-hunit,
-                       tasty-quickcheck,
                        with-utf8,
 
                        ouroboros-network-protocols:testlib,
                        ouroboros-network:sim-tests-lib
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -fno-ignore-asserts
+  ghc-options:         -fno-ignore-asserts
                        -threaded
                        -rtsopts
                        +RTS -T -RTS
@@ -287,6 +284,7 @@ test-suite sim-tests
 -- platforms: x86_64-w64-mingw32 (Windows), x86_64-linux, x86-64-darwin and
 -- aarch64-darwin.
 test-suite io-tests
+  import:              ghc-options-tests
   type:                exitcode-stdio-1.0
   hs-source-dirs:      io-tests
   main-is:             Main.hs
@@ -312,7 +310,6 @@ test-suite io-tests
                        ouroboros-network-mock,
                        ouroboros-network-protocols,
                        ouroboros-network-protocols:testlib,
-                       ouroboros-network-framework:testlib,
                        ouroboros-network-testing ^>= 0.7.0.0,
                        si-timers,
                        strict-stm,
@@ -323,14 +320,12 @@ test-suite io-tests
   else
     build-depends:     process
 
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -fno-ignore-asserts
-                       -threaded
+  ghc-options:         -threaded
                        -rtsopts
                        +RTS -T -RTS
 
 executable demo-chain-sync
+  import:              ghc-options
   hs-source-dirs:      demo
   main-is:             chain-sync.hs
   build-depends:       base >=4.14 && <4.21,
@@ -342,7 +337,6 @@ executable demo-chain-sync
                        optparse-applicative,
                        random,
                        serialise,
-                       stm,
 
                        contra-tracer,
 
@@ -356,11 +350,11 @@ executable demo-chain-sync
 
   default-language:    Haskell2010
   default-extensions:  ImportQualifiedPost
-  ghc-options:         -Wall
-                       -threaded
+  ghc-options:         -threaded
                        -rtsopts
 
 benchmark sim-benchmarks
+  import:              ghc-options-tests
   default-language:    Haskell2010
   default-extensions:  ImportQualifiedPost
   type:                exitcode-stdio-1.0
@@ -371,15 +365,7 @@ benchmark sim-benchmarks
 
                        ouroboros-network:sim-tests-lib
 
-  ghc-options:         -Wall
-                       -Wno-unticked-promoted-constructors
-                       -Wcompat
-                       -Wincomplete-uni-patterns
-                       -Wincomplete-record-updates
-                       -Wpartial-fields
-                       -Widentities
-                       -Wunused-packages
-                       -fno-ignore-asserts
+  ghc-options:         -fno-ignore-asserts
                        -with-rtsopts=-A32m
                        +RTS -T -RTS
 

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -20,7 +20,6 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Typeable (Typeable)
 
 import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Exception (assert)
@@ -60,9 +59,8 @@ import Ouroboros.Network.Mock.ConcreteBlock
 -- | Run a single block fetch protocol until the chain is downloaded.
 --
 blockFetchExample0 :: forall m.
-                      (MonadSTM m, MonadST m, MonadAsync m, MonadDelay m,
-                       MonadFork m, MonadTime m, MonadTimer m, MonadMask m,
-                       MonadThrow (STM m))
+                      (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
+                       MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
                    => Tracer m [TraceLabelPeer Int
                                  (FetchDecision [Point BlockHeader])]
                    -> Tracer m (TraceLabelPeer Int
@@ -169,9 +167,8 @@ blockFetchExample0 decisionTracer clientStateTracer clientMsgTracer
 -- will be interested in downloading them all.
 --
 blockFetchExample1 :: forall m.
-                      (MonadSTM m, MonadST m, MonadAsync m, MonadDelay m,
-                       MonadFork m, MonadTime m, MonadTimer m, MonadMask m,
-                       MonadThrow (STM m))
+                      (MonadST m, MonadAsync m, MonadDelay m, MonadFork m,
+                       MonadTime m, MonadTimer m, MonadMask m, MonadThrow (STM m))
                    => Tracer m [TraceLabelPeer Int
                                  (FetchDecision [Point BlockHeader])]
                    -> Tracer m (TraceLabelPeer Int
@@ -318,10 +315,9 @@ exampleFixedPeerGSVs =
 -- Utils to run fetch clients and servers
 --
 
-runFetchClient :: (MonadAsync m, MonadDelay m, MonadFork m, MonadMask m,
-                   MonadThrow (STM m), MonadST m, MonadTime m, MonadTimer m,
-                   Ord peerid, Serialise block, Serialise point,
-                   Typeable block, ShowProxy block)
+runFetchClient :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
+                   MonadST m, MonadTime m, MonadTimer m, Ord peerid, Serialise
+                   block, Serialise point, ShowProxy block)
                 => Tracer m (TraceSendRecv (BlockFetch block point))
                 -> version
                 -> (version -> WhetherReceivingTentativeBlocks)
@@ -342,7 +338,6 @@ runFetchClient tracer version isPipeliningEnabled registry peerid channel client
 runFetchServer :: (MonadAsync m, MonadFork m, MonadMask m, MonadThrow (STM m),
                    MonadST m, MonadTime m, MonadTimer m,
                    Serialise block, Serialise point,
-                   Typeable block,
                    ShowProxy block)
                 => Tracer m (TraceSendRecv (BlockFetch block point))
                 -> Channel m LBS.ByteString
@@ -360,9 +355,7 @@ runFetchClientAndServerAsync
                   (MonadAsync m, MonadDelay m, MonadFork m, MonadMask m,
                    MonadThrow (STM m), MonadST m, MonadTime m, MonadTimer m,
                    Ord peerid, Show peerid,
-                   Serialise header, Serialise block,
-                   Serialise (HeaderHash block),
-                   Typeable block,
+                   Serialise block, Serialise (HeaderHash block),
                    ShowProxy block)
                 => Tracer m (TraceSendRecv (BlockFetch block (Point block)))
                 -> Tracer m (TraceSendRecv (BlockFetch block (Point block)))

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/MockNode.hs
@@ -125,7 +125,6 @@ createOneWaySubscriptionChannels
   :: forall block tip m.
      ( MonadSTM m
      , MonadDelay m
-     , MonadTimer m
      )
   => DiffTime
   -> DiffTime
@@ -149,7 +148,6 @@ createOneWaySubscriptionChannels trDelay1 trDelay2 = do
 createTwoWaySubscriptionChannels
   :: forall block tip m.
      ( MonadDelay m
-     , MonadSTM m
      , MonadTimer m
      )
   => DiffTime
@@ -167,7 +165,6 @@ blockGenerator :: forall block m.
                   , MonadDelay m
                   , MonadSTM m
                   , MonadFork m
-                  , MonadTimer m
                   )
                => DiffTime
                -- ^ slot duration
@@ -270,8 +267,7 @@ forkRelayKernel upstream cpsVar = do
 -- @StrictTVar ('ChainProducerState' block)@. This allows to extend the relay
 -- node to a core node.
 relayNode :: forall m block.
-             ( MonadSTM m
-             , MonadFork m
+             ( MonadFork m
              , MonadTimer m
              , MonadThrow m
              , MonadSay m
@@ -341,7 +337,6 @@ relayNode _nid initChain chans = do
 forkCoreKernel :: forall block m.
                   ( HasFullHeader block
                   , MonadDelay m
-                  , MonadSTM m
                   , MonadFork m
                   , MonadTimer m
                   )
@@ -388,7 +383,6 @@ forkCoreKernel slotDuration gchain fixupBlock cpsVar = do
 --
 coreNode :: forall m.
         ( MonadDelay m
-        , MonadSTM m
         , MonadFork m
         , MonadThrow m
         , MonadTimer m

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -668,7 +668,7 @@ unit_bracketSyncWithFetchClient step = do
 
     testSkeleton :: forall m a b d.
                     (MonadAsync m, MonadDelay m, MonadFork m, MonadMask m,
-                     MonadThrow m, MonadThrow (STM m), MonadTimer m)
+                     MonadThrow (STM m), MonadTimer m)
                  => ((forall c. m c -> m c) -> m a)
                  -> ((forall c. m c -> m c) -> m b)
                  -> ((forall c. m c -> m c) -> m d)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -32,7 +32,7 @@ import Control.Applicative (Alternative)
 import Control.Concurrent.Class.MonadMVar (MonadMVar)
 import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Monad ((>=>))
-import Control.Monad.Class.MonadAsync (MonadAsync (Async, wait, withAsync))
+import Control.Monad.Class.MonadAsync (MonadAsync (wait, withAsync))
 import Control.Monad.Class.MonadFork (MonadFork)
 import Control.Monad.Class.MonadSay
 import Control.Monad.Class.MonadST (MonadST)
@@ -179,13 +179,11 @@ run :: forall resolver m.
        , MonadST          m
        , MonadTime        m
        , MonadTimer       m
-       , MonadThrow       m
        , MonadThrow       (STM m)
        , MonadMVar        m
 
        , resolver ~ ()
        , forall a. Semigroup a => Semigroup (m a)
-       , Eq (Async m Void)
        )
     => Node.BlockGeneratorArgs Block StdGen
     -> Node.LimitsAndTimeouts BlockHeader Block

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/NodeKernel.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/NodeKernel.hs
@@ -271,9 +271,7 @@ data NodeKernel header block s m = NodeKernel {
       nkPublicPeerSelectionVar :: StrictTVar m (PublicPeerSelectionState NtNAddr)
     }
 
-newNodeKernel :: ( MonadSTM m
-                 , RandomGen s
-                 )
+newNodeKernel :: MonadSTM m
               => s -> m (NodeKernel header block s m)
 newNodeKernel rng = do
     publicStateVar <- makePublicPeerSelectionStateVar
@@ -312,7 +310,6 @@ unregisterClientChains NodeKernel { nkClientChains } peerAddr = atomically $
 withSlotTime :: forall m a.
                 ( MonadAsync         m
                 , MonadDelay         m
-                , MonadMonotonicTime m
                 )
              => DiffTime
              -> ((SlotNo -> STM m SlotNo) -> m a)
@@ -360,8 +357,6 @@ withNodeKernelThread
      ( Alternative (STM m)
      , MonadAsync         m
      , MonadDelay         m
-     , MonadMonotonicTime m
-     , MonadTimer         m
      , MonadThrow         m
      , MonadThrow    (STM m)
      , HasFullHeader block

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Policies.hs
@@ -142,10 +142,7 @@ prop_hotToWarm :: ArbitraryPolicyArguments
 prop_hotToWarm args seed = runSimOrThrow $ prop_hotToWarmM args seed
 
 -- Verify that there are no peers worse than the peers picked for demotion.
-prop_hotToWarmM :: forall m.
-                   ( MonadLabelledSTM m
-                   , Monad (STM m)
-                   )
+prop_hotToWarmM :: forall m. MonadLabelledSTM m
                  => ArbitraryPolicyArguments
                  -> Int
                  -> m Property
@@ -209,10 +206,7 @@ prop_randomDemotion args seed = runSimOrThrow $ prop_randomDemotionM args seed
 
 -- Verifies that Tepid (formerly hot) or failing peers are more likely to get
 -- demoted/forgotten.
-prop_randomDemotionM :: forall m.
-                        ( MonadLabelledSTM m
-                        , Monad (STM m)
-                        )
+prop_randomDemotionM :: forall m. MonadLabelledSTM m
                      => ArbitraryPolicyArguments
                      -> Int
                      -> m Property

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/KeepAlive.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/KeepAlive.hs
@@ -47,9 +47,7 @@ runKeepAliveClient
         ( MonadAsync m
         , MonadFork m
         , MonadMask m
-        , MonadMonotonicTime m
         , MonadST m
-        , MonadSTM m
         , MonadTimer m
         , MonadThrow (STM m)
         , Ord peer)
@@ -77,9 +75,7 @@ runKeepAliveServer
         ( MonadAsync m
         , MonadFork m
         , MonadMask m
-        , MonadMonotonicTime m
         , MonadST m
-        , MonadSTM m
         , MonadTimer m
         , MonadThrow (STM m)
         )
@@ -101,14 +97,12 @@ runKeepAliveClientAndServer
         , MonadDelay m
         , MonadFork m
         , MonadMask m
-        , MonadMonotonicTime m
         , MonadSay m
         , MonadST m
-        , MonadSTM m
         , MonadTimer m
         , MonadThrow (STM m)
         , Ord peer
-        , Show peer)
+        )
     => NetworkDelay
     -> Int
     -> Tracer m (TraceKeepAliveClient peer)
@@ -136,15 +130,12 @@ instance Arbitrary NetworkDelay where
 
 prop_keepAlive_convergenceM
     :: forall m.
-        ( Eq (Async m ())
-        , MonadAsync m
+        ( MonadAsync m
         , MonadDelay m
         , MonadFork m
         , MonadMask m
-        , MonadMonotonicTime m
         , MonadSay m
         , MonadST m
-        , MonadSTM m
         , MonadTimer m
         , MonadThrow (STM m)
         )

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -615,12 +615,7 @@ instance (Show a) => Show (WithThreadAndTime a) where
     show WithThreadAndTime {wtatOccuredAt, wtatWithinThread, wtatEvent} =
         printf "%s: %s: %s" (show wtatOccuredAt) (show wtatWithinThread) (show wtatEvent)
 
-verboseTracer :: forall a m.
-                       ( MonadAsync m
-                       , MonadSay m
-                       , MonadMonotonicTime m
-                       , Show a
-                       )
+verboseTracer :: forall a m. (MonadSay m, Show a)
                => Tracer m a
 verboseTracer = nullTracer -- threadAndTimeTracer $ Tracer (say . show)
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/MockNode.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/MockNode.hs
@@ -72,7 +72,6 @@ test_blockGenerator
   :: forall m.
      ( MonadDelay m
      , MonadFork m
-     , MonadSTM m
      , MonadTime m
      , MonadTimer m
      )
@@ -99,12 +98,7 @@ test_blockGenerator chain slotDuration = do
         slotTime s = (realToFrac (unSlotNo s) * slotDuration) `addTime` startTime
 
     experiment
-      :: ( MonadSTM m
-         , MonadFork m
-         , MonadTime m
-         , MonadTimer m
-         )
-      => DiffTime
+      :: DiffTime
       -> Probe m (Time, Block)
       -> m ()
     experiment slotDur p = do
@@ -134,10 +128,8 @@ prop_blockGenerator_IO (TestBlockChain chain) (Positive slotDuration) =
 
 coreToRelaySim :: ( MonadDelay m
                   , MonadFork m
-                  , MonadSTM m
                   , MonadSay m
                   , MonadThrow m
-                  , MonadTime m
                   , MonadTimer m
                   )
                => Bool              -- ^ two way subscription
@@ -216,11 +208,9 @@ prop_coreToRelay (TestNodeSim chain slotDuration coreTrDelay relayTrDelay) =
 
 -- Node graph: c → r → r
 coreToRelaySim2 :: ( MonadDelay m
-                   , MonadSTM m
                    , MonadFork m
                    , MonadThrow m
                    , MonadSay m
-                   , MonadTime m
                    , MonadTimer m
                    )
                 => Chain Block
@@ -314,11 +304,9 @@ instance Arbitrary TestNetworkGraph where
 
 networkGraphSim :: forall m.
                   ( MonadDelay m
-                  , MonadSTM m
                   , MonadFork m
                   , MonadThrow m
                   , MonadSay m
-                  , MonadTime m
                   , MonadTimer m
                   )
                 => TestNetworkGraph

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -334,8 +334,8 @@ data TraceMockEnv = TraceEnvAddPeers       !PeerGraph
   deriving Show
 
 mockPeerSelectionActions :: forall m.
-                            (MonadAsync m, MonadDelay m, MonadTimer m,
-                             Fail.MonadFail m, MonadThrow (STM m), MonadTraceSTM m)
+                            (MonadAsync m, MonadDelay m, Fail.MonadFail m,
+                             MonadThrow (STM m), MonadTraceSTM m)
                          => Tracer m TraceMockEnv
                          -> GovernorMockEnvironment
                          -> ConsensusModePeerTargets
@@ -403,7 +403,7 @@ instance Exception TransitionError where
 
 
 mockPeerSelectionActions' :: forall m.
-                             (MonadAsync m, MonadDelay m, MonadSTM m, MonadTimer m, Fail.MonadFail m,
+                             (MonadAsync m, MonadDelay m, Fail.MonadFail m,
                               MonadThrow (STM m))
                           => Tracer m TraceMockEnv
                           -> GovernorMockEnvironment

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -162,10 +162,7 @@ data PeerMetricsTrace = PeerMetricsTrace {
 simulatePeerMetricScript
   :: forall m.
      ( MonadDelay m
-     , MonadTimer m
-     , MonadMonotonicTime m
      , MonadLabelledSTM m
-     , MonadTraceSTM m
      )
   => Tracer m PeerMetricsTrace
   -> PeerMetricsConfiguration

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -289,8 +289,7 @@ instance Arbitrary DNSLookupDelay where
 -- Adds DNS Lookup function for IOSim with different timeout and lookup
 -- delays for every attempt.
 mockDNSActions :: forall exception m.
-                  ( MonadSTM   m
-                  , MonadDelay m
+                  ( MonadDelay m
                   , MonadTimer m
                   )
                => StrictTVar m (Map Domain [(IP, TTL)])
@@ -338,7 +337,6 @@ mockLocalRootPeersProvider :: forall m.
                               , MonadTimer    m
                               , MonadTraceSTM m
                               , MonadLabelledSTM m
-                              , Eq (Async m Void)
                               )
                            => Tracer m (TraceLocalRootPeers SockAddr Failure)
                            -> MockRoots

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerState.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerState.hs
@@ -109,9 +109,7 @@ instance Arbitrary (ArbPeerState m) where
 --
 
 prop_SuspendDecisionSemigroup
-    :: ( Ord t
-       , Eq t
-       )
+    :: Ord t
     => ArbSuspendDecision t
     -> ArbSuspendDecision t
     -> ArbSuspendDecision t

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -3739,8 +3739,7 @@ selectDiffusionPeerSelectionState f =
             consensusMode
             (MinBigLedgerPeersForTrustedState 0) -- ^ todo: fix
 
-selectDiffusionPeerSelectionState' :: Eq a
-                                  => (forall peerconn. Governor.PeerSelectionState NtNAddr peerconn -> a)
+selectDiffusionPeerSelectionState' :: (forall peerconn. Governor.PeerSelectionState NtNAddr peerconn -> a)
                                   -> Events DiffusionTestTrace
                                   -> Signal a
 selectDiffusionPeerSelectionState' f =

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Simulation/Node.hs
@@ -953,13 +953,11 @@ diffusionSimulation
                , MonadEvaluate    m
                , MonadLabelledSTM m
                , MonadTraceSTM    m
-               , MonadCatch       m
                , MonadMask        m
                , MonadTime        m
                , MonadTimer       m
                , MonadThrow  (STM m)
                , MonadMVar        m
-               , Eq (Async m Void)
                , forall a. Semigroup a => Semigroup (m a)
                )
   => BearerInfo

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -109,9 +109,7 @@ newtype Mempool m txid = Mempool (TVar m (Seq (Tx txid)))
 emptyMempool :: MonadSTM m => m (Mempool m txid)
 emptyMempool = Mempool <$> newTVarIO Seq.empty
 
-newMempool :: ( MonadSTM m
-              , Eq txid
-              )
+newMempool :: MonadSTM m
            => [Tx txid]
            -> m (Mempool m txid)
 newMempool = fmap Mempool
@@ -125,7 +123,6 @@ readMempool (Mempool mempool) = toList <$> readTVarIO mempool
 getMempoolReader :: forall txid m.
                     ( MonadSTM m
                     , Eq txid
-                    , Show txid
                     )
                  => Mempool m txid
                  -> TxSubmissionMempoolReader txid (Tx txid) Int m
@@ -153,7 +150,6 @@ getMempoolReader (Mempool mempool) =
 getMempoolWriter :: forall txid m.
                     ( MonadSTM m
                     , Ord txid
-                    , Eq txid
                     )
                  => Mempool m txid
                  -> TxSubmissionMempoolWriter txid (Tx txid) Int m
@@ -205,13 +201,9 @@ txSubmissionSimulation
      , MonadMask  m
      , MonadSay   m
      , MonadST    m
-     , MonadSTM   m
      , MonadTimer m
-     , MonadThrow m
      , MonadThrow (STM m)
-     , MonadMonotonicTime m
      , Ord txid
-     , Eq  txid
      , ShowProxy txid
      , NoThunks (Tx txid)
 
@@ -372,7 +364,6 @@ instance (Show a) => Show (WithThreadAndTime a) where
 
 verboseTracer :: forall a m.
                        ( MonadAsync m
-                       , MonadDelay m
                        , MonadSay m
                        , MonadMonotonicTime m
                        , Show a
@@ -382,7 +373,6 @@ verboseTracer = threadAndTimeTracer $ showTracing $ Tracer say
 
 threadAndTimeTracer :: forall a m.
                        ( MonadAsync m
-                       , MonadDelay m
                        , MonadMonotonicTime m
                        )
                     => Tracer m (WithThreadAndTime a) -> Tracer m a


### PR DESCRIPTION
Provide two common stanzas: ghc-options and ghc-options-tests.  The
latter is using `-Wno-redundant-constraints`.

Constraints in `sim-test-lib` were cleaned up, but we will still use
`-Wno-redundant-constraints`.
