### PR TITLE
connection-manager: renamed methods

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Addapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4999
 * Addapted to `network-mux` changes in https://github.com/IntersectMBO/ouroboros-network/pull/4997
 * Removed deprecated `Ouroboros.Network.Channel.{to,from}Channel` functions.
+* Renamed `requestOutboundConnection` to `acquireOutboundConnection` and
+  `unregister{Inbound,Outbound}Connection` to `release{Inbound,Outbound}Connection`.
+  `AssertionLocation` constructors were renamed as well.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -484,7 +484,7 @@ bidirectionalExperiment
                            })
                   muxBundle
               res <-
-                unregisterOutboundConnection
+                releaseOutboundConnection
                   connectionManager remoteAddr
               case res of
                 UnsupportedState inState -> do
@@ -541,9 +541,9 @@ bidirectionalExperiment
                               Mux.InitiatorResponderMode
                               UnversionedProtocol))
     connect n cm | n <= 1 =
-      requestOutboundConnection cm remoteAddr
+      acquireOutboundConnection cm remoteAddr
     connect n cm =
-      requestOutboundConnection cm remoteAddr
+      acquireOutboundConnection cm remoteAddr
         `catch` \(_ :: IOException) -> threadDelay 1
                                     >> connect (pred n) cm
         `catch` \(_ :: Mux.Error)   -> threadDelay 1

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -810,7 +810,7 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                 -- another 5s is the longest delay for
                                 -- handshake negotiation.
                                 timeout (1 + 5 + testTimeWaitTimeout)
-                                  (requestOutboundConnection
+                                  (acquireOutboundConnection
                                     connectionManager addr))
                             `catches`
                               [ Handler $ \(e :: IOException) -> return (Left (toException e))
@@ -849,11 +849,11 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                     -- 'unregisterOutboundConnection' to be
                                     -- successful.
                                     void $
-                                      unregisterInboundConnection
+                                      releaseInboundConnection
                                         connectionManager addr
 
                                   res <-
-                                      unregisterOutboundConnection
+                                      releaseOutboundConnection
                                         connectionManager addr
                                   case res of
                                     UnsupportedState st ->
@@ -929,7 +929,7 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                 Left _ ->
                                   -- TODO: should we run 'unregisterInboundConnection' depending on 'seActiveDelay'
                                   void $
-                                    unregisterInboundConnection
+                                    releaseInboundConnection
                                       connectionManager addr
                           go (thread : threads) acceptNext conns'
                         (AcceptFailure err, _acceptNext) ->

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -873,7 +873,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
                                        case fromException e of
                                          Just SomeAsyncException {} -> Nothing
                                          _                          -> Just e)
-                          $ requestOutboundConnection cm remoteAddr
+                          $ acquireOutboundConnection cm remoteAddr
             case connHandle of
               Left _ ->
                 go connMap
@@ -888,7 +888,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
               m <- readTVar connVar
               check (Map.member (connId remoteAddr) m)
               writeTVar connVar (Map.delete (connId remoteAddr) m)
-            void (unregisterOutboundConnection cm remoteAddr)
+            void (releaseOutboundConnection cm remoteAddr)
             go (Map.delete remoteAddr connMap)
           RunMiniProtocols remoteAddr reqs -> do
             atomically $ do

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -469,8 +469,8 @@ with
           return (Just connId, state')
 
         CommitRemote connId -> do
-          res <- unregisterInboundConnection connectionManager
-                                             (remoteAddress connId)
+          res <- releaseInboundConnection connectionManager
+                                          (remoteAddress connId)
           traceWith tracer $ TrDemotedToColdRemote connId res
           case res of
             UnsupportedState {} -> do

--- a/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Experiments.hs
+++ b/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Experiments.hs
@@ -734,8 +734,8 @@ unidirectionalExperiment stdGen timeouts snocket makeBearer confSock socket clie
                 replicateM
                   (numberOfRounds clientAndServerData)
                   (bracket
-                     (requestOutboundConnection connectionManager serverAddr)
-                     (\_ -> unregisterOutboundConnection connectionManager serverAddr)
+                     (acquireOutboundConnection connectionManager serverAddr)
+                     (\_ -> releaseOutboundConnection connectionManager serverAddr)
                      (\connHandle -> do
                       case connHandle of
                         Connected connId _ (Handle mux muxBundle controlBundle _
@@ -831,11 +831,11 @@ bidirectionalExperiment
                   (numberOfRounds clientAndServerData0)
                   (bracket
                     (withLock useLock lock
-                      (requestOutboundConnection
+                      (acquireOutboundConnection
                         connectionManager0
                         localAddr1))
                     (\_ ->
-                      unregisterOutboundConnection
+                      releaseOutboundConnection
                         connectionManager0
                         localAddr1)
                     (\connHandle ->
@@ -853,11 +853,11 @@ bidirectionalExperiment
                   (numberOfRounds clientAndServerData1)
                   (bracket
                     (withLock useLock lock
-                      (requestOutboundConnection
+                      (acquireOutboundConnection
                         connectionManager1
                         localAddr0))
                     (\_ ->
-                      unregisterOutboundConnection
+                      releaseOutboundConnection
                         connectionManager1
                         localAddr0)
                     (\connHandle ->

--- a/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
+++ b/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
@@ -300,7 +300,7 @@ connectionManagerTraceMap
   -> String
 connectionManagerTraceMap (TrIncludeConnection p _)        =
   "TrIncludeConnection " ++ show p
-connectionManagerTraceMap (TrUnregisterConnection p _)     =
+connectionManagerTraceMap (TrReleaseConnection p _)     =
   "TrUnregisterConnection " ++ show p
 connectionManagerTraceMap (TrConnect _ _)                  =
   "TrConnect"

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -728,7 +728,7 @@ withPeerStateActions PeerStateActionsArguments {
         (newTVarIO PeerCold)
         (\peerStateVar -> atomically $ writeTVar peerStateVar PeerCold)
         $ \peerStateVar -> do
-          res <- requestOutboundConnection spsConnectionManager remotePeerAddr
+          res <- acquireOutboundConnection spsConnectionManager remotePeerAddr
           case res of
             Connected connectionId@ConnectionId { localAddress, remoteAddress }
                       _dataFlow
@@ -1041,7 +1041,7 @@ withPeerStateActions PeerStateActionsArguments {
           -- 'unregisterOutboundConnection' could only fail to demote the peer if
           -- connection manager would simultaneously promote it, but this is not
           -- possible.
-          _ <- unregisterOutboundConnection spsConnectionManager (remoteAddress pchConnectionId)
+          _ <- releaseOutboundConnection spsConnectionManager (remoteAddress pchConnectionId)
           wasWarm <- atomically (updateUnlessCoolingOrCold pchPeerStatus PeerCooling)
           when wasWarm $
             traceWith spsTracer (PeerStatusChanged (WarmToCooling pchConnectionId))


### PR DESCRIPTION
# Description

Renamed `connection-manager` methods as requested in #3464.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
