### PR TITLE
github-actions: fixed caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,11 +71,11 @@ jobs:
 
     - uses: actions/cache/restore@v4
       name: "Restore cache: `cabal store`"
+      id: cache-dependencies
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
         key: cache-dependencies-${{ env.CABAL_CACHE_VERSION }}-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: cache-dependencies-${{ env.CABAL_CACHE_VERSION }}-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}
-        enableCrossOsArchive: true
 
     - uses: actions/cache@v4
       name: "Cache `dist-newstyle`"
@@ -91,10 +91,10 @@ jobs:
 
     - uses: actions/cache/save@v4
       name: "Save cache: `cabal store`"
+      if: always() && steps.cache-dependencies.outputs.cache-hit != 'true'
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: cache-dependencies-${{ env.CABAL_CACHE_VERSION }}-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
-        enableCrossOsArchive: true
+        key: ${{ steps.cache-dependencies.outputs.cache-primary-key }}
 
     - name: Build projects [build]
       run: cabal build all -j

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,14 +122,8 @@ jobs:
       if: runner.os != 'Windows'
       run: cabal run ouroboros-network-framework:sim-tests -- +RTS -maxN2 -RTS
 
-    # TODO: run CDDL
-
     - name: ouroboros-network-protocols [test]
       run: cabal run ouroboros-network-protocols:test -- +RTS -maxN2 -RTS
-
-    # We don't run cddl in GitHub actions (only on Hydra).
-    # - name: ouroboros-network-protocols [cddl]
-    #   run: cabal run ouroboros-network-protocols-test:cddl
 
     - name: ouroboros-network [io-tests]
       run: cabal run ouroboros-network:io-tests -- +RTS -maxN2 -RTS


### PR DESCRIPTION
Fixed caching of cabal store: https://github.com/IntersectMBO/ouroboros-network/actions/runs/11435190378/job/31810104749

* more robust way of cache key management
* removed `enableCrossArchive` (it doesn't seem to be necessary now)
* only save the cache when necessary