### PR TITLE
Remove NodeToNodeV_12 older

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -9,6 +9,11 @@
      and `reRelativeStake` -> `recomputeRelativeStake`
 * Added `NodeToClientVersionV18`
 * Using `typed-protocols-0.3.0.0`.
+* Removed `NodeToNodeV_12` and older as these are unable
+  to cross the hard fork boundary.
+* Removed `WhetherReceivingTentativeBlocks` used to
+  distinguish whether a node version is pipelining-enabled,
+  used in older `NodeToNodeVersion`
 
 ### Non-breaking changes
 

--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -4,7 +4,6 @@
 module Ouroboros.Network.BlockFetch.ConsensusInterface
   ( FetchMode (..)
   , BlockFetchConsensusInterface (..)
-  , WhetherReceivingTentativeBlocks (..)
   , FromConsensus (..)
   ) where
 
@@ -86,8 +85,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- That function and 'readFetchedBlocks' are required to be linked. Upon
        -- successful completion of @addFetchedBlock@ it must be the case that
        -- 'readFetchedBlocks' reports the block.
-       mkAddFetchedBlock      :: WhetherReceivingTentativeBlocks
-                              -> STM m (Point block -> block -> m ()),
+       mkAddFetchedBlock      :: STM m (Point block -> block -> m ()),
 
        -- | The highest stored/downloaded slot number.
        --
@@ -151,13 +149,6 @@ data BlockFetchConsensusInterface peer header block m =
        -- WARNING: Same as 'headerForgeUTCTime'.
        blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime
      }
-
-
--- | Whether the block fetch peer is sending tentative blocks, which are
--- understood to possibly be invalid
-data WhetherReceivingTentativeBlocks
-  = ReceivingTentativeBlocks
-  | NotReceivingTentativeBlocks
 
 {-------------------------------------------------------------------------------
   Syntactic indicator of key precondition about Consensus time conversions

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -10,7 +10,6 @@ module Ouroboros.Network.NodeToNode.Version
   , ConnectionMode (..)
   , nodeToNodeVersionCodec
   , nodeToNodeCodecCBORTerm
-  , isPipeliningEnabled
   ) where
 
 import Data.Text (Text)
@@ -21,8 +20,6 @@ import Codec.CBOR.Term qualified as CBOR
 
 import Control.DeepSeq
 import GHC.Generics
-import Ouroboros.Network.BlockFetch.ConsensusInterface
-           (WhetherReceivingTentativeBlocks (..))
 import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Handshake.Acceptable (Accept (..), Acceptable (..))
 import Ouroboros.Network.Handshake.Queryable (Queryable (..))

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Ouroboros.Network.NodeToNode.Version
@@ -30,38 +31,39 @@ import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 
 -- | Enumeration of node to node protocol versions.
 --
-data NodeToNodeVersion
-    = NodeToNodeV_7
-    -- ^ Changes:
-    --
-    -- * new 'KeepAlive' codec
-    -- * Enable @CardanoNodeToNodeVersion5@, i.e., Alonzo
-    | NodeToNodeV_8
-    -- ^ Changes:
-    --
-    -- * Enable block diffusion pipelining in ChainSync and BlockFetch logic.
-    | NodeToNodeV_9
-    -- ^ Changes:
-    --
-    -- * Enable @CardanoNodeToNodeVersion6@, i.e., Babbage
-    | NodeToNodeV_10
-    -- ^ Changes:
-    --
-    -- * Enable full duplex connections.
-    | NodeToNodeV_11
-    -- ^ Changes:
-    --
-    -- * Adds a new extra parameter to handshake: PeerSharing
-    --   This version is needed to support the new  Peer Sharing miniprotocol
-    --   older versions that are negotiated will appear as not participating
-    --   in Peer Sharing to newer versions.
-    -- * Adds `query` to NodeToClientVersionData.
-    | NodeToNodeV_12
-    -- ^ No changes.
-    --
-    -- (In the past, this enabled Conway, but the negotiated 'NodeToNodeVersion'
-    -- no longer en-/disables eras.)
-    | NodeToNodeV_13
+data NodeToNodeVersion =
+    -- commented out versions that can't cross into the current HF era
+    -- NodeToNodeV_7
+    -- -- ^ Changes:
+    -- --
+    -- -- * new 'KeepAlive' codec
+    -- -- * Enable @CardanoNodeToNodeVersion5@, i.e., Alonzo
+    -- | NodeToNodeV_8
+    -- -- ^ Changes:
+    -- --
+    -- -- * Enable block diffusion pipelining in ChainSync and BlockFetch logic.
+    -- | NodeToNodeV_9
+    -- -- ^ Changes:
+    -- --
+    -- -- * Enable @CardanoNodeToNodeVersion6@, i.e., Babbage
+    -- | NodeToNodeV_10
+    -- -- ^ Changes:
+    -- --
+    -- -- * Enable full duplex connections.
+    -- | NodeToNodeV_11
+    -- -- ^ Changes:
+    -- --
+    -- -- * Adds a new extra parameter to handshake: PeerSharing
+    -- --   This version is needed to support the new  Peer Sharing miniprotocol
+    -- --   older versions that are negotiated will appear as not participating
+    -- --   in Peer Sharing to newer versions.
+    -- -- * Adds `query` to NodeToClientVersionData.
+    -- | NodeToNodeV_12
+    -- -- ^ No changes.
+    -- --
+    -- -- (In the past, this enabled Conway, but the negotiated 'NodeToNodeVersion'
+    -- -- no longer en-/disables eras.)
+    NodeToNodeV_13
     -- ^ Changes:
     --
     -- * Removed PeerSharingPrivate constructor
@@ -73,22 +75,10 @@ data NodeToNodeVersion
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
 nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
   where
-    encodeTerm NodeToNodeV_7  = CBOR.TInt 7
-    encodeTerm NodeToNodeV_8  = CBOR.TInt 8
-    encodeTerm NodeToNodeV_9  = CBOR.TInt 9
-    encodeTerm NodeToNodeV_10 = CBOR.TInt 10
-    encodeTerm NodeToNodeV_11 = CBOR.TInt 11
-    encodeTerm NodeToNodeV_12 = CBOR.TInt 12
     encodeTerm NodeToNodeV_13 = CBOR.TInt 13
 
-    decodeTerm (CBOR.TInt 7) = Right NodeToNodeV_7
-    decodeTerm (CBOR.TInt 8) = Right NodeToNodeV_8
-    decodeTerm (CBOR.TInt 9) = Right NodeToNodeV_9
-    decodeTerm (CBOR.TInt 10) = Right NodeToNodeV_10
-    decodeTerm (CBOR.TInt 11) = Right NodeToNodeV_11
-    decodeTerm (CBOR.TInt 12) = Right NodeToNodeV_12
     decodeTerm (CBOR.TInt 13) = Right NodeToNodeV_13
-    decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknonw tag: "
+    decodeTerm (CBOR.TInt n) = Left ( T.pack "decode NodeToNodeVersion: unknown tag: "
                                         <> T.pack (show n)
                                     , Just n
                                     )
@@ -157,121 +147,49 @@ instance Queryable NodeToNodeVersionData where
     queryVersion = query
 
 nodeToNodeCodecCBORTerm :: NodeToNodeVersion -> CodecCBORTerm Text NodeToNodeVersionData
-nodeToNodeCodecCBORTerm version
-  | version >= NodeToNodeV_13 =
-    let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
-        encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode, peerSharing, query }
-          = CBOR.TList
-              [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
-              , CBOR.TBool (case diffusionMode of
-                             InitiatorOnlyDiffusionMode         -> True
-                             InitiatorAndResponderDiffusionMode -> False)
-              , CBOR.TInt (case peerSharing of
-                             PeerSharingDisabled -> 0
-                             PeerSharingEnabled  -> 1)
-              , CBOR.TBool query
-              ]
+nodeToNodeCodecCBORTerm =
+  \case
+    NodeToNodeV_13 -> v13
 
-        decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
-        decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode, CBOR.TInt peerSharing, CBOR.TBool query])
-          | x >= 0
-          , x <= 0xffffffff
-          , Just ps <- case peerSharing of
-                        0 -> Just PeerSharingDisabled
-                        1 -> Just PeerSharingEnabled
-                        _ -> Nothing
-          = Right
-              NodeToNodeVersionData {
-                  networkMagic = NetworkMagic (fromIntegral x),
-                  diffusionMode = if diffusionMode
-                                  then InitiatorOnlyDiffusionMode
-                                  else InitiatorAndResponderDiffusionMode,
-                  peerSharing = ps,
-                  query = query
-                }
-          | x < 0 || x > 0xffffffff
-          = Left $ T.pack $ "networkMagic out of bound: " <> show x
-          | otherwise -- peerSharing < 0 || peerSharing > 1
-          = Left $ T.pack $ "peerSharing is out of bound: " <> show peerSharing
-        decodeTerm t
-          = Left $ T.pack $ "unknown encoding: " ++ show t
-     in CodecCBORTerm { encodeTerm, decodeTerm }
-  | version >= NodeToNodeV_11
-  , version <= NodeToNodeV_12 =
-    let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
-        encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode, query }
-          = CBOR.TList
-              [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
-              , CBOR.TBool (case diffusionMode of
-                             InitiatorOnlyDiffusionMode         -> True
-                             InitiatorAndResponderDiffusionMode -> False)
-                              -- There's a bug in this versions where the
-                              -- agreed PeerSharing value on the remote side
-                              -- is whatever that got proposed, so we have to
-                              -- disable peer sharing with such nodes to avoid
-                              -- protocol violations
-              , CBOR.TInt 0 -- 0 corresponds to PeerSharingDisabled
-              , CBOR.TBool query
-              ]
+  where
+    v13 = CodecCBORTerm { encodeTerm = encodeTerm13, decodeTerm = decodeTerm13 }
 
-        decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
-        decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode, CBOR.TInt _, CBOR.TBool query])
-          | x >= 0
-          , x <= 0xffffffff
-          = Right
-              NodeToNodeVersionData {
-                  networkMagic = NetworkMagic (fromIntegral x),
-                  diffusionMode = if diffusionMode
-                                  then InitiatorOnlyDiffusionMode
-                                  else InitiatorAndResponderDiffusionMode,
-                  peerSharing = PeerSharingDisabled,
-                  query = query
-                }
-          | x < 0 || x > 0xffffffff
-          = Left $ T.pack $ "networkMagic out of bound: " <> show x
-        decodeTerm t
-          = Left $ T.pack $ "unknown encoding: " ++ show t
-     in CodecCBORTerm { encodeTerm, decodeTerm }
-  | otherwise =
-    let encodeTerm :: NodeToNodeVersionData -> CBOR.Term
-        encodeTerm NodeToNodeVersionData { networkMagic, diffusionMode }
-          = CBOR.TList
-                  [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
-                  , CBOR.TBool (case diffusionMode of
-                                 InitiatorOnlyDiffusionMode         -> True
-                                 InitiatorAndResponderDiffusionMode -> False)
-                  ]
+    encodeTerm13 :: NodeToNodeVersionData -> CBOR.Term
+    encodeTerm13 NodeToNodeVersionData { networkMagic, diffusionMode, peerSharing, query }
+      = CBOR.TList
+          [ CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
+          , CBOR.TBool (case diffusionMode of
+                         InitiatorOnlyDiffusionMode         -> True
+                         InitiatorAndResponderDiffusionMode -> False)
+          , CBOR.TInt (case peerSharing of
+                         PeerSharingDisabled -> 0
+                         PeerSharingEnabled  -> 1)
+          , CBOR.TBool query
+          ]
 
-        decodeTerm :: CBOR.Term -> Either Text NodeToNodeVersionData
-        decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode])
-          | x >= 0
-          , x <= 0xffffffff
-          = Right
-              NodeToNodeVersionData {
-                  networkMagic  = NetworkMagic (fromIntegral x)
-                , diffusionMode = if diffusionMode
-                                  then InitiatorOnlyDiffusionMode
-                                  else InitiatorAndResponderDiffusionMode
-                  -- By default older versions do not participate in Peer
-                  -- Sharing, since they do not support the new miniprotocol
-                , peerSharing = PeerSharingDisabled
-                , query = False
-                }
-          | otherwise
-          = Left $ T.pack $ "networkMagic out of bound: " <> show x
-        decodeTerm t
-          = Left $ T.pack $ "unknown encoding: " ++ show t
-     in CodecCBORTerm { encodeTerm, decodeTerm }
+    decodeTerm13 :: CBOR.Term -> Either Text NodeToNodeVersionData
+    decodeTerm13 (CBOR.TList [CBOR.TInt x, CBOR.TBool diffusionMode, CBOR.TInt peerSharing, CBOR.TBool query])
+      | x >= 0
+      , x <= 0xffffffff
+      , Just ps <- case peerSharing of
+                    0 -> Just PeerSharingDisabled
+                    1 -> Just PeerSharingEnabled
+                    _ -> Nothing
+      = Right
+          NodeToNodeVersionData {
+              networkMagic = NetworkMagic (fromIntegral x),
+              diffusionMode = if diffusionMode
+                              then InitiatorOnlyDiffusionMode
+                              else InitiatorAndResponderDiffusionMode,
+              peerSharing = ps,
+              query = query
+            }
+      | x < 0 || x > 0xffffffff
+      = Left $ T.pack $ "networkMagic out of bound: " <> show x
+      | otherwise -- peerSharing < 0 || peerSharing > 1
+      = Left $ T.pack $ "peerSharing is out of bound: " <> show peerSharing
+    decodeTerm13 t
+      = Left $ T.pack $ "unknown encoding: " ++ show t
 
 
 data ConnectionMode = UnidirectionalMode | DuplexMode
-
--- | Check whether a version enabling diffusion pipelining has been
--- negotiated.
---
--- TODO: this ought to be defined in `ouroboros-consensus` or
--- `ouroboros-consensus-diffusion`
-isPipeliningEnabled :: NodeToNodeVersion -> WhetherReceivingTentativeBlocks
-isPipeliningEnabled v
-  | v >= NodeToNodeV_8 = ReceivingTentativeBlocks
-  | otherwise          = NotReceivingTentativeBlocks

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/PeerSharing/Codec.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/PeerSharing/Codec.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE LambdaCase #-}
+
 module Ouroboros.Network.PeerSelection.PeerSharing.Codec
   ( encodePortNumber
   , decodePortNumber
@@ -26,9 +28,11 @@ decodePortNumber = fromIntegral <$> CBOR.decodeWord16
 -- /Invariant:/ not a unix socket address type.
 ---
 encodeRemoteAddress :: NodeToNodeVersion -> SockAddr -> CBOR.Encoding
-encodeRemoteAddress ntnVersion sockAddr
-  | ntnVersion >= NodeToNodeV_13 =
-    case sockAddr of
+encodeRemoteAddress =
+  \case
+    NodeToNodeV_13 -> sockAddr
+  where
+    sockAddr = \case
       SockAddrInet pn w -> CBOR.encodeListLen 3
                         <> CBOR.encodeWord 0
                         <> CBOR.encodeWord32 w
@@ -41,22 +45,6 @@ encodeRemoteAddress ntnVersion sockAddr
                                             <> CBOR.encodeWord32 w4
                                             <> encodePortNumber pn
       SockAddrUnix _ -> error "Should never be encoding a SockAddrUnix!"
-  | otherwise =
-    case sockAddr of
-      SockAddrInet pn w -> CBOR.encodeListLen 3
-                        <> CBOR.encodeWord 0
-                        <> CBOR.encodeWord32 w
-                        <> encodePortNumber pn
-      SockAddrInet6 pn fi (w1, w2, w3, w4) si -> CBOR.encodeListLen 8
-                                              <> CBOR.encodeWord 1
-                                              <> CBOR.encodeWord32 w1
-                                              <> CBOR.encodeWord32 w2
-                                              <> CBOR.encodeWord32 w3
-                                              <> CBOR.encodeWord32 w4
-                                              <> CBOR.encodeWord32 fi
-                                              <> CBOR.encodeWord32 si
-                                              <> encodePortNumber pn
-      SockAddrUnix _ -> error "Should never be encoding a SockAddrUnix!"
 
 -- | This decoder should be faithful to the PeerSharing
 -- CDDL Specification.
@@ -64,39 +52,23 @@ encodeRemoteAddress ntnVersion sockAddr
 -- See the network design document for more details
 --
 decodeRemoteAddress :: NodeToNodeVersion -> CBOR.Decoder s SockAddr
-decodeRemoteAddress ntnVersion
-  | ntnVersion >= NodeToNodeV_13 = do
-    _ <- CBOR.decodeListLen
-    tok <- CBOR.decodeWord
-    case tok of
-      0 -> do
-        w <- CBOR.decodeWord32
-        pn <- decodePortNumber
-        return (SockAddrInet pn w)
-      1 -> do
-        w1 <- CBOR.decodeWord32
-        w2 <- CBOR.decodeWord32
-        w3 <- CBOR.decodeWord32
-        w4 <- CBOR.decodeWord32
-        pn <- decodePortNumber
-        return (SockAddrInet6 pn 0 (w1, w2, w3, w4) 0)
-      _ -> fail ("Serialise.decode.SockAddr unexpected tok " ++ show tok)
-  | otherwise = do
-    _ <- CBOR.decodeListLen
-    tok <- CBOR.decodeWord
-    case tok of
-      0 -> do
-        w <- CBOR.decodeWord32
-        pn <- decodePortNumber
-        return (SockAddrInet pn w)
-      1 -> do
-        w1 <- CBOR.decodeWord32
-        w2 <- CBOR.decodeWord32
-        w3 <- CBOR.decodeWord32
-        w4 <- CBOR.decodeWord32
-        _fi <- CBOR.decodeWord32
-        _si <- CBOR.decodeWord32
-        pn <- decodePortNumber
-        return (SockAddrInet6 pn 0 (w1, w2, w3, w4) 0)
-      _ -> fail ("Serialise.decode.SockAddr unexpected tok " ++ show tok)
-
+decodeRemoteAddress =
+  \case
+    NodeToNodeV_13 -> decoder13
+  where
+    decoder13 = do
+      _ <- CBOR.decodeListLen
+      tok <- CBOR.decodeWord
+      case tok of
+        0 -> do
+          w <- CBOR.decodeWord32
+          pn <- decodePortNumber
+          return (SockAddrInet pn w)
+        1 -> do
+          w1 <- CBOR.decodeWord32
+          w2 <- CBOR.decodeWord32
+          w3 <- CBOR.decodeWord32
+          w4 <- CBOR.decodeWord32
+          pn <- decodePortNumber
+          return (SockAddrInet6 pn 0 (w1, w2, w3, w4) 0)
+        _ -> fail ("Serialise.decode.SockAddr unexpected tok " ++ show tok)

--- a/ouroboros-network-protocols/test-cddl/Main.hs
+++ b/ouroboros-network-protocols/test-cddl/Main.hs
@@ -152,27 +152,16 @@ tests CDDLSpecs { cddlChainSync
                 , cddlTxSubmission2
                 , cddlKeepAlive
                 , cddlLocalStateQuery
-                , cddlHandshakeNodeToNodeV7To10
-                , cddlHandshakeNodeToNodeV11ToV12
                 , cddlHandshakeNodeToNodeV13ToLast
                 , cddlHandshakeNodeToClient
-                , cddlPeerSharingNodeToNodeV11ToV12
                 , cddlPeerSharingNodeToNodeV13ToLast
-                , cddlNodeToNodeVersionDataV7To10
-                , cddlNodeToNodeVersionDataV11ToV12
                 , cddlNodeToNodeVersionDataV13ToLast
                 } =
   adjustOption (const $ QuickCheckMaxSize 10) $
   testGroup "cddl"
     [ testGroup "encoding"
       -- validate encoding against a specification
-      [ testProperty "NodeToNode.Handshake V7 to V10"
-                                         (prop_encodeHandshakeNodeToNodeV7To10
-                                               cddlHandshakeNodeToNodeV7To10)
-      , testProperty "NodeToNode.Handshake V11 to V12"
-                                         (prop_encodeHandshakeNodeToNodeV11ToV12
-                                               cddlHandshakeNodeToNodeV11ToV12)
-      , testProperty "NodeToNode.Handshake V13 to Last"
+      [ testProperty "NodeToNode.Handshake V13 to Last"
                                          (prop_encodeHandshakeNodeToNodeV13ToLast
                                                cddlHandshakeNodeToNodeV13ToLast)
       , -- If this fails whilst adding a new node-to-client version, ensure that
@@ -199,27 +188,15 @@ tests CDDLSpecs { cddlChainSync
       , testProperty "LocalStateQuery"   (prop_encodeLocalStateQuery
                                                cddlLocalStateQuery)
 
-      , testProperty "PeerSharing V11 to V12" (prop_encodePeerSharingV11ToV12
-                                               cddlPeerSharingNodeToNodeV11ToV12)
       , testProperty "PeerSharing V13 to Last" (prop_encodePeerSharingV13ToLast
                                                cddlPeerSharingNodeToNodeV13ToLast)
 
-      , testProperty "NodeToNodeVersionData V7 to V10"   (prop_encodeNodeToNodeVersionDataV7To10
-                                                            cddlNodeToNodeVersionDataV7To10)
-      , testProperty "NodeToNodeVersionData V11 to V12"  (prop_encodeNodeToNodeVersionDataV11ToV12
-                                                            cddlNodeToNodeVersionDataV11ToV12)
       , testProperty "NodeToNodeVersionData V13 to Last" (prop_encodeNodeToNodeVersionDataV13ToLast
                                                             cddlNodeToNodeVersionDataV13ToLast)
       ]
     , testGroup "decoder"
       -- validate decoder by generating messages from the specification
-      [ testCase "NodeToNode.Handshake V7 to V10"
-                                     (unit_decodeHandshakeNodeToNode
-                                           cddlHandshakeNodeToNodeV7To10)
-      , testCase "NodeToNode.Handshake V11 to V12"
-                                     (unit_decodeHandshakeNodeToNode
-                                           cddlHandshakeNodeToNodeV11ToV12)
-      , testCase "NodeToNode.Handshake V13 to Last"
+      [ testCase "NodeToNode.Handshake V13 to Last"
                                      (unit_decodeHandshakeNodeToNode
                                            cddlHandshakeNodeToNodeV13ToLast)
       , testCase "NodeToClient.Handshake"
@@ -240,15 +217,9 @@ tests CDDLSpecs { cddlChainSync
       , testCase "LocalStateQuery"   (unit_decodeLocalStateQuery
                                            cddlLocalStateQuery)
 
-      , testCase "PeerSharing V11 to V12" (unit_decodePeerSharingV11ToV12
-                                                cddlPeerSharingNodeToNodeV11ToV12)
       , testCase "PeerSharing V13 to Last" (unit_decodePeerSharingV13ToLast
                                                 cddlPeerSharingNodeToNodeV13ToLast)
 
-      , testCase "NodeToNodeVersionData V7 to V10"   (unit_decodeNodeToNodeVersionData
-                                                        cddlNodeToNodeVersionDataV7To10)
-      , testCase "NodeToNodeVersionData V11 to V12"  (unit_decodeNodeToNodeVersionDataV11ToV12
-                                                        cddlNodeToNodeVersionDataV11ToV12)
       , testCase "NodeToNodeVersionData V13 to Last" (unit_decodeNodeToNodeVersionDataV13ToLast
                                                         cddlNodeToNodeVersionDataV13ToLast)
       ]
@@ -260,8 +231,6 @@ newtype CDDLSpec ps = CDDLSpec BL.ByteString
 
 data CDDLSpecs = CDDLSpecs {
     cddlHandshakeNodeToClient        :: CDDLSpec (Handshake NodeToClientVersion CBOR.Term),
-    cddlHandshakeNodeToNodeV7To10    :: CDDLSpec (Handshake NodeToNodeVersion   CBOR.Term),
-    cddlHandshakeNodeToNodeV11ToV12  :: CDDLSpec (Handshake NodeToNodeVersion   CBOR.Term),
     cddlHandshakeNodeToNodeV13ToLast :: CDDLSpec (Handshake NodeToNodeVersion   CBOR.Term),
     cddlChainSync                    :: CDDLSpec (ChainSync BlockHeader HeaderPoint HeaderTip),
     cddlBlockFetch                   :: CDDLSpec (BlockFetch Block BlockPoint),
@@ -273,11 +242,8 @@ data CDDLSpecs = CDDLSpecs {
     cddlLocalTxMonitor               :: CDDLSpec (LocalTxMonitor TxId Tx SlotNo),
     cddlLocalStateQuery              :: CDDLSpec (LocalStateQuery Block BlockPoint Query),
 
-    cddlPeerSharingNodeToNodeV11ToV12  :: CDDLSpec (PeerSharing.PeerSharing SockAddr),
     cddlPeerSharingNodeToNodeV13ToLast :: CDDLSpec (PeerSharing.PeerSharing SockAddr),
 
-    cddlNodeToNodeVersionDataV7To10    :: CDDLSpec NodeToNodeVersionData,
-    cddlNodeToNodeVersionDataV11ToV12  :: CDDLSpec NodeToNodeVersionData,
     cddlNodeToNodeVersionDataV13ToLast :: CDDLSpec NodeToNodeVersionData
   }
 
@@ -289,8 +255,6 @@ readCDDLSpecs = do
        <$> doesDirectoryExist "ouroboros-network-protocols"
     common                <- BL.readFile (dir </> "common.cddl")
     handshakeNodeToClient <- BL.readFile (dir </> "handshake-node-to-client.cddl")
-    handshakeNodeToNodeV7To10    <- BL.readFile (dir </> "handshake-node-to-node.cddl")
-    handshakeNodeToNodeV11ToV12  <- BL.readFile (dir </> "handshake-node-to-node-v11-12.cddl")
     handshakeNodeToNodeV13ToLast <- BL.readFile (dir </> "handshake-node-to-node-v13.cddl")
     chainSync             <- BL.readFile (dir </> "chain-sync.cddl")
     blockFetch            <- BL.readFile (dir </> "block-fetch.cddl")
@@ -300,18 +264,13 @@ readCDDLSpecs = do
     localTxMonitor        <- BL.readFile (dir </> "local-tx-monitor.cddl")
     localStateQuery       <- BL.readFile (dir </> "local-state-query.cddl")
 
-    peerSharingNodeToNodeV11ToV12  <- BL.readFile (dir </> "peer-sharing-v11-12.cddl")
     peerSharingNodeToNodeV13ToLast <- BL.readFile (dir </> "peer-sharing-v13.cddl")
 
-    nodeToNodeVersionDataV7To10 <- BL.readFile (dir </> "node-to-node-version-data.cddl")
-    nodeToNodeVersionDataV11ToV12  <- BL.readFile (dir </> "node-to-node-version-data-v11-12.cddl")
     nodeToNodeVersionDataV13ToLast <- BL.readFile (dir </> "node-to-node-version-data-v13.cddl")
     -- append common definitions; they must be appended since the first
     -- definition is the entry point for a cddl spec.
     return CDDLSpecs {
         cddlHandshakeNodeToClient        = CDDLSpec $ handshakeNodeToClient,
-        cddlHandshakeNodeToNodeV7To10    = CDDLSpec $ handshakeNodeToNodeV7To10,
-        cddlHandshakeNodeToNodeV11ToV12  = CDDLSpec $ handshakeNodeToNodeV11ToV12,
         cddlHandshakeNodeToNodeV13ToLast = CDDLSpec $ handshakeNodeToNodeV13ToLast,
         cddlChainSync                    = CDDLSpec $ chainSync
                                                    <> common,
@@ -327,13 +286,9 @@ readCDDLSpecs = do
         cddlLocalStateQuery              = CDDLSpec $ localStateQuery
                                                    <> common,
 
-        cddlPeerSharingNodeToNodeV11ToV12  = CDDLSpec $ peerSharingNodeToNodeV11ToV12
-                                                     <> common,
         cddlPeerSharingNodeToNodeV13ToLast = CDDLSpec $ peerSharingNodeToNodeV13ToLast
                                                      <> common,
 
-        cddlNodeToNodeVersionDataV7To10    = CDDLSpec nodeToNodeVersionDataV7To10,
-        cddlNodeToNodeVersionDataV11ToV12  = CDDLSpec nodeToNodeVersionDataV11ToV12,
         cddlNodeToNodeVersionDataV13ToLast = CDDLSpec nodeToNodeVersionDataV13ToLast
       }
 
@@ -456,16 +411,6 @@ validateCBOR (CDDLSpec spec) blob =
 -- with Peer Sharing required yet another parameter ((see
 -- specs/handshake-node-to-node-v13.cddl)
 --
-newtype NtNHandshakeV7To10 =
-  NtNHandshakeV7To10
-    (AnyMessage (Handshake NodeToNodeVersion CBOR.Term))
-    deriving Show
-
-newtype NtNHandshakeV11ToV12 =
-  NtNHandshakeV11ToV12
-    (AnyMessage (Handshake NodeToNodeVersion CBOR.Term))
-    deriving Show
-
 newtype NtNHandshakeV13ToLast =
   NtNHandshakeV13ToLast
     (AnyMessage (Handshake NodeToNodeVersion CBOR.Term))
@@ -515,35 +460,10 @@ genNtNHandshake genVersion = oneof
           <*> (Text.pack <$> arbitrary)
       ]
 
--- TODO: issue 4294
-instance Arbitrary NtNHandshakeV7To10 where
-  arbitrary = do
-    let genVersion = elements [minBound .. NodeToNodeV_10]
-    NtNHandshakeV7To10 <$> genNtNHandshake genVersion
-
-instance Arbitrary NtNHandshakeV11ToV12 where
-  arbitrary = do
-    let genVersion = elements [NodeToNodeV_11, NodeToNodeV_12]
-    NtNHandshakeV11ToV12 <$> genNtNHandshake genVersion
-
 instance Arbitrary NtNHandshakeV13ToLast where
   arbitrary = do
     let genVersion = elements [NodeToNodeV_13 ..]
     NtNHandshakeV13ToLast <$> genNtNHandshake genVersion
-
-prop_encodeHandshakeNodeToNodeV7To10
-    :: CDDLSpec            (Handshake NodeToNodeVersion CBOR.Term)
-    -> NtNHandshakeV7To10
-    -> Property
-prop_encodeHandshakeNodeToNodeV7To10 spec (NtNHandshakeV7To10 x) =
-  validateEncoder spec nodeToNodeHandshakeCodec x
-
-prop_encodeHandshakeNodeToNodeV11ToV12
-    :: CDDLSpec            (Handshake NodeToNodeVersion CBOR.Term)
-    -> NtNHandshakeV11ToV12
-    -> Property
-prop_encodeHandshakeNodeToNodeV11ToV12 spec (NtNHandshakeV11ToV12 x) =
-  validateEncoder spec nodeToNodeHandshakeCodec x
 
 prop_encodeHandshakeNodeToNodeV13ToLast
     :: CDDLSpec            (Handshake NodeToNodeVersion CBOR.Term)
@@ -668,14 +588,6 @@ instance Arbitrary SockAddr where
                                     <*> arbitrary
                     ]
 
-prop_encodePeerSharingV11ToV12
-    :: CDDLSpec (PeerSharing.PeerSharing SockAddr)
-    -> NtNVersionV11ToV12
-    -> AnyMessage (PeerSharing.PeerSharing SockAddr)
-    -> Property
-prop_encodePeerSharingV11ToV12 spec (NtNVersionV11ToV12 ntnVersion) =
-  validateEncoder spec (peerSharingCodec ntnVersion)
-
 prop_encodePeerSharingV13ToLast
     :: CDDLSpec (PeerSharing.PeerSharing SockAddr)
     -> NtNVersionV13ToLast
@@ -684,20 +596,8 @@ prop_encodePeerSharingV13ToLast
 prop_encodePeerSharingV13ToLast spec (NtNVersionV13ToLast ntnVersion) =
   validateEncoder spec (peerSharingCodec ntnVersion)
 
-newtype NtNVersionV7To10    = NtNVersionV7To10 NodeToNodeVersion
-  deriving Show
-newtype NtNVersionV11       = NtNVersionV11 NodeToNodeVersion
-  deriving Show
-newtype NtNVersionV11ToV12 = NtNVersionV11ToV12 NodeToNodeVersion
-  deriving Show
 newtype NtNVersionV13ToLast = NtNVersionV13ToLast NodeToNodeVersion
   deriving Show
-
-instance Arbitrary NtNVersionV7To10 where
-  arbitrary = NtNVersionV7To10 <$> elements [NodeToNodeV_7 .. NodeToNodeV_10]
-
-instance Arbitrary NtNVersionV11ToV12 where
-  arbitrary = NtNVersionV11ToV12 <$> elements [NodeToNodeV_11, NodeToNodeV_12]
 
 instance Arbitrary NtNVersionV13ToLast where
   arbitrary = NtNVersionV13ToLast <$> elements [NodeToNodeV_13 ..]
@@ -714,41 +614,14 @@ instance Arbitrary NodeToNodeVersionData where
                      ]
         <*> arbitrary
 
-newtype NtNVersionDataV11ToV12 = NtNVersionDataV11ToV12 (NodeToNodeVersion , NodeToNodeVersionData)
-  deriving Show
-
 newtype NtNVersionDataV13ToLast = NtNVersionDataV13ToLast (NodeToNodeVersion, NodeToNodeVersionData)
   deriving Show
-
-instance Arbitrary NtNVersionDataV11ToV12 where
-  arbitrary = do
-    NtNVersionV11ToV12 ntnVersion <- arbitrary
-    ntnVersionData <- arbitrary
-    return (NtNVersionDataV11ToV12 (ntnVersion, ntnVersionData))
 
 instance Arbitrary NtNVersionDataV13ToLast where
   arbitrary = do
     NtNVersionV13ToLast ntnVersion <- arbitrary
     ntnVersionData <- arbitrary
     return (NtNVersionDataV13ToLast (ntnVersion, ntnVersionData))
-
-prop_encodeNodeToNodeVersionDataV7To10
-    :: CDDLSpec NodeToNodeVersionData
-    -> NtNVersionV7To10
-    -> NodeToNodeVersionData
-    -> Property
-prop_encodeNodeToNodeVersionDataV7To10 spec (NtNVersionV7To10 v) a =
-  validateCBORTermEncoder spec (nodeToNodeCodecCBORTerm v)
-                          a { peerSharing = PeerSharingDisabled,
-                              NtNVersion.query = False
-                            }
-
-prop_encodeNodeToNodeVersionDataV11ToV12
-    :: CDDLSpec NodeToNodeVersionData
-    -> NtNVersionDataV11ToV12
-    -> Property
-prop_encodeNodeToNodeVersionDataV11ToV12 spec (NtNVersionDataV11ToV12 (v, a)) =
-  validateCBORTermEncoder spec (nodeToNodeCodecCBORTerm v) a
 
 prop_encodeNodeToNodeVersionDataV13ToLast
     :: CDDLSpec NodeToNodeVersionData
@@ -1067,18 +940,6 @@ unit_decodeLocalStateQuery spec =
       ]
       100
 
-unit_decodePeerSharingV11ToV12
-    :: CDDLSpec (PeerSharing.PeerSharing SockAddr)
-    -> Assertion
-unit_decodePeerSharingV11ToV12 spec =
-    forM_ [NodeToNodeV_11 .. NodeToNodeV_12] $ \v ->
-    validateDecoder Nothing
-      spec (peerSharingCodec v)
-      [ SomeAgency PeerSharing.SingIdle
-      , SomeAgency PeerSharing.SingBusy
-      ]
-      100
-
 unit_decodePeerSharingV13ToLast
     :: CDDLSpec (PeerSharing.PeerSharing SockAddr)
     -> Assertion
@@ -1090,20 +951,6 @@ unit_decodePeerSharingV13ToLast spec =
       , SomeAgency PeerSharing.SingBusy
       ]
       100
-
-unit_decodeNodeToNodeVersionData
-    :: CDDLSpec NodeToNodeVersionData
-    -> Assertion
-unit_decodeNodeToNodeVersionData spec =
-    forM_ [NodeToNodeV_7 .. NodeToNodeV_10] $ \v ->
-    validateCBORTermDecoder Nothing spec (nodeToNodeCodecCBORTerm v) 100
-
-unit_decodeNodeToNodeVersionDataV11ToV12
-    :: CDDLSpec NodeToNodeVersionData
-    -> Assertion
-unit_decodeNodeToNodeVersionDataV11ToV12 spec =
-    forM_ [NodeToNodeV_11, NodeToNodeV_12] $ \v ->
-    validateCBORTermDecoder Nothing spec (nodeToNodeCodecCBORTerm v) 100
 
 unit_decodeNodeToNodeVersionDataV13ToLast
     :: CDDLSpec NodeToNodeVersionData

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -51,7 +51,6 @@ import Ouroboros.Network.Mock.ConcreteBlock
 import Ouroboros.Network.Mux
 import Ouroboros.Network.NodeToClient (LocalConnectionId)
 import Ouroboros.Network.NodeToNode
-import Ouroboros.Network.NodeToNode.Version (isPipeliningEnabled)
 import Ouroboros.Network.Point (WithOrigin (..))
 import Ouroboros.Network.Snocket
 import Ouroboros.Network.Socket
@@ -399,7 +398,7 @@ clientBlockFetch sockAddrs maxSlotNo = withIOManager $ \iocp -> do
           InitiatorProtocolOnly $
             MiniProtocolCb $ \MinimalInitiatorContext { micConnectionId = connId } channel ->
               bracketDqRegistry registry connId $
-              bracketFetchClient registry maxBound isPipeliningEnabled connId $ \clientCtx -> do
+              bracketFetchClient registry (maxBound :: NodeToNodeVersion) connId $ \clientCtx -> do
                 threadDelay 1000000
                 runPipelinedPeer
                   nullTracer -- (contramap (show . TraceLabelPeer ("block-fetch", getFilePath $ remoteAddress connId)) stdoutTracer)
@@ -420,7 +419,7 @@ clientBlockFetch sockAddrs maxSlotNo = withIOManager $ \iocp -> do
                                          getTestFetchedBlocks blockHeap,
               readFetchedMaxSlotNo   = maybe NoMaxSlotNo (maxSlotNoFromWithOrigin . pointSlot) <$>
                                          getLastFetchedPoint blockHeap,
-              mkAddFetchedBlock        = \_enablePipelining -> do
+              mkAddFetchedBlock      = do
                   pure $ \p b ->
                     addTestFetchedBlock blockHeap (castPoint p) (blockHeader b),
 

--- a/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
@@ -167,7 +167,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
       (cborTermVersionDataCodec nodeToNodeCodecCBORTerm)
       (HandshakeCallbacks acceptableVersion queryVersion)
       (simpleSingletonVersions
-        NodeToNodeV_7
+        (maxBound :: NodeToNodeVersion)
         (NodeToNodeVersionData {
           networkMagic  = NetworkMagic 0,
           diffusionMode = InitiatorAndResponderDiffusionMode,
@@ -187,7 +187,7 @@ demo chain0 updates = withIOManager $ \iocp -> do
           nullNetworkConnectTracers
           (HandshakeCallbacks acceptableVersion queryVersion)
           (simpleSingletonVersions
-            NodeToNodeV_7
+            (maxBound :: NodeToNodeVersion)
             (NodeToNodeVersionData {
               networkMagic  = NetworkMagic 0,
               diffusionMode = InitiatorOnlyDiffusionMode,

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -88,7 +88,7 @@ blockFetchExample0 decisionTracer clientStateTracer clientMsgTracer
                     NodeToNode.isPipeliningEnabled
                     clientDelay serverDelay
                     registry peerno
-                    (blockFetchClient NodeToNodeV_7 controlMessageSTM nullTracer)
+                    (blockFetchClient (maxBound :: NodeToNodeVersion) controlMessageSTM nullTracer)
                     (mockBlockFetchServer1 candidateChain)
 
     fetchAsync  <- async $ do
@@ -196,10 +196,9 @@ blockFetchExample1 decisionTracer clientStateTracer clientMsgTracer
                         (contramap (TraceLabelPeer peerno) clientMsgTracer)
                         (contramap (TraceLabelPeer peerno) serverMsgTracer)
                         (maxBound :: NodeToNodeVersion)
-                        NodeToNode.isPipeliningEnabled
                         clientDelay serverDelay
                         registry peerno
-                        (blockFetchClient NodeToNodeV_7 controlMessageSTM nullTracer)
+                        (blockFetchClient (maxBound :: NodeToNodeVersion) controlMessageSTM nullTracer)
                         (mockBlockFetchServer1 candidateChain)
                     | (peerno, candidateChain) <- zip [1..] candidateChains
                     ]

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
@@ -50,7 +51,7 @@ import Ouroboros.Network.BlockFetch.Examples
 import Ouroboros.Network.Driver (TraceSendRecv)
 import Ouroboros.Network.Mock.Chain qualified as Chain
 import Ouroboros.Network.Mock.ConcreteBlock
-import Ouroboros.Network.NodeToNode.Version (isPipeliningEnabled)
+import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
 
 import Ouroboros.Network.Testing.Utils
@@ -672,14 +673,14 @@ unit_bracketSyncWithFetchClient step = do
                  -> m (Either SomeException a, Either SomeException b)
     testSkeleton withFetchTestAction withSyncTestAction withKeepAliveTestAction = do
       registry <- newFetchClientRegistry
-      setFetchClientContext registry nullTracer (const dummyPolicy)
+      setFetchClientContext registry nullTracer dummyPolicy
 
       fetchStatePeerChainsVar <- newTVarIO Map.empty
 
       let peer  = "thepeer"
           fetch :: m a
           fetch = withFetchTestAction $ \body ->
-                    bracketFetchClient registry maxBound isPipeliningEnabled peer $ \_ ->
+                    bracketFetchClient registry (maxBound @NodeToNodeVersion) peer $ \_ ->
                       body
 
           sync :: m b

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -313,7 +313,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
                                    map (maxSlotNoFromWithOrigin . pointSlot) .
                                    Set.elems <$>
                                    getBlockPointSet (nkChainDB nodeKernel),
-          mkAddFetchedBlock        = \_enablePipelining ->
+          mkAddFetchedBlock        =
               pure $ \_p b ->
                 atomically (addBlock b (nkChainDB nodeKernel)),
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -432,7 +432,6 @@ applications debugTracer nodeKernel
       -> do labelThisThread "BlockFetchClient"
             bracketFetchClient (nkFetchClientRegistry nodeKernel)
                                UnversionedProtocol
-                               (const NotReceivingTentativeBlocks)
                                remoteAddress
                                $ \clientCtx ->
               runPeerWithLimits

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -256,7 +256,7 @@ txSubmissionSimulation maxUnacked outboundTxs
         nullTracer
         maxUnacked
         (getMempoolReader outboundMempool)
-        NodeToNodeV_7
+        (maxBound :: NodeToNodeVersion)
         controlMessageSTM
 
     inboundPeer :: Mempool m txid -> TxSubmissionServerPipelined txid (Tx txid) m ()
@@ -266,7 +266,7 @@ txSubmissionSimulation maxUnacked outboundTxs
         maxUnacked
         (getMempoolReader inboundMempool)
         (getMempoolWriter inboundMempool)
-        NodeToNodeV_7
+        (maxBound :: NodeToNodeVersion)
 
 
 newtype LargeNonEmptyList a = LargeNonEmpty { getLargeNonEmpty :: [a] }

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -98,7 +98,6 @@ module Ouroboros.Network.BlockFetch
   , FetchMode (..)
   , FromConsensus (..)
   , SizeInBytes
-  , WhetherReceivingTentativeBlocks (..)
   ) where
 
 import Data.Hashable (Hashable)
@@ -118,8 +117,7 @@ import Ouroboros.Network.BlockFetch.ClientRegistry (FetchClientPolicy (..),
            readFetchClientsStateVars, readFetchClientsStatus, readPeerGSVs,
            setFetchClientContext)
 import Ouroboros.Network.BlockFetch.ConsensusInterface
-           (BlockFetchConsensusInterface (..), FromConsensus (..),
-           WhetherReceivingTentativeBlocks (..))
+           (BlockFetchConsensusInterface (..), FromConsensus (..))
 import Ouroboros.Network.BlockFetch.State
 
 
@@ -180,9 +178,9 @@ blockFetchLogic decisionTracer clientStateTracer
       fetchTriggerVariables
       fetchNonTriggerVariables
   where
-    mkFetchClientPolicy :: WhetherReceivingTentativeBlocks -> STM m (FetchClientPolicy header block m)
-    mkFetchClientPolicy receivingTentativeBlocks = do
-      addFetchedBlock <- mkAddFetchedBlock receivingTentativeBlocks
+    mkFetchClientPolicy :: STM m (FetchClientPolicy header block m)
+    mkFetchClientPolicy = do
+      addFetchedBlock <- mkAddFetchedBlock
       pure FetchClientPolicy {
           blockFetchSize,
           blockMatchesHeader,

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -31,7 +31,6 @@ module Ouroboros.Network.BlockFetch.ClientState
   , ChainRange (..)
     -- * Ancillary
   , FromConsensus (..)
-  , WhetherReceivingTentativeBlocks (..)
   ) where
 
 import Data.List as List (foldl')
@@ -52,8 +51,7 @@ import Network.Mux.Trace (TraceLabelPeer (..))
 import Ouroboros.Network.AnchoredFragment (AnchoredFragment)
 import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.Block (HasHeader, MaxSlotNo (..), Point, blockPoint)
-import Ouroboros.Network.BlockFetch.ConsensusInterface (FromConsensus (..),
-           WhetherReceivingTentativeBlocks (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (FromConsensus (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (PeerFetchInFlightLimits (..),
            PeerGSV, SizeInBytes, calculatePeerFetchInFlightLimits)
 import Ouroboros.Network.ControlMessage (ControlMessageSTM,

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -1286,8 +1286,7 @@ run tracers tracersExtra args argsExtra apps appsExtra = do
 nodeDataFlow :: NodeToNodeVersion
              -> NodeToNodeVersionData
              -> DataFlow
-nodeDataFlow v NodeToNodeVersionData { diffusionMode = InitiatorAndResponderDiffusionMode }
-                 | v >= NodeToNodeV_10
+nodeDataFlow _v NodeToNodeVersionData { diffusionMode = InitiatorAndResponderDiffusionMode }
                  = Duplex
 nodeDataFlow _ _ = Unidirectional
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToNode.hs
@@ -246,7 +246,7 @@ nodeToNodeProtocols
   -> NodeToNodeVersion
   -> PeerSharing -- ^ Node's own PeerSharing value
   -> OuroborosBundle muxMode initiatorCtx responderCtx bytes m a b
-nodeToNodeProtocols miniProtocolParameters protocols version ownPeerSharing =
+nodeToNodeProtocols miniProtocolParameters protocols _version ownPeerSharing =
     TemperatureBundle
       -- Hot protocols: 'chain-sync', 'block-fetch' and 'tx-submission'.
       (WithHot $
@@ -278,10 +278,8 @@ nodeToNodeProtocols miniProtocolParameters protocols version ownPeerSharing =
       -- Established protocols: 'keep-alive'.
       (WithEstablished $
         case protocols of
-          -- Only register PeerSharing Protocol if version >= NodeToNodeV_11 and if peer
-          -- has PeerSharing enabled
           NodeToNodeProtocols { keepAliveProtocol, peerSharingProtocol }
-            | version >= NodeToNodeV_11 && ownPeerSharing /= PeerSharingDisabled ->
+            | ownPeerSharing /= PeerSharingDisabled ->
             [ MiniProtocol {
                 miniProtocolNum    = keepAliveMiniProtocolNum,
                 miniProtocolLimits = keepAliveProtocolLimits miniProtocolParameters,


### PR DESCRIPTION
# Description

Removes support for NodeToNodeV_12 and older as these are unable to cross the hard fork boundary.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
