### PR TITLE
Dropped NodeToClient versions < 16

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,8 +22,5 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: git fetch
-      run: git fetch origin master:master
-
     - name: Check changelogs
       run: ./scripts/ci/check-changelogs.sh

--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -1521,13 +1521,6 @@ table~\ref{table:node-to-client-protocol-versions}.
   \begin{center}
     \begin{tabular}{l|l}
       version & description \\\hline\hline
-      $NodeToClientV\_9$ & alonzo \\\hline
-      $NodeToClientV\_10$ & GetChainBlock \& GetChainPoint queries \\\hline
-      $NodeToClientV\_11$ & GetRewardInfoPools query \\\hline
-      $NodeToClientV\_12$ & Added LocalTxMonitor mini-protocol \\\hline
-      $NodeToClientV\_13$ & babbage \\\hline
-      $NodeToClientV\_14$ & GetPoolDistr, GetPoolState, GetSnapshots queries \\\hline
-      $NodeToClientV\_15$ & internal changes \\\hline
       $NodeToClientV\_16$ & Add ImmutableTip to LocalStateQuery, conway, GetStakeDelegDeposits query \\\hline
       $NodeToClientV\_17$ & GetProposals, GetRatifyState queries \\\hline
       $NodeToClientV\_18$ & GetFuturePParams query \\\hline

--- a/docs/network-spec/network-spec.tex
+++ b/docs/network-spec/network-spec.tex
@@ -241,6 +241,13 @@ in table~\ref{table:historical-node-to-client-protocol-versions}.
       $NodeToClientV\_6$ & mary \\\hline
       $NodeToClientV\_7$ & new queries added to local state query mini-protocol\\\hline
       $NodeToClientV\_8$ & codec changed for local state query mini-protocol\\\hline
+      $NodeToClientV\_9$ & alonzo \\\hline
+      $NodeToClientV\_10$ & GetChainBlock \& GetChainPoint queries \\\hline
+      $NodeToClientV\_11$ & GetRewardInfoPools query \\\hline
+      $NodeToClientV\_12$ & Added LocalTxMonitor mini-protocol \\\hline
+      $NodeToClientV\_13$ & babbage \\\hline
+      $NodeToClientV\_14$ & GetPoolDistr, GetPoolState, GetSnapshots queries \\\hline
+      $NodeToClientV\_15$ & internal changes \\\hline
     \end{tabular}
     \caption{Node-to-client protocol versions}
     \label{table:historical-node-to-client-protocol-versions}

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -8,6 +8,7 @@
   * `getLegacyTipBlockNo`
   * `legacyTip`
   * `toLegacyTip`
+* Dropped all node-to-client versions < `NodeToClientV_16`.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -27,21 +27,21 @@ import Ouroboros.Network.Magic
 -- | Enumeration of node to client protocol versions.
 --
 data NodeToClientVersion
-    = NodeToClientV_9
-    -- ^ enabled @CardanoNodeToClientVersion7@, i.e., Alonzo
-    | NodeToClientV_10
-    -- ^ added 'GetChainBlockNo' and 'GetChainPoint' queries
-    | NodeToClientV_11
-    -- ^ added 'GetRewardInfoPools` Block query
-    | NodeToClientV_12
-    -- ^ added 'LocalTxMonitor' mini-protocol
-    | NodeToClientV_13
-    -- ^ enabled @CardanoNodeToClientVersion9@, i.e., Babbage
-    | NodeToClientV_14
-    -- ^ added @GetPoolDistr@, @GetPoolState@, @GetSnapshots@
-    | NodeToClientV_15
-    -- ^ added `query` to NodeToClientVersionData
-    | NodeToClientV_16
+    -- = NodeToClientV_9
+    -- -- ^ enabled @CardanoNodeToClientVersion7@, i.e., Alonzo
+    -- | NodeToClientV_10
+    -- -- ^ added 'GetChainBlockNo' and 'GetChainPoint' queries
+    -- | NodeToClientV_11
+    -- -- ^ added 'GetRewardInfoPools` Block query
+    -- | NodeToClientV_12
+    -- -- ^ added 'LocalTxMonitor' mini-protocol
+    -- | NodeToClientV_13
+    -- -- ^ enabled @CardanoNodeToClientVersion9@, i.e., Babbage
+    -- | NodeToClientV_14
+    -- -- ^ added @GetPoolDistr@, @GetPoolState@, @GetSnapshots@
+    -- | NodeToClientV_15
+    -- -- ^ added `query` to NodeToClientVersionData
+    = NodeToClientV_16
     -- ^ added @ImmutableTip@ to @LocalStateQuery@, enabled
     -- @CardanoNodeToClientVersion11@, i.e., Conway and
     -- @GetStakeDelegDeposits@.
@@ -64,13 +64,6 @@ nodeToClientVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToClientVersion
 nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
     where
       encodeTerm = \case
-          NodeToClientV_9  -> enc 9
-          NodeToClientV_10 -> enc 10
-          NodeToClientV_11 -> enc 11
-          NodeToClientV_12 -> enc 12
-          NodeToClientV_13 -> enc 13
-          NodeToClientV_14 -> enc 14
-          NodeToClientV_15 -> enc 15
           NodeToClientV_16 -> enc 16
           NodeToClientV_17 -> enc 17
           NodeToClientV_18 -> enc 18
@@ -81,13 +74,6 @@ nodeToClientVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
 
       decodeTerm =
           dec >=> \case
-            9  -> Right NodeToClientV_9
-            10 -> Right NodeToClientV_10
-            11 -> Right NodeToClientV_11
-            12 -> Right NodeToClientV_12
-            13 -> Right NodeToClientV_13
-            14 -> Right NodeToClientV_14
-            15 -> Right NodeToClientV_15
             16 -> Right NodeToClientV_16
             17 -> Right NodeToClientV_17
             18 -> Right NodeToClientV_18
@@ -133,22 +119,15 @@ instance Queryable NodeToClientVersionData where
     queryVersion = query
 
 nodeToClientCodecCBORTerm :: NodeToClientVersion -> CodecCBORTerm Text NodeToClientVersionData
-nodeToClientCodecCBORTerm v = CodecCBORTerm {encodeTerm, decodeTerm}
+nodeToClientCodecCBORTerm _v = CodecCBORTerm {encodeTerm, decodeTerm}
     where
       encodeTerm :: NodeToClientVersionData -> CBOR.Term
       encodeTerm NodeToClientVersionData { networkMagic, query }
-        | v >= NodeToClientV_15
         = CBOR.TList [CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic), CBOR.TBool query]
-        | otherwise
-        = CBOR.TInt (fromIntegral $ unNetworkMagic networkMagic)
 
       decodeTerm :: CBOR.Term -> Either Text NodeToClientVersionData
       decodeTerm (CBOR.TList [CBOR.TInt x, CBOR.TBool query])
-        | v >= NodeToClientV_15
         = decoder x query
-      decodeTerm (CBOR.TInt x)
-        | v < NodeToClientV_15
-        = decoder x False
       decodeTerm t
         = Left $ T.pack $ "unknown encoding: " ++ show t
 

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Non-breaking changes
 
+* Dropped all node-to-client versions < `NodeToClientV_16`.
+
 ## 0.14.0.0 -- 2024-10-17
 
 ### Breaking changes

--- a/ouroboros-network-protocols/cddl/specs/handshake-node-to-client.cddl
+++ b/ouroboros-network-protocols/cddl/specs/handshake-node-to-client.cddl
@@ -9,32 +9,20 @@ handshakeMessage
     / msgQueryReply
 
 msgProposeVersions = [0, versionTable]
-msgAcceptVersion   = [1, oldVersionNumber, oldNodeToClientVersionData]
-                   / [1, versionNumber, nodeToClientVersionData]
+msgAcceptVersion   = [1, versionNumber, nodeToClientVersionData]
 msgRefuse          = [2, refuseReason]
 msgQueryReply      = [3, versionTable]
 
 ; Entries must be sorted by version number. For testing, this is handled in `handshakeFix`.
-versionTable = { * oldVersionNumber => oldNodeToClientVersionData
-               , *    versionNumber =>    nodeToClientVersionData
-               }
+versionTable = { * versionNumber => nodeToClientVersionData }
 
-
-; Version 15 introduces the version query flag
-; as of version 2 (which is no longer supported) we set 15th bit to 1
-;               15    / 16    / 17    / 18    / 19
-versionNumber = 32783 / 32784 / 32785 / 32786 / 32787
 
 ; as of version 2 (which is no longer supported) we set 15th bit to 1
-;                  9     / 10    / 11    / 12    / 13    / 14
-oldVersionNumber = 32777 / 32778 / 32779 / 32780 / 32781 / 32782
-
-anyVersionNumber = versionNumber / oldVersionNumber
+;               16    / 17    / 18    / 19
+versionNumber = 32784 / 32785 / 32786 / 32787
 
 ; As of version 15 and higher
 nodeToClientVersionData = [networkMagic, query]
-
-oldNodeToClientVersionData = networkMagic
 
 networkMagic = uint
 query        = bool
@@ -44,6 +32,6 @@ refuseReason
     / refuseReasonHandshakeDecodeError
     / refuseReasonRefused
 
-refuseReasonVersionMismatch      = [0, [ *anyVersionNumber ] ]
-refuseReasonHandshakeDecodeError = [1, anyVersionNumber, tstr]
-refuseReasonRefused              = [2, anyVersionNumber, tstr]
+refuseReasonVersionMismatch      = [0, [ *versionNumber ] ]
+refuseReasonHandshakeDecodeError = [1, versionNumber, tstr]
+refuseReasonRefused              = [2, versionNumber, tstr]

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -61,6 +61,7 @@
 * Added `defaultDeadlineChurnInterval` and `defaultBulkChurnInterval` to Configuration
   module. Previously these were hard coded in node.
 * Updated tests for `network-mux` changes.
+* Dropped all node-to-client versions < `NodeToClientV_16`.
 
 ## 0.17.1.2 -- 2024-10-11
 

--- a/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
+++ b/ouroboros-network/src/Ouroboros/Network/NodeToClient.hs
@@ -165,7 +165,7 @@ nodeToClientProtocols
   :: NodeToClientProtocols appType addr bytes m a b
   -> NodeToClientVersion
   -> OuroborosApplicationWithMinimalCtx appType addr bytes m a b
-nodeToClientProtocols protocols version =
+nodeToClientProtocols protocols _version =
     OuroborosApplication $
       case protocols of
         NodeToClientProtocols {
@@ -176,11 +176,8 @@ nodeToClientProtocols protocols version =
           } ->
           [ localChainSyncMiniProtocol localChainSyncProtocol
           , localTxSubmissionMiniProtocol localTxSubmissionProtocol
-          ] <>
-          [ localStateQueryMiniProtocol localStateQueryProtocol
-          ] <>
-          [ localTxMonitorMiniProtocol localTxMonitorProtocol
-          | version >= NodeToClientV_12
+          , localStateQueryMiniProtocol localStateQueryProtocol
+          , localTxMonitorMiniProtocol localTxMonitorProtocol
           ]
 
   where

--- a/scripts/ci/check-changelogs.sh
+++ b/scripts/ci/check-changelogs.sh
@@ -9,8 +9,8 @@ RESULT=0
 function check_project () {
   project=$1
   n=$()
-  if [[ -n $(git diff --name-only origin/master..HEAD -- $project) ]];then
-    if [[ -z $(git diff --name-only origin/master..HEAD -- $project/CHANGELOG.md) ]]; then
+  if [[ -n $(git diff --name-only origin/main..HEAD -- $project) ]];then
+    if [[ -z $(git diff --name-only origin/main..HEAD -- $project/CHANGELOG.md) ]]; then
       echo "$project was modified but its CHANGELOG was not updated"
       RESULT=1
     fi


### PR DESCRIPTION
# Description

- **ouroboros-network-api: droped all versions < NodeToClientV_16**
- **Updated `check-changelogs.sh script**

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
