### PR TITLE
Remove field `blockForgeUTCTime` since `headerForgeUTCTime` is enough.

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -20,7 +20,8 @@
   * `accBigPoolStake` -> `accumulateBigLedgerStake`
      and `reRelativeStake` -> `recomputeRelativeStake`
 * Using `typed-protocols-0.3.0.0`.
-* Added `NodeToClientV_19`. 
+* Added `NodeToClientV_19`.
+* Removed `blockForgeUTCTime` from `BlockFetchConsensusInterface`.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -177,13 +177,6 @@ data BlockFetchConsensusInterface peer header block m =
        -- ancillary functions\/interfaces from this function.
        headerForgeUTCTime :: FromConsensus header -> STM m UTCTime,
 
-       -- | Calculate when a block was forged.
-       --
-       -- PRECONDITION: Same as 'headerForgeUTCTime'.
-       --
-       -- WARNING: Same as 'headerForgeUTCTime'.
-       blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime,
-
        -- | Information on the ChainSel starvation status; whether it is ongoing
        -- or has ended recently. Needed by the bulk sync decision logic.
        readChainSelStarvation :: STM m ChainSelStarvation,

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -20,7 +20,7 @@
 * Introduced `daReadLedgerPeerSnapshot` to `P2P.ArgumentsExtra` which holds
   a `Maybe LedgerPeerSnapshot` from a node's configuration. If present, it
   may be used to pick big ledger peers by the peer selection governor when
-  bootstrapping a node in Genesis consensus mode, or in general when 
+  bootstrapping a node in Genesis consensus mode, or in general when
   LedgerStateJudgement = TooOld, subject to conditions in
   `LedgerPeers.ledgerPeersThread`.
 * Diffusion run function in P2P mode has new paramaters:
@@ -46,6 +46,7 @@
 * `Ouroboros.Network.NodeToNode.connectTo` returns either an error or the
   result of the first terminated mini-protocol.
 * Adjusted for changes in `ouroboros-network-framework` (PR #4990)
+* Renamed `blockForgeUTCTime` to `headerForgeUTCTime` in `FetchClientPolicy`.
 
 ### Non-Breaking changes
 
@@ -60,7 +61,7 @@
   a node is syncing up.
 * Implemented verification of big ledger peer snapshot when syncing reaches
   the point at which the snapshot was taken. An error is raised when there's
-  a mismatch detected. 
+  a mismatch detected.
 * Added `defaultDeadlineChurnInterval` and `defaultBulkChurnInterval` to Configuration
   module. Previously these were hard coded in node.
 * Updated tests for `network-mux` changes.

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -436,7 +436,6 @@ clientBlockFetch sockAddrs maxSlotNo = withIOManager $ \iocp -> do
               blockMatchesHeader     = \_ _ -> True,
 
               headerForgeUTCTime,
-              blockForgeUTCTime      = headerForgeUTCTime . fmap blockHeader,
               readChainSelStarvation = pure (ChainSelStarvationEndedAt (Time 0)),
 
               demoteChainSyncJumpingDynamo = \_ -> pure ()

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -301,7 +301,6 @@ sampleBlockFetchPolicy1 fetchMode headerFieldsForgeUTCTime blockHeap currentChai
       blockMatchesHeader     = \_ _ -> True,
 
       headerForgeUTCTime     = headerFieldsForgeUTCTime,
-      blockForgeUTCTime      = headerFieldsForgeUTCTime,
       readChainSelStarvation = pure (ChainSelStarvationEndedAt (Time 0)),
 
       demoteChainSyncJumpingDynamo = \_ -> pure ()

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
@@ -327,7 +327,6 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
           blockMatchesHeader     = \_ _ -> True,
 
           headerForgeUTCTime,
-          blockForgeUTCTime      = headerForgeUTCTime . fmap blockHeader,
 
           readChainSelStarvation       = pure (ChainSelStarvationEndedAt (Time 0)),
           demoteChainSyncJumpingDynamo = \_ -> pure ()

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -208,7 +208,7 @@ blockFetchLogic decisionTracer clientStateTracer
           blockFetchSize,
           blockMatchesHeader,
           addFetchedBlock,
-          blockForgeUTCTime
+          headerForgeUTCTime
         }
 
     fetchDecisionPolicy :: FetchDecisionPolicy header

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Client.hs
@@ -83,7 +83,7 @@ blockFetchClient _version controlMessageSTM reportFetched
                                                blockFetchSize,
                                                blockMatchesHeader,
                                                addFetchedBlock,
-                                               blockForgeUTCTime
+                                               headerForgeUTCTime
                                              },
                    fetchClientCtxStateVars = stateVars
                  } =
@@ -266,7 +266,7 @@ blockFetchClient _version controlMessageSTM reportFetched
             -- Add the block to the chain DB, notifying of any new chains.
             addFetchedBlock (castPoint (blockPoint header)) block
 
-            forgeTime <- atomically $ blockForgeUTCTime $ FromConsensus block
+            forgeTime <- atomically $ headerForgeUTCTime $ FromConsensus header
             let blockDelay = diffUTCTime now forgeTime
 
             let hf = getHeaderFields header

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/ClientState.hs
@@ -80,7 +80,7 @@ data FetchClientPolicy header block m =
        blockFetchSize     :: header -> SizeInBytes,
        blockMatchesHeader :: header -> block -> Bool,
        addFetchedBlock    :: Point block -> block -> m (),
-       blockForgeUTCTime  :: FromConsensus block -> STM m UTCTime
+       headerForgeUTCTime :: FromConsensus header -> STM m UTCTime
      }
 
 -- | A set of variables shared between the block fetch logic thread and each


### PR DESCRIPTION
# Description

See title. Part of https://github.com/IntersectMBO/ouroboros-consensus/issues/1301

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
