### PR TITLE
gha: updated nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: "3.10.3.0"
+        cabal-version: "3.12.1.0"
         pacman-packages: >
           mingw-w64-x86_64-pkg-config
           mingw-w64-x86_64-openssl

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.6.2"]
+        ghc: ["8.10", "9.8"]
         os: [ubuntu-latest]
 
     env:
@@ -34,7 +34,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: "3.10.1.0"
+        cabal-version: "3.12.1.0"
         pacman-packages: >
           mingw-w64-x86_64-pkg-config
           mingw-w64-x86_64-openssl


### PR DESCRIPTION
Use GHC-9.8.  There is an error when building
`typed-protocols-examples-0.5.0.0` with `GHC-9.6.2` (reproducible
locally):

```
<no location info>: error:
    expectJust ty_co_subst bad roles
CallStack (from HasCallStack):
  error, called at compiler/GHC/Data/Maybe.hs:71:27 in ghc:GHC.Data.Maybe
  expectJust, called at compiler/GHC/Core/Coercion.hs:2076:31 in ghc:GHC.Core.Coercion

```

Newer `GHC` versions work fine (e.g. `GHC-9.6.5`).
