### PR TITLE
Randomized ProtocolTimeLimits

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Non-breaking changes
 
 * `IsLedgerPeer` added to `Ouroboros.Network.LedgerPeers.Types` module.
+* Added `ProtocolTimeLimitsWithRnd` to `Ouroboros.Network.Protocol.Limits`
 
 ## 0.14.0.0 - 2025-05-13
 

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -74,6 +74,7 @@ library
     network-mux ^>=0.8,
     nothunks,
     quiet,
+    random,
     serialise >=0.2 && <0.3,
     si-timers,
     strict-stm,

--- a/ouroboros-network-api/src/Ouroboros/Network/Protocol/Limits.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/Protocol/Limits.hs
@@ -11,6 +11,7 @@ module Ouroboros.Network.Protocol.Limits where
 
 import Control.Exception
 import Control.Monad.Class.MonadTime.SI
+import System.Random (StdGen)
 
 import Network.TypedProtocol.Core
 
@@ -28,6 +29,11 @@ newtype ProtocolTimeLimits ps = ProtocolTimeLimits {
        timeLimitForState :: forall  (st :: ps). ActiveState st
                          => StateToken st -> Maybe DiffTime
      }
+
+newtype ProtocolTimeLimitsWithRnd ps = ProtocolTimeLimitsWithRnd {
+      timeLimitForStateWithRnd :: forall (st :: ps). ActiveState st
+                               => StateToken st -> StdGen -> (Maybe DiffTime, StdGen)
+    }
 
 data ProtocolLimitFailure where
     ExceededSizeLimit :: forall ps (st :: ps).

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -115,6 +115,7 @@
 ### Non-breaking changes
 
 * Added tracing on CM connVars for testing purposes.
+* Improved haddocks of `Hanshake` protocol codec.
 
 ## 0.13.2.5 -- 2024-10-11
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/Driver/Limits.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Driver/Limits.hs
@@ -22,14 +22,19 @@ module Ouroboros.Network.Driver.Limits
     -- * Normal peers
   , runPeerWithLimits
   , runPipelinedPeerWithLimits
+  , runPeerWithLimitsRnd
+  , runPipelinedPeerWithLimitsRnd
   , TraceSendRecv (..)
     -- * Driver utilities
   , driverWithLimits
   , runConnectedPeersWithLimits
   , runConnectedPipelinedPeersWithLimits
+  , runConnectedPeersWithLimitsRnd
+  , runConnectedPipelinedPeersWithLimitsRnd
   ) where
 
 import Data.Maybe (fromMaybe)
+import System.Random
 
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
@@ -105,6 +110,68 @@ driverWithLimits tracer timeoutFn
         Nothing                    -> throwIO (ExceededTimeLimit tok)
 
 
+-- | Like 'driverWithLimits' but gives access to `StdGen` to generate
+-- `ProtocolTimeouts` for the next state.
+--
+driverWithLimitsRnd :: forall ps (pr :: PeerRole) failure bytes m.
+                       ( MonadThrow m
+                       , ShowProxy ps
+                       , forall (st' :: ps) tok. tok ~ StateToken st' => Show tok
+                       , Show failure
+                       )
+                    => Tracer m (TraceSendRecv ps)
+                    -> TimeoutFn m
+                    -> StdGen
+                    -> Codec ps failure m bytes
+                    -> ProtocolSizeLimits ps bytes
+                    -> (StdGen -> ProtocolTimeLimits ps)
+                    -> Channel m bytes
+                    -> Driver ps pr (Maybe bytes, StdGen) m
+driverWithLimitsRnd tracer timeoutFn rnd0
+                    Codec{encode, decode}
+                    ProtocolSizeLimits{sizeLimitForState, dataSize}
+                    genProtocolTimeLimits
+                    channel@Channel{send} =
+    Driver { sendMessage, recvMessage, initialDState = (Nothing, rnd0) }
+  where
+    sendMessage :: forall (st :: ps) (st' :: ps).
+                   StateTokenI st
+                => ActiveState st
+                => WeHaveAgencyProof pr st
+                -> Message ps st st'
+                -> m ()
+    sendMessage !_ msg = do
+      send (encode msg)
+      traceWith tracer (TraceSendMsg (AnyMessage msg))
+
+
+    recvMessage :: forall (st :: ps).
+                   StateTokenI st
+                => ActiveState st
+                => TheyHaveAgencyProof pr st
+                -> (Maybe bytes, StdGen)
+                -> m (SomeMessage st, (Maybe bytes, StdGen))
+    recvMessage !_ (trailing, !rnd) = do
+      let tok = stateToken
+      decoder <- decode tok
+      let sizeLimit = sizeLimitForState @st stateToken
+
+      let (rnd', rnd'') = split rnd
+          ProtocolTimeLimits{timeLimitForState} = genProtocolTimeLimits rnd''
+          timeLimit = fromMaybe (-1) $ timeLimitForState @st stateToken
+      result  <- timeoutFn timeLimit $
+                   runDecoderWithLimit sizeLimit dataSize
+                                       channel trailing decoder
+
+      case result of
+        Just (Right (x@(SomeMessage msg), trailing')) -> do
+          traceWith tracer (TraceRecvMsg (AnyMessage msg))
+          return (x, (trailing', rnd'))
+        Just (Left (Just failure)) -> throwIO (DecoderFailure tok failure)
+        Just (Left Nothing)        -> throwIO (ExceededSizeLimit tok)
+        Nothing                    -> throwIO (ExceededTimeLimit tok)
+
+
 runDecoderWithLimit
     :: forall m bytes failure a. Monad m
     => Word
@@ -152,7 +219,8 @@ runDecoderWithLimit limit size Channel{recv} =
                        Just bs -> do let sz' = sz + size bs
                                      go sz' Nothing =<< k (Just bs)
 
-
+-- | Run a peer with limits.
+--
 runPeerWithLimits
   :: forall ps (st :: ps) pr failure bytes m a .
      ( MonadAsync m
@@ -175,6 +243,37 @@ runPeerWithLimits tracer codec slimits tlimits channel peer =
     withTimeoutSerial $ \timeoutFn ->
       let driver = driverWithLimits tracer timeoutFn codec slimits tlimits channel
       in runPeerWithDriver driver peer
+
+
+-- | Run a peer with limits.  'ProtocolTimeLimits' have access to
+-- a pseudorandom generator.
+--
+runPeerWithLimitsRnd
+  :: forall ps (st :: ps) pr failure bytes m a .
+     ( MonadAsync m
+     , MonadFork m
+     , MonadMask m
+     , MonadThrow (STM m)
+     , MonadTimer m
+     , ShowProxy ps
+     , forall (st' :: ps) stok. stok ~ StateToken st' => Show stok
+     , Show failure
+     )
+  => Tracer m (TraceSendRecv ps)
+  -> StdGen
+  -> Codec ps failure m bytes
+  -> ProtocolSizeLimits ps bytes
+  -> (StdGen -> ProtocolTimeLimits ps)
+  -> Channel m bytes
+  -> Peer ps pr NonPipelined st m a
+  -> m (a, Maybe bytes)
+runPeerWithLimitsRnd tracer rnd codec slimits tlimits channel peer =
+    withTimeoutSerial $ \timeoutFn ->
+      let driver = driverWithLimitsRnd tracer timeoutFn rnd codec slimits tlimits channel
+      in     (\(a, (trailing, _)) -> (a, trailing))
+         <$> runPeerWithDriver driver peer
+
+
 -- | Run a pipelined peer with the given channel via the given codec.
 --
 -- This runs the peer to completion (if the protocol allows for termination).
@@ -204,6 +303,35 @@ runPipelinedPeerWithLimits tracer codec slimits tlimits channel peer =
     withTimeoutSerial $ \timeoutFn ->
       let driver = driverWithLimits tracer timeoutFn codec slimits tlimits channel
       in runPipelinedPeerWithDriver driver peer
+
+
+-- | Like 'runPipelinedPeerWithLimits' but time limits have access to
+-- a pseudorandom generator.
+--
+runPipelinedPeerWithLimitsRnd
+  :: forall ps (st :: ps) pr failure bytes m a.
+     ( MonadAsync m
+     , MonadFork m
+     , MonadMask m
+     , MonadTimer m
+     , MonadThrow (STM m)
+     , ShowProxy ps
+     , forall (st' :: ps) stok. stok ~ StateToken st' => Show stok
+     , Show failure
+     )
+  => Tracer m (TraceSendRecv ps)
+  -> StdGen
+  -> Codec ps failure m bytes
+  -> ProtocolSizeLimits ps bytes
+  -> (StdGen -> ProtocolTimeLimits ps)
+  -> Channel m bytes
+  -> PeerPipelined ps pr st m a
+  -> m (a, Maybe bytes)
+runPipelinedPeerWithLimitsRnd tracer rnd codec slimits tlimits channel peer =
+    withTimeoutSerial $ \timeoutFn ->
+      let driver = driverWithLimitsRnd tracer timeoutFn rnd codec slimits tlimits channel
+      in     (\(a, (trailing, _)) -> (a, trailing))
+         <$> runPipelinedPeerWithDriver driver peer
 
 
 -- | Run two 'Peer's via a pair of connected 'Channel's and a common 'Codec'.
@@ -248,6 +376,41 @@ runConnectedPeersWithLimits createChannels tracer codec slimits tlimits client s
     tracerServer = contramap ((,) Server) tracer
 
 
+runConnectedPeersWithLimitsRnd
+  :: forall ps pr st failure bytes m a b.
+     ( MonadAsync       m
+     , MonadFork        m
+     , MonadMask        m
+     , MonadTimer       m
+     , MonadThrow  (STM m)
+     , Exception failure
+     , ShowProxy ps
+     , forall (st' :: ps) sing. sing ~ StateToken st' => Show sing
+     )
+  => m (Channel m bytes, Channel m bytes)
+  -> Tracer m (Role, TraceSendRecv ps)
+  -> StdGen
+  -> Codec ps failure m bytes
+  -> ProtocolSizeLimits ps bytes
+  -> (StdGen -> ProtocolTimeLimits ps)
+  -> Peer ps             pr  NonPipelined st m a
+  -> Peer ps (FlipAgency pr) NonPipelined st m b
+  -> m (a, b)
+runConnectedPeersWithLimitsRnd createChannels tracer rnd codec slimits tlimits client server =
+    createChannels >>= \(clientChannel, serverChannel) ->
+
+    (do labelThisThread "client"
+        fst <$> runPeerWithLimitsRnd
+                        tracerClient rnd codec slimits tlimits
+                                     clientChannel client)
+      `concurrently`
+    (do labelThisThread "server"
+        fst <$> runPeer tracerServer codec serverChannel server)
+  where
+    tracerClient = contramap ((,) Client) tracer
+    tracerServer = contramap ((,) Server) tracer
+
+
 -- | Run two 'Peer's via a pair of connected 'Channel's and a common 'Codec'.
 -- The client side is using 'driverWithLimits'.
 --
@@ -280,6 +443,39 @@ runConnectedPipelinedPeersWithLimits createChannels tracer codec slimits tlimits
 
     (fst <$> runPipelinedPeerWithLimits
                      tracerClient codec slimits tlimits
+                                        clientChannel client)
+      `concurrently`
+    (fst <$> runPeer tracerServer codec serverChannel server)
+  where
+    tracerClient = contramap ((,) Client) tracer
+    tracerServer = contramap ((,) Server) tracer
+
+
+runConnectedPipelinedPeersWithLimitsRnd
+  :: forall ps pr st failure bytes m a b.
+     ( MonadAsync      m
+     , MonadFork       m
+     , MonadMask       m
+     , MonadTimer      m
+     , MonadThrow (STM m)
+     , Exception failure
+     , ShowProxy ps
+     , forall (st' :: ps) sing. sing ~ StateToken st' => Show sing
+     )
+  => m (Channel m bytes, Channel m bytes)
+  -> Tracer m (Role, TraceSendRecv ps)
+  -> StdGen
+  -> Codec ps failure m bytes
+  -> ProtocolSizeLimits ps bytes
+  -> (StdGen -> ProtocolTimeLimits ps)
+  -> PeerPipelined ps    pr               st m a
+  -> Peer ps (FlipAgency pr) NonPipelined st m b
+  -> m (a, b)
+runConnectedPipelinedPeersWithLimitsRnd createChannels tracer rnd codec slimits tlimits client server =
+    createChannels >>= \(clientChannel, serverChannel) ->
+
+    (fst <$> runPipelinedPeerWithLimitsRnd
+                     tracerClient rnd codec slimits tlimits
                                         clientChannel client)
       `concurrently`
     (fst <$> runPeer tracerServer codec serverChannel server)

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake/Codec.hs
@@ -99,6 +99,14 @@ byteLimitsHandshake = ProtocolSizeLimits stateToLimit (fromIntegral . BL.length)
 
 -- | Time limits.
 --
+-- +--------------------+-------------+
+-- | 'Handshake' state  | timeout (s) |
+-- +====================+=============+
+-- | `StPropose`        | `shortWait` |
+-- +--------------------+-------------+
+-- | `StConfirm`        | `shortWait` |
+-- +--------------------+-------------+
+--
 timeLimitsHandshake :: forall vNumber. ProtocolTimeLimits (Handshake vNumber CBOR.Term)
 timeLimitsHandshake = ProtocolTimeLimits stateToLimit
   where
@@ -123,10 +131,9 @@ noTimeLimitsHandshake = ProtocolTimeLimits stateToLimit
 
 -- |
 -- @'Handshake'@ codec.  The @'MsgProposeVersions'@ encodes proposed map in
--- ascending order and it expects to receive them in this order.  This allows
--- to construct the map in linear time.  There is also another limiting factor
--- to the number of versions on can present: the whole message must fit into
--- a single TCP segment.
+-- ascending order and it expects to receive them in this order.  The whole
+-- `MsgProposeVersions` message must fit into a single TCP segment which limits
+-- number of versions that can be proposed.
 --
 codecHandshake
   :: forall vNumber m failure.
@@ -135,6 +142,7 @@ codecHandshake
      , Show failure
      )
   => CodecCBORTerm (failure, Maybe Int) vNumber
+  -- ^ `CBOR.Term` codec for `vNumber`
   -> Codec (Handshake vNumber CBOR.Term) CBOR.DeserialiseFailure m ByteString
 codecHandshake versionNumberCodec = mkCodecCborLazyBS encodeMsg decodeMsg
     where

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -4,7 +4,14 @@
 
 ### Breaking changes
 
+* Chain-sync protocol is providing `ProtocolTimeLimitsWithRnd`.  It now must be
+  run using either `runPeerWithLimitsRnd` or `runPipelinedPeerWithLimitsRnd`.
+* `Ouroboros.Network.Protocols.TxSubmission2.Codec.{encode,decode}TxSubmission2`
+  are no longer exported.
+
 ### Non-breaking changes
+
+* Improved haddocks of `node-to-node` mini-protocol codecs.
 
 ## 0.14.0.1 -- 2025-05-13
 

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -106,6 +106,7 @@ library
     nothunks,
     ouroboros-network-api ^>=0.14,
     quiet,
+    random,
     serialise,
     si-timers,
     singletons,

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/BlockFetch/Codec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
-{-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -18,19 +17,20 @@ import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadTime.SI
 
 import Data.ByteString.Lazy qualified as LBS
+import Data.Kind (Type)
 
 import Codec.CBOR.Decoding qualified as CBOR
 import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Read qualified as CBOR
 import Text.Printf
 
-import Network.TypedProtocol.Codec.CBOR
+import Network.TypedProtocol.Codec.CBOR hiding (decode, encode)
 
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Protocol.Limits
 
 -- | Byte Limit.
-byteLimitsBlockFetch :: forall bytes block point.
+byteLimitsBlockFetch :: forall bytes (block :: Type) (point :: Type).
                         (bytes -> Word) -- ^ compute size of bytes
                      -> ProtocolSizeLimits (BlockFetch block point) bytes
 byteLimitsBlockFetch = ProtocolSizeLimits stateToLimit
@@ -54,6 +54,7 @@ byteLimitsBlockFetch = ProtocolSizeLimits stateToLimit
 -- | `BFStreaming`    | `longWait`    |
 -- +------------------+---------------+
 --
+timeLimitsBlockFetch :: forall (block :: Type) (point :: Type).
                         ProtocolTimeLimits (BlockFetch block point)
 timeLimitsBlockFetch = ProtocolTimeLimits stateToLimit
   where
@@ -138,7 +139,7 @@ codecBlockFetch encodeBlock decodeBlock
 
 
 codecBlockFetchId
-  :: forall block point m.
+  :: forall (block :: Type) (point :: Type) m.
      Monad m
   => Codec (BlockFetch block point) CodecFailure m
            (AnyMessage (BlockFetch block point))

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/ChainSync/Codec.hs
@@ -23,6 +23,7 @@ import Ouroboros.Network.Protocol.ChainSync.Type
 import Ouroboros.Network.Protocol.Limits
 
 import Data.ByteString.Lazy qualified as LBS
+import Data.Kind (Type)
 import Data.Singletons (withSingI)
 import System.Random (StdGen, randomR)
 
@@ -78,7 +79,7 @@ maxChainSyncTimeout = 269
 -- | @'StIntersect'@            | 'shortWait'                                                 |
 -- +----------------------------+-------------------------------------------------------------+
 --
-timeLimitsChainSync :: forall header point tip.
+timeLimitsChainSync :: forall (header :: Type) (point :: Type) (tip :: Type).
                        StdGen
                     -> ProtocolTimeLimits (ChainSync header point tip)
 timeLimitsChainSync rnd = ProtocolTimeLimits stateToLimit

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/KeepAlive/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/KeepAlive/Codec.hs
@@ -86,6 +86,16 @@ byteLimitsKeepAlive = ProtocolSizeLimits sizeLimitForState
     sizeLimitForState a@SingDone = notActiveState a
 
 
+-- | 'KeepAlive' time limits.
+--
+-- +--------------------+---------------+
+-- | 'KeepAlive' state  | timeout (s)   |
+-- +====================+===============+
+-- | `StClient`         | @Just 97@     |
+-- +--------------------+---------------+
+-- | `StServer`         | @Just 60@     |
+-- +--------------------+---------------+
+--
 timeLimitsKeepAlive :: ProtocolTimeLimits KeepAlive
 timeLimitsKeepAlive = ProtocolTimeLimits { timeLimitForState }
   where

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
@@ -10,21 +10,20 @@
 module Ouroboros.Network.Protocol.TxSubmission2.Codec
   ( codecTxSubmission2
   , codecTxSubmission2Id
-  , encodeTxSubmission2
-  , decodeTxSubmission2
   , byteLimitsTxSubmission2
   , timeLimitsTxSubmission2
   ) where
 
 import Control.Monad.Class.MonadST
 import Control.Monad.Class.MonadTime.SI
+import Data.ByteString.Lazy (ByteString)
+import Data.Kind (Type)
 import Data.List.NonEmpty qualified as NonEmpty
+import Text.Printf
 
 import Codec.CBOR.Decoding qualified as CBOR
 import Codec.CBOR.Encoding qualified as CBOR
 import Codec.CBOR.Read qualified as CBOR
-import Data.ByteString.Lazy (ByteString)
-import Text.Printf
 
 import Network.TypedProtocol.Codec.CBOR
 
@@ -63,6 +62,7 @@ byteLimitsTxSubmission2 = ProtocolSizeLimits stateToLimit
 -- | `StTxs`                     | `shortWait`   |
 -- +-----------------------------+---------------+
 --
+timeLimitsTxSubmission2 :: forall (txid :: Type) (tx :: Type). ProtocolTimeLimits (TxSubmission2 txid tx)
 timeLimitsTxSubmission2 = ProtocolTimeLimits stateToLimit
   where
     stateToLimit :: forall (st :: TxSubmission2 txid tx).
@@ -76,7 +76,7 @@ timeLimitsTxSubmission2 = ProtocolTimeLimits stateToLimit
 
 
 codecTxSubmission2
-  :: forall txid tx m.
+  :: forall (txid :: Type) (tx :: Type) m.
      MonadST m
   => (txid -> CBOR.Encoding)
   -- ^ encode 'txid'
@@ -103,7 +103,7 @@ codecTxSubmission2 encodeTxId decodeTxId
       decodeTxSubmission2 decodeTxId decodeTx stok len key
 
 encodeTxSubmission2
-    :: forall txid tx (st :: TxSubmission2 txid tx) (st' :: TxSubmission2 txid tx).
+    :: forall (txid :: Type) (tx :: Type) (st :: TxSubmission2 txid tx) (st' :: TxSubmission2 txid tx).
        (txid -> CBOR.Encoding)
     -- ^ encode 'txid'
     -> (tx -> CBOR.Encoding)

--- a/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
+++ b/ouroboros-network-protocols/src/Ouroboros/Network/Protocol/TxSubmission2/Codec.hs
@@ -47,13 +47,22 @@ byteLimitsTxSubmission2 = ProtocolSizeLimits stateToLimit
     stateToLimit a@SingDone                  = notActiveState a
 
 
--- | Time Limits.
+-- | 'TxSubmission2' time limits.
 --
--- `SingTxIds SingBlocking` No timeout
--- `SingTxIds SingNonBlocking` `shortWait` timeout
--- `SingTxs` `shortWait` timeout
--- `SingIdle` `shortWait` timeout
-timeLimitsTxSubmission2 :: forall txid tx. ProtocolTimeLimits (TxSubmission2 txid tx)
+-- +-----------------------------+---------------+
+-- | 'TxSubmission2' state       | timeout (s)   |
+-- +=============================+===============+
+-- | `StInit`                    | `waitForever` |
+-- +-----------------------------+---------------+
+-- | `StIdle`                    | `waitForever` |
+-- +-----------------------------+---------------+
+-- | @'StTxIds' 'StBlocking'@    | `waitForever` |
+-- +-----------------------------+---------------+
+-- | @'StTxIds' 'StNonBlocking'@ | `shortWait`   |
+-- +-----------------------------+---------------+
+-- | `StTxs`                     | `shortWait`   |
+-- +-----------------------------+---------------+
+--
 timeLimitsTxSubmission2 = ProtocolTimeLimits stateToLimit
   where
     stateToLimit :: forall (st :: TxSubmission2 txid tx).
@@ -70,9 +79,13 @@ codecTxSubmission2
   :: forall txid tx m.
      MonadST m
   => (txid -> CBOR.Encoding)
+  -- ^ encode 'txid'
   -> (forall s . CBOR.Decoder s txid)
+  -- ^ decode 'txid'
   -> (tx -> CBOR.Encoding)
+  -- ^ encode transaction
   -> (forall s . CBOR.Decoder s tx)
+  -- ^ decode transaction
   -> Codec (TxSubmission2 txid tx) CBOR.DeserialiseFailure m ByteString
 codecTxSubmission2 encodeTxId decodeTxId
                    encodeTx   decodeTx =
@@ -90,16 +103,17 @@ codecTxSubmission2 encodeTxId decodeTxId
       decodeTxSubmission2 decodeTxId decodeTx stok len key
 
 encodeTxSubmission2
-    :: forall txid tx.
+    :: forall txid tx (st :: TxSubmission2 txid tx) (st' :: TxSubmission2 txid tx).
        (txid -> CBOR.Encoding)
+    -- ^ encode 'txid'
     -> (tx -> CBOR.Encoding)
-    -> (forall (st :: TxSubmission2 txid tx) (st' :: TxSubmission2 txid tx).
-               Message (TxSubmission2 txid tx) st st'
-            -> CBOR.Encoding)
+    -- ^ encode 'tx'
+    -> Message (TxSubmission2 txid tx) st st'
+    -> CBOR.Encoding
 encodeTxSubmission2 encodeTxId encodeTx = encode
   where
-    encode :: forall st st'.
-              Message (TxSubmission2 txid tx) st st'
+    encode :: forall st0 st1.
+              Message (TxSubmission2 txid tx) st0 st1
            -> CBOR.Encoding
     encode MsgInit =
         CBOR.encodeListLen 1
@@ -148,23 +162,24 @@ encodeTxSubmission2 encodeTxId encodeTx = encode
 
 
 decodeTxSubmission2
-    :: forall txid tx.
-       (forall s . CBOR.Decoder s txid)
-    -> (forall s . CBOR.Decoder s tx)
-    -> (forall (st :: TxSubmission2 txid tx) s.
-               ActiveState st
-            => StateToken st
-            -> Int
-            -> Word
-            -> CBOR.Decoder s (SomeMessage st))
+    :: forall (txid :: Type) (tx :: Type) (st :: TxSubmission2 txid tx) s.
+       ActiveState st
+    => (forall s'. CBOR.Decoder s' txid)
+    -- ^ decode 'txid'
+    -> (forall s'. CBOR.Decoder s' tx)
+    -- ^ decode transaction
+    -> StateToken st
+    -> Int
+    -> Word
+    -> CBOR.Decoder s (SomeMessage st)
 decodeTxSubmission2 decodeTxId decodeTx = decode
   where
-    decode :: forall s (st :: TxSubmission2 txid tx).
-              ActiveState st
-           => StateToken st
+    decode :: forall (st' :: TxSubmission2 txid tx).
+              ActiveState st'
+           => StateToken st'
            -> Int
            -> Word
-           -> CBOR.Decoder s (SomeMessage st)
+           -> CBOR.Decoder s (SomeMessage st')
     decode stok len key = do
       case (stok, len, key) of
         (SingInit,       1, 6) ->

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Policies.hs
@@ -40,18 +40,6 @@ deactivateTimeout = 300
 closeConnectionTimeout :: DiffTime
 closeConnectionTimeout = 120
 
-
--- | Chain sync `mustReplayTimeout` lower bound.
---
-minChainSyncTimeout :: DiffTime
-minChainSyncTimeout = 135
-
-
--- | Chain sync `mustReplayTimeout` upper bound.
---
-maxChainSyncTimeout :: DiffTime
-maxChainSyncTimeout = 269
-
 -- | Churn timeouts after 60s trying to establish a connection.
 --
 -- This doesn't mean the connection is terminated after it, just churns moves

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -139,7 +139,7 @@ data LimitsAndTimeouts header block = LimitsAndTimeouts
       :: ProtocolSizeLimits (ChainSync header (Point block) (Tip block))
                             ByteString
   , chainSyncTimeLimits
-      :: StdGen -> ProtocolTimeLimits (ChainSync header (Point block) (Tip block))
+      :: ProtocolTimeLimitsWithRnd (ChainSync header (Point block) (Tip block))
 
     -- block-fetch
   , blockFetchLimits

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano.hs
@@ -348,7 +348,6 @@ unit_cm_valid_transitions =
             [ ( NodeArgs
                   (-2)
                   InitiatorAndResponderDiffusionMode
-                  (Just 269)
                   (Map.fromList [(RelayAccessAddress "0:71:0:1:0:1:0:1" 65_534,
                                   DoAdvertisePeer)])
                   GenesisMode
@@ -391,7 +390,6 @@ unit_cm_valid_transitions =
               , ( NodeArgs
                   0
                   InitiatorAndResponderDiffusionMode
-                  (Just 90)
                   Map.empty
                   GenesisMode
                   (Script (DontUseBootstrapPeers :| []))
@@ -567,7 +565,6 @@ unit_connection_manager_trace_coverage =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -597,7 +594,6 @@ unit_connection_manager_trace_coverage =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -691,7 +687,6 @@ unit_connection_manager_transitions_coverage =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -721,7 +716,6 @@ unit_connection_manager_transitions_coverage =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -1013,7 +1007,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
     script =
       DiffusionScript (SimArgs 1 10)
         (singletonTimedScript Map.empty)
-        [ ( NodeArgs (-6) InitiatorAndResponderDiffusionMode (Just 180)
+        [ ( NodeArgs (-6) InitiatorAndResponderDiffusionMode
               (Map.fromList [(RelayAccessDomain "test2" 65_535, DoAdvertisePeer)])
               PraosMode
               (Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []))
@@ -1044,7 +1038,7 @@ unit_4177 = prop_inbound_governor_transitions_coverage absNoAttenuation script
             ,Reconfigure 4.870_967_741_935 [(1,1,Map.fromList [(RelayAccessDomain "test2" 65_535,LocalRootConfig DoAdvertisePeer InitiatorAndResponderDiffusionMode IsNotTrustable)])]
             ]
           )
-        , ( NodeArgs 1 InitiatorAndResponderDiffusionMode (Just 135)
+        , ( NodeArgs 1 InitiatorAndResponderDiffusionMode
              (Map.fromList [(RelayAccessAddress "0:7:0:7::" 65_533, DoAdvertisePeer)])
              PraosMode
               (Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []))
@@ -1669,7 +1663,6 @@ unit_4191 = testWithIOSim prop_diffusion_dns_can_recover long_trace absInfo scri
         [(NodeArgs
             16
             InitiatorAndResponderDiffusionMode
-            (Just 224)
             Map.empty
             PraosMode
             (Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []))
@@ -1785,7 +1778,6 @@ prop_connect_failure (AbsIOError ioerr) =
         [ (NodeArgs {
             naSeed = 0,
             naDiffusionMode = InitiatorAndResponderDiffusionMode,
-            naMbTime = Just 224,
             naPublicRoots = Map.empty,
             naConsensusMode = PraosMode,
             naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -1814,7 +1806,6 @@ prop_connect_failure (AbsIOError ioerr) =
           (NodeArgs {
             naSeed = 0,
             naDiffusionMode = InitiatorAndResponderDiffusionMode,
-            naMbTime = Just 224,
             naPublicRoots = Map.empty,
             naConsensusMode = PraosMode,
             naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -1911,7 +1902,6 @@ prop_accept_failure (AbsIOError ioerr) =
         [ (NodeArgs {
             naSeed = 0,
             naDiffusionMode = InitiatorAndResponderDiffusionMode,
-            naMbTime = Just 224,
             naPublicRoots = Map.empty,
             naConsensusMode = PraosMode,
             naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -1940,7 +1930,6 @@ prop_accept_failure (AbsIOError ioerr) =
           (NodeArgs {
             naSeed = 0,
             naDiffusionMode = InitiatorAndResponderDiffusionMode,
-            naMbTime = Just 224,
             naPublicRoots = Map.empty,
             naConsensusMode = PraosMode,
             naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -2967,7 +2956,6 @@ async_demotion_network_script =
     common = NodeArgs {
         naSeed             = 10,
         naDiffusionMode    = InitiatorAndResponderDiffusionMode,
-        naMbTime           = Just 1,
         naPublicRoots      = Map.empty,
         naConsensusMode    = PraosMode,
         naBootstrapPeers   = Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []),
@@ -3546,8 +3534,8 @@ prop_unit_4258 =
       diffScript = DiffusionScript
         (SimArgs 1 10)
         (singletonTimedScript Map.empty)
-        [( NodeArgs (-3) InitiatorAndResponderDiffusionMode (Just 224)
-             Map.empty
+        [( NodeArgs (-3) InitiatorAndResponderDiffusionMode
+             (Map.fromList [])
              PraosMode
              (Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []))
              (TestAddress (IPAddr (read "0.0.0.4") 9))
@@ -3580,7 +3568,7 @@ prop_unit_4258 =
              Reconfigure 4.190_476_190_476 []
            ]
          ),
-         ( NodeArgs (-5) InitiatorAndResponderDiffusionMode (Just 269)
+         ( NodeArgs (-5) InitiatorAndResponderDiffusionMode
              (Map.fromList [(RelayAccessAddress "0.0.0.4" 9, DoAdvertisePeer)])
              PraosMode
              (Script (UseBootstrapPeers [RelayAccessDomain "bootstrap" 0] :| []))
@@ -3652,7 +3640,6 @@ prop_unit_reconnect =
           [(NodeArgs
               (-3)
               InitiatorAndResponderDiffusionMode
-              (Just 224)
               Map.empty
               PraosMode
               (Script (DontUseBootstrapPeers :| []))
@@ -3683,7 +3670,6 @@ prop_unit_reconnect =
           , (NodeArgs
                (-1)
                InitiatorAndResponderDiffusionMode
-               (Just 2)
                Map.empty
                PraosMode
                (Script (DontUseBootstrapPeers :| []))
@@ -4108,7 +4094,6 @@ unit_peer_sharing =
     defaultNodeArgs naConsensusMode = NodeArgs {
         naSeed = 0,
         naDiffusionMode = InitiatorAndResponderDiffusionMode,
-        naMbTime = Nothing,
         naPublicRoots = mempty,
         naBootstrapPeers = singletonScript DontUseBootstrapPeers,
         naAddr = undefined,
@@ -4614,7 +4599,6 @@ unit_local_root_diffusion_mode diffusionMode =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),
@@ -4644,7 +4628,6 @@ unit_local_root_diffusion_mode diffusionMode =
           (NodeArgs {
              naSeed = 0,
              naDiffusionMode = InitiatorAndResponderDiffusionMode,
-             naMbTime = Just 224,
              naPublicRoots = Map.empty,
              naConsensusMode = PraosMode,
              naBootstrapPeers = Script (DontUseBootstrapPeers :| []),

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
@@ -119,8 +119,8 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig, WarmValency (..))
 import Ouroboros.Network.Protocol.BlockFetch.Codec (byteLimitsBlockFetch,
            timeLimitsBlockFetch)
-import Ouroboros.Network.Protocol.ChainSync.Codec (ChainSyncTimeout (..),
-           byteLimitsChainSync, timeLimitsChainSync)
+import Ouroboros.Network.Protocol.ChainSync.Codec (byteLimitsChainSync,
+           timeLimitsChainSync)
 import Ouroboros.Network.Protocol.KeepAlive.Codec (byteLimitsKeepAlive,
            timeLimitsKeepAlive)
 import Ouroboros.Network.Protocol.Limits (shortWait, smallByteLimit)
@@ -193,8 +193,6 @@ data NodeArgs =
     { naSeed                   :: Int
       -- ^ 'randomBlockGenerationArgs' seed argument
     , naDiffusionMode          :: DiffusionMode
-    , naMbTime                 :: Maybe DiffTime
-      -- ^ 'LimitsAndTimeouts' argument
     , naPublicRoots            :: Map RelayAccessPoint PeerAdvertise
       -- ^ 'Interfaces' relays auxiliary value
     , naConsensusMode          :: ConsensusMode
@@ -222,7 +220,7 @@ data NodeArgs =
     }
 
 instance Show NodeArgs where
-    show NodeArgs { naSeed, naDiffusionMode, naMbTime, naBootstrapPeers,
+    show NodeArgs { naSeed, naDiffusionMode, naBootstrapPeers,
                     naPublicRoots, naAddr, naPeerSharing, naLedgerPeers,
                     naLocalRootPeers, naPeerTargets, naDNSTimeoutScript,
                     naDNSLookupDelayScript, naChainSyncExitOnBlockNo,
@@ -230,7 +228,6 @@ instance Show NodeArgs where
       unwords [ "NodeArgs"
               , "(" ++ show naSeed ++ ")"
               , show naDiffusionMode
-              , "(" ++ show naMbTime ++ ")"
               , "(" ++ show naPublicRoots ++ ")"
               , show naConsensusMode
               , "(" ++ show naBootstrapPeers ++ ")"
@@ -378,20 +375,6 @@ genNodeArgs relays minConnected localRootPeers self = flip suchThat hasUpstream 
                              , (3, pure InitiatorAndResponderDiffusionMode)
                              ]
 
-  -- These values approximately correspond to false positive
-  -- thresholds for streaks of empty slots with 99% probability,
-  -- 99.9% probability up to 99.999% probability.
-  -- t = T_s [log (1-Y) / log (1-f)]
-  -- Y = [0.99, 0.999...]
-  --
-  -- T_s = slot length of 1s.
-  -- f = 0.05
-  -- The timeout is randomly picked per bearer to avoid all bearers
-  -- going down at the same time in case of a long streak of empty
-  -- slots. TODO: workaround until peer selection governor.
-  -- Taken from ouroboros-consensus/src/Ouroboros/Consensus/Node.hs
-  mustReplyTimeout <- Just <$> oneof (pure <$> [90, 135, 180, 224, 269])
-
   -- Make sure our targets for active peers cover the maximum of peers
   -- one generated
   SmallTargets deadlineTargets <- resize (length relays * 2) arbitrary
@@ -440,7 +423,6 @@ genNodeArgs relays minConnected localRootPeers self = flip suchThat hasUpstream 
    $ NodeArgs
       { naSeed                   = seed
       , naDiffusionMode          = diffusionMode
-      , naMbTime                 = mustReplyTimeout
       , naPublicRoots            = publicRoots
         -- TODO: we haven't been using public root peers so far because we set
         -- `UseLedgerPeers 0`!
@@ -1046,7 +1028,6 @@ diffusionSimulation
             }
             NodeArgs
             { naSeed                   = seed
-            , naMbTime                 = mustReplyTimeout
             , naPublicRoots            = publicRoots
             , naConsensusMode          = consensusMode
             , naBootstrapPeers         = bootstrapPeers
@@ -1089,22 +1070,12 @@ diffusionSimulation
                                            bgaRng
                                            quota
 
-          stdChainSyncTimeout :: ChainSyncTimeout
-          stdChainSyncTimeout = do
-              ChainSyncTimeout
-                { canAwaitTimeout  = shortWait
-                , intersectTimeout = shortWait
-                , mustReplyTimeout
-                , idleTimeout      = Nothing
-                }
-
           limitsAndTimeouts :: Node.LimitsAndTimeouts BlockHeader Block
           limitsAndTimeouts
             = Node.LimitsAndTimeouts
                 { Node.chainSyncLimits      = defaultMiniProtocolsLimit
                 , Node.chainSyncSizeLimits  = byteLimitsChainSync (const 0)
-                , Node.chainSyncTimeLimits  =
-                    timeLimitsChainSync stdChainSyncTimeout
+                , Node.chainSyncTimeLimits  = timeLimitsChainSync
                 , Node.blockFetchLimits     = defaultMiniProtocolsLimit
                 , Node.blockFetchSizeLimits = byteLimitsBlockFetch (const 0)
                 , Node.blockFetchTimeLimits = timeLimitsBlockFetch
@@ -1148,7 +1119,7 @@ diffusionSimulation
                       return $ Map.elems
                              $ accPoolStake
                              $ getLedgerPools
-                             $ ledgerPools)
+                               ledgerPools)
                     Cardano.LedgerPeersConsensusInterface {
                       Cardano.readFetchMode = pure (PraosFetchMode FetchModeDeadline)
                     , Cardano.getLedgerStateJudgement = pure TooOld


### PR DESCRIPTION

# Description

Provide access to a pseudo random number generator for consructing
`ProtocolTimeLimits`.  This is used for `ChainSync` timeout in the `StNext
StMustReply` state.

- **chain-sync: randomised ProtocolTimeLimits**
- **ouroboros-network-protocols: improved haddocks**
- **ouroboros-network-protocols: improved haddocks of node-to-node protocols**
- **ouroboros-network-protocols: type signatures**
- **Updated CHANGELOG.md files**

Depends on:
* [x] #4974
* [x] #4979

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
