### PR TITLE
Add an extra header parameter to BlockFetchConsensusInterface

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -47,7 +47,8 @@ data FetchMode =
 --
 -- These are provided as input to the block fetch by the consensus layer.
 --
-data BlockFetchConsensusInterface peer header block m =
+-- REVIEW: Explain why we have two types of headers.
+data BlockFetchConsensusInterface peer selectionHeader header block m =
      BlockFetchConsensusInterface {
 
        -- | Read the K-suffixes of the candidate chains.
@@ -63,7 +64,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- This must contain info on the last @K@ blocks (unless we're near
        -- the chain genesis of course).
        --
-       readCurrentChain       :: STM m (AnchoredFragment header),
+       readCurrentChain       :: STM m (AnchoredFragment selectionHeader),
 
        -- | Read the current fetch mode that the block fetch logic should use.
        --
@@ -105,7 +106,7 @@ data BlockFetchConsensusInterface peer header block m =
        -- we would consider a chain of equal length to the current chain.
        --
        plausibleCandidateChain :: HasCallStack
-                               => AnchoredFragment header
+                               => AnchoredFragment selectionHeader
                                -> AnchoredFragment header -> Bool,
 
        -- | Compare two candidate chains and return a preference ordering.

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -418,7 +418,7 @@ clientBlockFetch sockAddrs maxSlotNo = withIOManager $ \iocp -> do
                                     nullTracer clientCtx)
 
         blockFetchPolicy :: BlockFetchConsensusInterface
-                             LocalConnectionId BlockHeader Block IO
+                             LocalConnectionId BlockHeader BlockHeader Block IO
         blockFetchPolicy =
             BlockFetchConsensusInterface {
               readCandidateChains    = readTVar candidateChainsVar

--- a/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/sim-tests-lib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -272,7 +272,7 @@ sampleBlockFetchPolicy1 :: (MonadSTM m, HasHeader header, HasHeader block)
                         -> TestFetchedBlockHeap m block
                         -> AnchoredFragment header
                         -> Map peer (AnchoredFragment header)
-                        -> BlockFetchConsensusInterface peer header block m
+                        -> BlockFetchConsensusInterface peer header header block m
 sampleBlockFetchPolicy1 headerFieldsForgeUTCTime blockHeap currentChain candidateChains =
     BlockFetchConsensusInterface {
       readCandidateChains    = return candidateChains,

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -298,7 +298,7 @@ run blockGeneratorArgs limits ni na tracersExtra tracerBlockFetch =
         })
 
     blockFetchPolicy :: NodeKernel BlockHeader Block s m
-                     -> BlockFetchConsensusInterface NtNAddr BlockHeader Block m
+                     -> BlockFetchConsensusInterface NtNAddr BlockHeader BlockHeader Block m
     blockFetchPolicy nodeKernel =
         BlockFetchConsensusInterface {
           readCandidateChains    = readTVar (nkClientChains nodeKernel)

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -152,9 +152,11 @@ data BlockFetchConfiguration =
 --
 -- This runs forever and should be shut down using mechanisms such as async.
 --
-blockFetchLogic :: forall addr header block m.
-                   ( HasHeader header
+blockFetchLogic :: forall addr selectionHeader header block m.
+                   ( HasHeader selectionHeader
+                   , HasHeader header
                    , HasHeader block
+                   , HeaderHash selectionHeader ~ HeaderHash block
                    , HeaderHash header ~ HeaderHash block
                    , MonadDelay m
                    , MonadSTM m
@@ -163,7 +165,7 @@ blockFetchLogic :: forall addr header block m.
                    )
                 => Tracer m [TraceLabelPeer addr (FetchDecision [Point header])]
                 -> Tracer m (TraceLabelPeer addr (TraceFetchClientState header))
-                -> BlockFetchConsensusInterface addr header block m
+                -> BlockFetchConsensusInterface addr selectionHeader header block m
                 -> FetchClientRegistry addr header block m
                 -> BlockFetchConfiguration
                 -> m Void
@@ -190,7 +192,7 @@ blockFetchLogic decisionTracer clientStateTracer
           blockForgeUTCTime
         }
 
-    fetchDecisionPolicy :: FetchDecisionPolicy header
+    fetchDecisionPolicy :: FetchDecisionPolicy selectionHeader header
     fetchDecisionPolicy =
       FetchDecisionPolicy {
         maxInFlightReqsPerPeer   = bfcMaxRequestsInflight,
@@ -204,7 +206,7 @@ blockFetchLogic decisionTracer clientStateTracer
         blockFetchSize
       }
 
-    fetchTriggerVariables :: FetchTriggerVariables addr header m
+    fetchTriggerVariables :: FetchTriggerVariables addr selectionHeader header m
     fetchTriggerVariables =
       FetchTriggerVariables {
         readStateCurrentChain    = readCurrentChain,


### PR DESCRIPTION
This parameter is currently called `selectionHeader`. This change allow us to use two header types in the interface. The `header` type, now is intended to convey additional information, in particular the slot time at which the header was downloaded. In this way we can address [this
issue](https://github.com/IntersectMBO/ouroboros-consensus/issues/1301) which allow us to simplify Consensus time conversions. Additionally, this change will enable us to remove `FromConsensus` data and the precondition of `headerForgeUTCTime`.

The `selectionHeader` type will typically denote a raw header.

# Description

_reasonably detailed description of the pull request_

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
