### PR TITLE
Modify connection manager state data type

### DIFF
--- a/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
+++ b/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
@@ -8,6 +8,9 @@ module Network.Mux.Bearer.AttenuatedChannel
   , Size
   , SuccessOrFailure (..)
   , Attenuation (..)
+  , QueueChannel
+  , newAttenuatedChannel
+  , echoQueueChannel
   , newConnectedAttenuatedChannelPair
   , attenuationChannelAsBearer
     -- * Trace
@@ -59,6 +62,19 @@ data QueueChannel m = QueueChannel {
     qcRead  :: StrictTVar m (Maybe (StrictTQueue m Message)),
     qcWrite :: StrictTVar m (Maybe (StrictTQueue m Message))
   }
+
+
+-- A `QueueChannel` which receives what is written to it.
+--
+echoQueueChannel :: MonadSTM m => STM m (QueueChannel m)
+echoQueueChannel = do
+  q <- newTQueue
+  v <- newTVar (Just q)
+  return QueueChannel {
+    qcRead  = v,
+    qcWrite = v
+  }
+
 
 --
 -- QueueChannel API

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -12,6 +12,8 @@
   `unregister{Inbound,Outbound}Connection` to `release{Inbound,Outbound}Connection`.
   `AssertionLocation` constructors were renamed as well.
 * Added `RawBearer` API (see https://github.com/IntersectMBO/ouroboros-network/pull/4395)
+* Connection manager is using `ConnectionId`s to identify connections, this
+  affects its API.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -485,7 +485,7 @@ bidirectionalExperiment
                   muxBundle
               res <-
                 releaseOutboundConnection
-                  connectionManager remoteAddr
+                  connectionManager connId
               case res of
                 UnsupportedState inState -> do
                   traceWith debugTracer ( "initiator-loop"

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -31,6 +31,7 @@ library
     Ouroboros.Network.ConnectionId
     Ouroboros.Network.ConnectionManager.Core
     Ouroboros.Network.ConnectionManager.InformationChannel
+    Ouroboros.Network.ConnectionManager.State
     Ouroboros.Network.ConnectionManager.Types
     Ouroboros.Network.Context
     Ouroboros.Network.Driver

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -29,6 +29,7 @@ library
     Ouroboros.Network.Channel
     Ouroboros.Network.ConnectionHandler
     Ouroboros.Network.ConnectionId
+    Ouroboros.Network.ConnectionManager.ConnMap
     Ouroboros.Network.ConnectionManager.Core
     Ouroboros.Network.ConnectionManager.InformationChannel
     Ouroboros.Network.ConnectionManager.State

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -422,7 +422,7 @@ mkSnocket scheduleMap = do
                      )
 
             . getSchedule
-          <$> (getScheduleMap scheduleMap)
+          <$> getScheduleMap scheduleMap
     v <- newTVarIO inboundSchedule
     return $ Snocket {
         getLocalAddr,
@@ -449,10 +449,10 @@ mkSnocket scheduleMap = do
                       $> x
 
     getLocalAddr (FD v) =
-      fdLocalAddress <$> atomically (readTVar v)
+      fdLocalAddress <$> readTVarIO v
 
     getRemoteAddr (FD v) = do
-      mbRemote <- fdRemoteAddress <$> atomically (readTVar v)
+      mbRemote <- fdRemoteAddress <$> readTVarIO v
       case mbRemote of
         Nothing   -> throwIO InvalidArgumentError
         Just addr -> pure addr

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -830,7 +830,7 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
 
                             Right (Just (Disconnected {})) -> pure ()
 
-                            Right (Just (Connected _ _ _)) -> do
+                            Right (Just (Connected connId _ _)) -> do
                               threadDelay (either id id (seActiveDelay conn))
                               -- if this outbound connection is not
                               -- executed within inbound connection,
@@ -850,11 +850,11 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                     -- successful.
                                     void $
                                       releaseInboundConnection
-                                        connectionManager addr
+                                        connectionManager connId
 
                                   res <-
                                       releaseOutboundConnection
-                                        connectionManager addr
+                                        connectionManager connId
                                   case res of
                                     UnsupportedState st ->
                                       throwIO (UnsupportedStateError
@@ -879,17 +879,20 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                         (Accepted fd' addr', acceptNext) -> do
                           thread <-
                             async $ do
+                              localAddress <- getLocalAddr snocket fd'
+                              let connId = ConnectionId { localAddress,
+                                                          remoteAddress = addr' }
                               labelThisThread ("th-inbound-"
                                                 ++ show (getTestAddress addr))
                               Just conn' <-
                                 fdScheduleEntry
-                                  <$> atomically (readTVar (fdState fd'))
+                                  <$> readTVarIO (fdState fd')
                               when (addr /= addr' && seIdx conn /= seIdx conn') $
                                 throwIO (MismatchedScheduleEntry (addr, seIdx conn)
                                                                  (addr', seIdx conn'))
                               _ <-
                                 includeInboundConnection
-                                  connectionManager maxBound fd' addr
+                                  connectionManager maxBound fd' connId
                               t <- getMonotonicTime
 
                               let activeDelay = either id id (seActiveDelay conn)
@@ -902,11 +905,11 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                     threadDelay x
                                     _ <-
                                       promotedToWarmRemote
-                                        connectionManager addr
+                                        connectionManager connId
                                     threadDelay y
                                     _ <-
                                       demotedToColdRemote
-                                        connectionManager addr
+                                        connectionManager connId
                                     return ()
                                   )
                                   (threadDelay activeDelay)
@@ -930,7 +933,7 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
                                   -- TODO: should we run 'unregisterInboundConnection' depending on 'seActiveDelay'
                                   void $
                                     releaseInboundConnection
-                                      connectionManager addr
+                                      connectionManager connId
                           go (thread : threads) acceptNext conns'
                         (AcceptFailure err, _acceptNext) ->
                           throwIO err

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -1166,7 +1166,7 @@ prop_connection_manager_valid_transition_order (Fixed rnd) serverAcc (ArbDataFlo
            MainReturn {} -> mempty
            _             -> All False
        )
-       (verifyAbstractTransitionOrder True)
+       (verifyAbstractTransitionOrder id True)
     . fmap (map ttTransition)
     . groupConns id abstractStateIsFinalTransition
     $ abstractTransitionEvents
@@ -1206,7 +1206,7 @@ prop_connection_manager_valid_transition_order_racy (Fixed rnd) serverAcc (ArbDa
                MainReturn {} -> mempty
                _             -> All False
            )
-           (verifyAbstractTransitionOrder True)
+           (verifyAbstractTransitionOrder id True)
         . fmap (map ttTransition)
         . groupConns id abstractStateIsFinalTransition
         $ abstractTransitionEvents

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -1039,6 +1039,7 @@ prop_connection_manager_valid_transitions_racy
    (Fixed rnd) serverAcc (ArbDataFlow dataFlow)
   defaultBearerInfo mns@(MultiNodeScript events attenuationMap) =
     exploreSimTrace id sim $ \_ trace ->
+                             counterexample (ppTrace trace) $
                              validate_transitions mns trace
   where
     sim :: IOSim s ()

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -884,7 +884,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
               m <- readTVar connVar
               check (Map.member (connId remoteAddr) m)
               writeTVar connVar (Map.delete (connId remoteAddr) m)
-            void (releaseOutboundConnection cm remoteAddr)
+            void (releaseOutboundConnection cm (connId remoteAddr))
             go (Map.delete remoteAddr connMap)
           RunMiniProtocols remoteAddr reqs -> do
             atomically $ do
@@ -1159,6 +1159,7 @@ prop_connection_manager_valid_transition_order (Fixed rnd) serverAcc (ArbDataFlo
   in tabulate "ConnectionEvents" (map showConnectionEvents events)
     . counterexample (ppScript mns)
     . counterexample (Trace.ppTrace show show abstractTransitionEvents)
+    . counterexample (ppTrace trace)
     . bifoldMap
        ( \ case
            MainReturn {} -> mempty

--- a/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
@@ -40,6 +40,7 @@ import Data.ByteString.Lazy (ByteString)
 import Data.Foldable (traverse_)
 import Data.Functor (void)
 import Data.Map qualified as Map
+import Data.Maybe (isNothing)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Text.Printf
@@ -50,6 +51,7 @@ import Ouroboros.Network.Snocket
 import Simulation.Network.Snocket
 
 import Network.Mux as Mx
+import Network.Mux.Types as Mx
 import Network.TypedProtocol.Codec.CBOR
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Peer
@@ -81,6 +83,8 @@ tests =
                    prop_connect_to_not_listening_socket
     , testProperty "simultaneous_open"
                    prop_simultaneous_open
+    , testProperty "self connect"
+                   prop_self_connect
     ]
 
 type TestAddr      = TestAddress Int
@@ -542,6 +546,47 @@ prop_simultaneous_open defaultBearerInfo =
             _ <- listenAndConnect (TestAddress 1) (TestAddress 0)
                                  snocket getState
             wait clientAsync
+
+
+-- | Check that when we bind both outbound and inbound socket to the same
+-- address, and connect the outbound to inbound:
+--
+-- * accept loop never returns
+-- * the outbound socket acts as a mirror
+--
+-- This is how socket API behaves on Linux.
+--
+prop_self_connect :: ByteString -> Property
+prop_self_connect payload =
+    runSimOrThrow sim
+  where
+    addr :: TestAddress Int
+    addr = TestAddress 0
+
+    sim :: forall s. IOSim s Property
+    sim =
+      withSnocket nullTracer noAttenuation Map.empty
+      $ \snocket _getState ->
+        withAsync (runServer addr snocket
+                             (close snocket) acceptOne return)
+          $ \serverThread -> do
+            bracket (openToConnect snocket addr)
+                    (close snocket)
+                  $ \fd -> do
+                    bind snocket fd addr
+                    connect snocket fd addr
+                    bearer <- getBearer makeFDBearer 10 nullTracer fd
+                    let channel = bearerAsChannel bearer (MiniProtocolNum 0) InitiatorDir
+                    send channel payload
+                    payload' <- recv channel
+                    threadDelay 1
+                    serverResult <- atomically $
+                                    (Just <$> waitSTM serverThread)
+                                   `orElse`
+                                   pure Nothing
+                    return $ Just payload === payload'
+                        .&&. isNothing serverResult
+
 
 --
 -- Utils

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -411,10 +411,10 @@ makeConnectionHandler muxTracer singMuxMode
 --
 
 
--- | 'ConnectionHandlerTrace' is embedded into 'ConnectionManagerTrace' with
--- 'Ouroboros.Network.ConnectionManager.Types.ConnectionHandlerTrace'
--- constructor.  It already includes 'ConnectionId' so we don't need to take
--- care of it here.
+-- | 'ConnectionHandlerTrace' is embedded into
+-- 'Ouroboros.Network.ConnectionManager.Core.Trace' with
+-- 'Ouroboros.Network.ConnectionManager.Types.TrConnectionHandler' constructor.
+-- It already includes 'ConnectionId' so we don't need to take care of it here.
 --
 -- TODO: when 'Handshake' will get its own tracer, independent of 'Mux', it
 -- should be embedded into 'ConnectionHandlerTrace'.

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionId.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionId.hs
@@ -33,7 +33,8 @@ data ConnectionId addr = ConnectionId {
 --
 -- /Note:/ we relay on the fact that `remoteAddress` is an order
 -- preserving map (which allows us to use `Map.mapKeysMonotonic` in some
--- cases).
+-- cases.  We also relay on this particular order in
+-- `Ouroboros.Network.ConnectionManager.State.liveConnections`
 --
 instance Ord addr => Ord (ConnectionId addr) where
     conn `compare` conn' =

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/ConnMap.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/ConnMap.hs
@@ -1,0 +1,269 @@
+{-# LANGUAGE DeriveTraversable   #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Ouroboros.Network.ConnectionManager.ConnMap
+  ( ConnMap (..)
+  , LocalAddr (..)
+  , toList
+  , toMap
+  , empty
+  , insert
+  , insertUnknownLocalAddr
+  , delete
+    -- , deleteUnknownLocalAddr
+  , deleteAtRemoteAddr
+  , lookup
+  , lookupByRemoteAddr
+  , updateLocalAddr
+  , traverseMaybeWithKey
+  ) where
+
+import Prelude hiding (lookup)
+
+import Data.Foldable qualified as Foldable
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import System.Random (RandomGen, uniformR)
+
+import Ouroboros.Network.ConnectionId
+
+data LocalAddr peerAddr =
+    -- | A reserved slot for an outbound connection which is being created.  The
+    -- outbound connection must be in the `ReservedOutbound` state.
+    UnknownLocalAddr
+    -- | All connections which are not in the `ReservedOutbound` state use
+    -- `LocalAddr`, since for them the local address is known.
+  | LocalAddr peerAddr
+  deriving (Show, Eq, Ord)
+
+
+-- | The outer map keys are remote addresses, the internal ones are local
+-- addresses.
+--
+newtype ConnMap peerAddr a
+  = ConnMap {
+      getConnMap ::
+        Map peerAddr
+          (Map (LocalAddr peerAddr) a)
+    }
+  deriving (Show, Functor, Foldable)
+
+instance  Traversable (ConnMap peerAddr) where
+  traverse f (ConnMap m) = ConnMap <$> traverse (traverse f) m
+
+
+toList :: ConnMap m a -> [a]
+toList = Foldable.toList
+
+
+-- | Create a map of all connections with a known `ConnectionId`.
+--
+toMap :: forall peerAddr a.
+         Ord peerAddr
+      => ConnMap peerAddr a
+      -> Map (ConnectionId peerAddr) a
+toMap =
+    -- We can use `fromAscList` because of the `Ord` instance of `ConnectionId`.
+    -- /NOTE:/ if `fromAscList` is used on input which doesn't satisfy its
+    -- precondition, then `Map.lookup` might fail when it shouldn't.
+    Map.fromAscList
+  . Map.foldrWithKey
+      (\remoteAddress st conns ->
+        Map.foldrWithKey
+          (\localAddr conn conns' ->
+            case localAddr of
+              UnknownLocalAddr -> conns'
+              LocalAddr localAddress ->
+                (ConnectionId { remoteAddress, localAddress }, conn) : conns'
+          )
+          conns
+          st
+      )
+      []
+  . getConnMap
+
+
+empty :: ConnMap peerAddr a
+empty = ConnMap Map.empty
+
+
+insert :: Ord peerAddr
+       => ConnectionId peerAddr
+       -> a
+       -> ConnMap peerAddr a
+       -> ConnMap peerAddr a
+insert ConnectionId { remoteAddress, localAddress } a =
+    ConnMap
+  . Map.alter
+      (\case
+        Nothing -> Just $! Map.singleton (LocalAddr localAddress) a
+        Just st -> Just $! Map.insert (LocalAddr localAddress) a st)
+    remoteAddress
+  . getConnMap
+
+
+insertUnknownLocalAddr
+  :: Ord peerAddr
+  => peerAddr
+  -> a
+  -> ConnMap peerAddr a
+  -> ConnMap peerAddr a
+insertUnknownLocalAddr remoteAddress a =
+    ConnMap
+  . Map.alter
+      (\case
+        Nothing -> Just $! Map.singleton UnknownLocalAddr a
+        Just st -> Just $! Map.insert UnknownLocalAddr a st
+      )
+    remoteAddress
+  . getConnMap
+
+
+delete :: Ord peerAddr
+       => ConnectionId peerAddr
+       -> ConnMap peerAddr a
+       -> ConnMap peerAddr a
+delete ConnectionId { remoteAddress, localAddress } =
+    ConnMap
+  . Map.alter
+      (\case
+          Nothing -> Nothing
+          Just st ->
+            let st' = Map.delete (LocalAddr localAddress) st
+            in if Map.null st'
+                 then Nothing
+                 else Just st'
+      )
+      remoteAddress
+  . getConnMap
+
+
+deleteAtRemoteAddr
+  :: (Ord peerAddr, Eq a)
+  => peerAddr
+  -- ^ remoteAddr
+  -> a
+  -- ^ element to remove
+  -> ConnMap peerAddr a
+  -> ConnMap peerAddr a
+deleteAtRemoteAddr remoteAddress a =
+    ConnMap
+  . Map.alter
+      (\case
+          Nothing -> Nothing
+          Just st ->
+            let st' = Map.filter (/=a) st in
+            if Map.null st'
+              then Nothing
+              else Just st'
+      )
+      remoteAddress
+  . getConnMap
+
+
+
+lookup :: Ord peerAddr
+       => ConnectionId peerAddr
+       -> ConnMap peerAddr a
+       -> Maybe a
+lookup ConnectionId { remoteAddress, localAddress } (ConnMap st) =
+   case remoteAddress `Map.lookup` st of
+     Nothing  -> Nothing
+     Just st' -> LocalAddr localAddress `Map.lookup` st'
+
+
+-- | Find a random entry for a given remote address.
+--
+-- NOTE: the outbound governor will only ask for a connection to a peer if it
+-- doesn't have one (and one isn't being created).  This property, simplifies
+-- `lookupOutbound`: we can pick (randomly) one of the connections to the
+-- remote peer.  When the outbound governor is asking, likely all of the
+-- connections are in an inbound state.  The outbound governor will has a grace
+-- period after demoting a peer, so a race (when a is being demoted and
+-- promoted at the same time) is unlikely.
+--
+lookupByRemoteAddr
+    :: forall rnd peerAddr a.
+       ( Ord peerAddr
+       , RandomGen rnd
+       )
+    => rnd
+    -- ^ a fresh `rnd` (it must come from a `split`)
+    -> peerAddr
+    -- ^ remote address
+    -> ConnMap peerAddr a
+    -> (Maybe a)
+lookupByRemoteAddr rnd remoteAddress (ConnMap st) =
+  case remoteAddress `Map.lookup` st of
+    Nothing -> Nothing
+    Just st' ->
+      case UnknownLocalAddr `Map.lookup` st' of
+        Just a -> Just a
+        Nothing ->
+          if Map.null st'
+          then Nothing
+          else let (indx, _rnd') = uniformR (0, Map.size st' - 1) rnd
+               in Just $ snd $ Map.elemAt indx st'
+
+
+-- | Promote `UnknownLocalAddr` to `LocalAddr`.
+--
+updateLocalAddr
+  :: Ord peerAddr
+  => ConnectionId peerAddr
+  -> ConnMap peerAddr a
+  -> (Bool, ConnMap peerAddr a)
+  -- ^ Return `True` iff the entry was updated.
+updateLocalAddr ConnectionId { remoteAddress, localAddress } (ConnMap m) =
+      ConnMap
+  <$> Map.alterF
+      (\case
+        Nothing -> (False, Nothing)
+        Just m' ->
+          let -- delete & lookup for entry in `UnknownLocalAddr`
+              (ma, m'') =
+                Map.alterF
+                  (\x -> (x,Nothing))
+                  UnknownLocalAddr
+                  m'
+          in
+            case ma of
+              -- there was no entry, so no need to update the inner map
+              Nothing -> (False, Just m')
+              -- we have an entry: put it in the `LocalAddr`, but only if it's
+              -- not present in the map.
+              Just {} ->
+                  fmap Just
+                . Map.alterF
+                    (\case
+                      Nothing  -> (True, ma)
+                      a@Just{} -> (False, a)
+                    )
+                    (LocalAddr localAddress)
+                $ m''
+      )
+      remoteAddress
+      m
+
+
+traverseMaybeWithKey
+  :: Applicative f
+  => (Either peerAddr (ConnectionId peerAddr) -> a -> f (Maybe b))
+  -> ConnMap peerAddr a
+  -> f [b]
+traverseMaybeWithKey fn =
+    fmap (concat . Map.elems)
+  . Map.traverseMaybeWithKey
+      (\remoteAddress st ->
+          fmap (Just . Map.elems)
+        . Map.traverseMaybeWithKey
+            (\case
+                UnknownLocalAddr       -> fn (Left remoteAddress)
+                LocalAddr localAddress -> fn (Right ConnectionId { remoteAddress,
+                                                                   localAddress })
+            )
+        $ st
+      )
+  . getConnMap

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -81,6 +81,8 @@ data Arguments handlerTrace socket peerAddr handle handleError versionNumber ver
 
         -- | Trace state transitions.
         --
+        -- TODO: do we need this tracer?  In some tests we relay on `traceTVar` in
+        -- `newNetworkMutableState` instead.
         trTracer            :: Tracer m (TransitionTrace peerAddr
                                             (ConnectionState peerAddr handle handleError versionNumber m)),
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -8,8 +8,6 @@
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TupleSections         #-}
--- Undecidable instances are need for 'Show' instance of 'ConnectionState'.
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE TypeApplications      #-}
 {-# LANGUAGE UndecidableInstances  #-}
 
@@ -41,9 +39,7 @@ import Control.Monad.Class.MonadTimer.SI
 import Control.Monad.Fix
 import Control.Tracer (Tracer, contramap, traceWith)
 import Data.Foldable (foldMap', traverse_)
-import Data.Function (on)
 import Data.Functor (void, ($>))
-import Data.Maybe (maybeToList)
 import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)
 import GHC.Stack (CallStack, HasCallStack, callStack)
@@ -66,11 +62,11 @@ import Ouroboros.Network.ConnectionManager.InformationChannel
            (InformationChannel)
 import Ouroboros.Network.ConnectionManager.InformationChannel qualified as InfoChannel
 import Ouroboros.Network.ConnectionManager.Types
+import Ouroboros.Network.ConnectionManager.State
 import Ouroboros.Network.InboundGovernor.Event (NewConnectionInfo (..))
 import Ouroboros.Network.MuxMode
 import Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import Ouroboros.Network.Snocket
-import Ouroboros.Network.Testing.Utils (WithName (..))
 
 
 -- | Arguments for a 'ConnectionManager' which are independent of 'MuxMode'.
@@ -151,106 +147,6 @@ data Arguments handlerTrace socket peerAddr handle handleError versionNumber ver
       }
 
 
--- | 'MutableConnState', which supplies a unique identifier.
---
--- TODO: We can get away without id, by tracking connections in
--- `TerminatingState` using a separate priority search queue.
---
-data MutableConnState peerAddr handle handleError version m = MutableConnState {
-    -- | A unique identifier
-    --
-    connStateId  :: !Int
-
-  , -- | Mutable state
-    --
-    connVar      :: !(StrictTVar m (ConnectionState peerAddr handle handleError
-                                                    version m))
-  }
-
-
-instance Eq (MutableConnState peerAddr handle handleError version m) where
-    (==) =  (==) `on` connStateId
-
-
--- | A supply of fresh id's.
---
--- We use a fresh ids for 'MutableConnState'.
---
-newtype FreshIdSupply m = FreshIdSupply { getFreshId :: STM m Int }
-
-
--- | Create a 'FreshIdSupply' inside an 'STM' monad.
---
-newFreshIdSupply :: forall m. MonadSTM m
-                 => Proxy m -> STM m (FreshIdSupply m)
-newFreshIdSupply _ = do
-    (v :: StrictTVar m Int) <- newTVar 0
-    let getFreshId :: STM m Int
-        getFreshId = do
-          c <- readTVar v
-          writeTVar v (succ c)
-          return c
-    return $ FreshIdSupply { getFreshId }
-
-
-newMutableConnState :: forall peerAddr handle handleError version m.
-                      ( MonadTraceSTM m
-                      , Typeable peerAddr
-                      )
-                    => peerAddr
-                    -> FreshIdSupply m
-                    -> ConnectionState peerAddr handle handleError
-                                       version m
-                    -> STM m (MutableConnState peerAddr handle handleError
-                                               version m)
-newMutableConnState peerAddr freshIdSupply connState = do
-      connStateId <- getFreshId freshIdSupply
-      connVar <- newTVar connState
-      -- This tracing is a no op in IO.
-      --
-      -- We need this for IOSimPOR testing of connection manager state
-      -- transition tests. It can happen that the transitions happen
-      -- correctly but IOSimPOR reorders the threads that log the transitions.
-      -- This is a false positive and we don't want that to happen.
-      --
-      -- The simplest way to do so is to leverage the `traceTVar` IOSim
-      -- capabilities. These trace messages won't be reordered by IOSimPOR
-      -- since these happen atomically in STM.
-      --
-      traceTVar
-        (Proxy @m) connVar
-        (\mbPrev curr ->
-          let currAbs = abstractState (Known curr)
-           in case mbPrev of
-                Just prev |
-                    let prevAbs = abstractState (Known prev)
-                  , prevAbs /= currAbs -> pure
-                                       $ TraceDynamic
-                                       $ WithName connStateId
-                                       $ TransitionTrace peerAddr
-                                       $ mkAbsTransition prevAbs
-                                                         currAbs
-                Nothing                -> pure
-                                       $ TraceDynamic
-                                       $ WithName connStateId
-                                       $ TransitionTrace peerAddr
-                                       $ mkAbsTransition TerminatedSt
-                                                         currAbs
-                _                      -> pure DontTrace
-        )
-      return $ MutableConnState { connStateId, connVar }
-
-
--- | 'ConnectionManager' state: for each peer we keep a 'ConnectionState' in
--- a mutable variable, which reduces congestion on the 'TMVar' which keeps
--- 'ConnectionManagerState'.
---
--- It is important we can lookup by remote @peerAddr@; this way we can find if
--- the connection manager is already managing a connection towards that
--- @peerAddr@ and reuse the 'ConnectionState'.
---
-type ConnectionManagerState peerAddr handle handleError version m
-  = Map peerAddr (MutableConnState peerAddr handle handleError version m)
 
 connectionManagerStateToCounters
   :: Map peerAddr (ConnectionState peerAddr handle handleError version m)
@@ -258,44 +154,6 @@ connectionManagerStateToCounters
 connectionManagerStateToCounters =
     foldMap' connectionStateToCounters
 
--- | State of a connection.
---
-data ConnectionState peerAddr handle handleError version m =
-    -- | Each outbound connections starts in this state.
-    ReservedOutboundState
-
-    -- | Each inbound connection starts in this state, outbound connection
-    -- reach this state once `connect` call returns.
-    --
-    -- note: the async handle is lazy, because it's passed with 'mfix'.
-  | UnnegotiatedState   !Provenance
-                        !(ConnectionId peerAddr)
-                         (Async m ())
-
-    -- | @OutboundState Unidirectional@ state.
-  | OutboundUniState    !(ConnectionId peerAddr) !(Async m ()) !handle
-
-    -- | Either @OutboundState Duplex@ or @OutboundState^\tau Duplex@.
-  | OutboundDupState    !(ConnectionId peerAddr) !(Async m ()) !handle !TimeoutExpired
-
-    -- | Before connection is reset it is put in 'OutboundIdleState' for the
-    -- duration of 'outboundIdleTimeout'.
-    --
-  | OutboundIdleState   !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
-  | InboundIdleState    !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
-  | InboundState        !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
-  | DuplexState         !(ConnectionId peerAddr) !(Async m ()) !handle
-  | TerminatingState    !(ConnectionId peerAddr) !(Async m ()) !(Maybe handleError)
-  | TerminatedState                              !(Maybe handleError)
-
-
--- | Return 'True' for states in which the connection was already closed.
---
-connectionTerminated :: ConnectionState peerAddr handle handleError version m
-                     -> Bool
-connectionTerminated TerminatingState {} = True
-connectionTerminated TerminatedState  {} = True
-connectionTerminated _                   = False
 
 
 -- | Perform counting from an 'AbstractState'
@@ -349,76 +207,6 @@ connectionStateToCounters state =
     outboundConn       = ConnectionManagerCounters 0 0 0 0 1
 
 
-instance ( Show peerAddr
-         , Show handleError
-         , MonadAsync m
-         )
-      => Show (ConnectionState peerAddr handle handleError version m) where
-    show ReservedOutboundState = "ReservedOutboundState"
-    show (UnnegotiatedState pr connId connThread) =
-      concat ["UnnegotiatedState "
-             , show pr
-             , " "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             ]
-    show (OutboundUniState connId connThread _handle) =
-      concat [ "OutboundState Unidirectional "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             ]
-    show (OutboundDupState connId connThread _handle expired) =
-      concat [ "OutboundState "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             , " "
-             , show expired
-             ]
-    show (OutboundIdleState connId connThread _handle df) =
-      concat [ "OutboundIdleState "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             , " "
-             , show df
-             ]
-    show (InboundIdleState connId connThread _handle df) =
-      concat [ "InboundIdleState "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             , " "
-             , show df
-             ]
-    show (InboundState  connId connThread _handle df) =
-      concat [ "InboundState "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             , " "
-             , show df
-             ]
-    show (DuplexState   connId connThread _handle) =
-      concat [ "DuplexState "
-             , show connId
-             , " "
-             , show (asyncThreadId connThread)
-             ]
-    show (TerminatingState connId connThread handleError) =
-      concat ([ "TerminatingState "
-              , show connId
-              , " "
-              , show (asyncThreadId connThread)
-              ]
-              ++ maybeToList ((' ' :) . show <$> handleError))
-    show (TerminatedState handleError) =
-      concat (["TerminatedState"]
-              ++ maybeToList ((' ' :) . show <$> handleError))
-
-
 getConnThread :: ConnectionState peerAddr handle handleError version m
               -> Maybe (Async m ())
 getConnThread ReservedOutboundState                                     = Nothing
@@ -464,25 +252,6 @@ isInboundConn InboundState {}                            = True
 isInboundConn DuplexState {}                             = True
 isInboundConn TerminatingState {}                        = False
 isInboundConn TerminatedState {}                         = False
-
-
-abstractState :: MaybeUnknown (ConnectionState muxMode peerAddr m a b) -> AbstractState
-abstractState = \case
-    Unknown  -> UnknownConnectionSt
-    Race s'  -> go s'
-    Known s' -> go s'
-  where
-    go :: ConnectionState muxMode peerAddr m a b -> AbstractState
-    go ReservedOutboundState {}       = ReservedOutboundSt
-    go (UnnegotiatedState pr _ _)     = UnnegotiatedSt pr
-    go (OutboundUniState    _ _ _)    = OutboundUniSt
-    go (OutboundDupState    _ _ _ te) = OutboundDupSt te
-    go (OutboundIdleState _ _ _ df)   = OutboundIdleSt df
-    go (InboundIdleState _ _ _ df)    = InboundIdleSt df
-    go (InboundState     _ _ _ df)    = InboundSt df
-    go DuplexState {}                 = DuplexSt
-    go TerminatingState {}            = TerminatingSt
-    go TerminatedState {}             = TerminatedSt
 
 -- | The default value for 'timeWaitTimeout'.
 --

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -408,15 +408,11 @@ with args@Arguments {
       <- atomically $  do
           v  <- newTMVar State.empty
           labelTMVar v "cm-state"
-          traceTMVar (Proxy :: Proxy m) v
-                   $ \old new ->
-                     case (old, new) of
-                       (Nothing, _)             -> pure DontTrace
-                       -- taken
-                       (Just (Just _), Nothing) -> pure (TraceString "cm-state: taken")
-                       -- released
-                       (Just Nothing,  Just _)  -> pure (TraceString "cm-state: released")
-                       (_, _)                   -> pure DontTrace
+          traceTMVar (Proxy :: Proxy m) v $ \_ mbst -> do
+            st' <- case mbst of
+              Nothing -> pure Nothing
+              Just st -> Just <$> traverse (inspectTVar (Proxy :: Proxy m) . toLazyTVar . connVar) st
+            return (TraceString (show st'))
 
           freshIdSupply <- State.newFreshIdSupply (Proxy :: Proxy m)
           stdGenVar <- newTVar (stdGen args)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -45,8 +45,8 @@ import Data.Typeable (Typeable)
 import GHC.Stack (CallStack, HasCallStack, callStack)
 import System.Random (StdGen, split)
 
-import Data.Map (Map)
-import Data.Map qualified as Map
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
 import Data.Monoid.Synchronisation

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -1810,13 +1810,14 @@ with args@Arguments {
                     TerminatedState handleErrorM
               transition = mkTransition connState connState'
               absConnState = State.abstractState (Known connState)
-              shouldTrace = absConnState /= TerminatedSt
+              shouldTransition = absConnState /= TerminatedSt
 
           -- 'handleError' might be either a handshake negotiation
           -- a protocol failure (an IO exception, a timeout or
           -- codec failure).  In the first case we should not reset
           -- the connection as this is not a protocol error.
-          writeTVar connVar connState'
+          when shouldTransition $ do
+            writeTVar connVar connState'
 
           updated <-
             modifyTMVarPure
@@ -1835,7 +1836,7 @@ with args@Arguments {
             -- Key was present in the dictionary (stateVar) and
             -- removed so we trace the removal.
               return $
-                if shouldTrace
+                if shouldTransition
                    then [ transition
                         , Transition
                            { fromState = Known (TerminatedState Nothing)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
@@ -157,7 +157,7 @@ abstractState = \case
     go :: ConnectionState muxMode peerAddr m a b -> AbstractState
     go ReservedOutboundState {}       = ReservedOutboundSt
     go (UnnegotiatedState pr _ _)     = UnnegotiatedSt pr
-    go (OutboundUniState    _ _ _)    = OutboundUniSt
+    go OutboundUniState {}            = OutboundUniSt
     go (OutboundDupState    _ _ _ te) = OutboundDupSt te
     go (OutboundIdleState _ _ _ df)   = OutboundIdleSt df
     go (InboundIdleState _ _ _ df)    = InboundIdleSt df

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
@@ -1,0 +1,260 @@
+{-# LANGUAGE LambdaCase            #-}
+{-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TypeApplications      #-}
+-- Undecidable instances are need for 'Show' instance of 'ConnectionState'.
+{-# LANGUAGE QuantifiedConstraints #-}
+
+module Ouroboros.Network.ConnectionManager.State
+  ( ConnectionManagerState
+  , MutableConnState (..)
+  , FreshIdSupply
+  , newFreshIdSupply
+  , newMutableConnState
+  , abstractState
+  , ConnectionState (..)
+  , connectionTerminated
+  ) where
+
+import Control.Monad.Class.MonadAsync
+import Control.Concurrent.Class.MonadSTM.Strict
+import Data.Function (on)
+import Data.Map (Map)
+import Data.Maybe (maybeToList)
+import Data.Proxy (Proxy (..))
+import Data.Typeable (Typeable)
+
+import Ouroboros.Network.ConnectionId
+import Ouroboros.Network.ConnectionManager.Types
+
+import Ouroboros.Network.Testing.Utils (WithName (..))
+
+-- | 'ConnectionManager' state: for each peer we keep a 'ConnectionState' in
+-- a mutable variable, which reduces congestion on the 'TMVar' which keeps
+-- 'ConnectionManagerState'.
+--
+-- It is important we can lookup by remote @peerAddr@; this way we can find if
+-- the connection manager is already managing a connection towards that
+-- @peerAddr@ and reuse the 'ConnectionState'.
+--
+type ConnectionManagerState peerAddr handle handleError version m
+  = Map peerAddr (MutableConnState peerAddr handle handleError version m)
+
+
+-- | 'MutableConnState', which supplies a unique identifier.
+--
+-- TODO: We can get away without id, by tracking connections in
+-- `TerminatingState` using a separate priority search queue.
+--
+data MutableConnState peerAddr handle handleError version m = MutableConnState {
+    -- | A unique identifier
+    --
+    connStateId  :: !Int
+
+  , -- | Mutable state
+    --
+    connVar      :: !(StrictTVar m (ConnectionState peerAddr handle handleError
+                                                    version m))
+  }
+
+
+instance Eq (MutableConnState peerAddr handle handleError version m) where
+    (==) =  (==) `on` connStateId
+
+
+-- | A supply of fresh id's.
+--
+-- We use a fresh ids for 'MutableConnState'.
+--
+newtype FreshIdSupply m = FreshIdSupply { getFreshId :: STM m Int }
+
+
+-- | Create a 'FreshIdSupply' inside an 'STM' monad.
+--
+newFreshIdSupply :: forall m. MonadSTM m
+                 => Proxy m -> STM m (FreshIdSupply m)
+newFreshIdSupply _ = do
+    (v :: StrictTVar m Int) <- newTVar 0
+    let getFreshId :: STM m Int
+        getFreshId = do
+          c <- readTVar v
+          writeTVar v (succ c)
+          return c
+    return $ FreshIdSupply { getFreshId }
+
+
+newMutableConnState :: forall peerAddr handle handleError version m.
+                      ( MonadTraceSTM m
+                      , Typeable peerAddr
+                      )
+                    => peerAddr
+                    -> FreshIdSupply m
+                    -> ConnectionState peerAddr handle handleError
+                                       version m
+                    -> STM m (MutableConnState peerAddr handle handleError
+                                               version m)
+newMutableConnState peerAddr freshIdSupply connState = do
+      connStateId <- getFreshId freshIdSupply
+      connVar <- newTVar connState
+      -- This tracing is a no op in IO.
+      --
+      -- We need this for IOSimPOR testing of connection manager state
+      -- transition tests. It can happen that the transitions happen
+      -- correctly but IOSimPOR reorders the threads that log the transitions.
+      -- This is a false positive and we don't want that to happen.
+      --
+      -- The simplest way to do so is to leverage the `traceTVar` IOSim
+      -- capabilities. These trace messages won't be reordered by IOSimPOR
+      -- since these happen atomically in STM.
+      --
+      traceTVar
+        (Proxy @m) connVar
+        (\mbPrev curr ->
+          let currAbs = abstractState (Known curr)
+           in case mbPrev of
+                Just prev |
+                    let prevAbs = abstractState (Known prev)
+                  , prevAbs /= currAbs -> pure
+                                       $ TraceDynamic
+                                       $ WithName connStateId
+                                       $ TransitionTrace peerAddr
+                                       $ mkAbsTransition prevAbs
+                                                         currAbs
+                Nothing                -> pure
+                                       $ TraceDynamic
+                                       $ WithName connStateId
+                                       $ TransitionTrace peerAddr
+                                       $ mkAbsTransition TerminatedSt
+                                                         currAbs
+                _                      -> pure DontTrace
+        )
+      return $ MutableConnState { connStateId, connVar }
+
+
+abstractState :: MaybeUnknown (ConnectionState muxMode peerAddr m a b) -> AbstractState
+abstractState = \case
+    Unknown  -> UnknownConnectionSt
+    Race s'  -> go s'
+    Known s' -> go s'
+  where
+    go :: ConnectionState muxMode peerAddr m a b -> AbstractState
+    go ReservedOutboundState {}       = ReservedOutboundSt
+    go (UnnegotiatedState pr _ _)     = UnnegotiatedSt pr
+    go (OutboundUniState    _ _ _)    = OutboundUniSt
+    go (OutboundDupState    _ _ _ te) = OutboundDupSt te
+    go (OutboundIdleState _ _ _ df)   = OutboundIdleSt df
+    go (InboundIdleState _ _ _ df)    = InboundIdleSt df
+    go (InboundState     _ _ _ df)    = InboundSt df
+    go DuplexState {}                 = DuplexSt
+    go TerminatingState {}            = TerminatingSt
+    go TerminatedState {}             = TerminatedSt
+
+
+-- | State of a connection.
+--
+data ConnectionState peerAddr handle handleError version m =
+    -- | Each outbound connections starts in this state.
+    ReservedOutboundState
+
+    -- | Each inbound connection starts in this state, outbound connection
+    -- reach this state once `connect` call returns.
+    --
+    -- note: the async handle is lazy, because it's passed with 'mfix'.
+  | UnnegotiatedState   !Provenance
+                        !(ConnectionId peerAddr)
+                         (Async m ())
+
+    -- | @OutboundState Unidirectional@ state.
+  | OutboundUniState    !(ConnectionId peerAddr) !(Async m ()) !handle
+
+    -- | Either @OutboundState Duplex@ or @OutboundState^\tau Duplex@.
+  | OutboundDupState    !(ConnectionId peerAddr) !(Async m ()) !handle !TimeoutExpired
+
+    -- | Before connection is reset it is put in 'OutboundIdleState' for the
+    -- duration of 'outboundIdleTimeout'.
+    --
+  | OutboundIdleState   !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
+  | InboundIdleState    !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
+  | InboundState        !(ConnectionId peerAddr) !(Async m ()) !handle !DataFlow
+  | DuplexState         !(ConnectionId peerAddr) !(Async m ()) !handle
+  | TerminatingState    !(ConnectionId peerAddr) !(Async m ()) !(Maybe handleError)
+  | TerminatedState                              !(Maybe handleError)
+
+
+instance ( Show peerAddr
+         , Show handleError
+         , MonadAsync m
+         )
+      => Show (ConnectionState peerAddr handle handleError version m) where
+    show ReservedOutboundState = "ReservedOutboundState"
+    show (UnnegotiatedState pr connId connThread) =
+      concat ["UnnegotiatedState "
+             , show pr
+             , " "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             ]
+    show (OutboundUniState connId connThread _handle) =
+      concat [ "OutboundState Unidirectional "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             ]
+    show (OutboundDupState connId connThread _handle expired) =
+      concat [ "OutboundState "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             , " "
+             , show expired
+             ]
+    show (OutboundIdleState connId connThread _handle df) =
+      concat [ "OutboundIdleState "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             , " "
+             , show df
+             ]
+    show (InboundIdleState connId connThread _handle df) =
+      concat [ "InboundIdleState "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             , " "
+             , show df
+             ]
+    show (InboundState  connId connThread _handle df) =
+      concat [ "InboundState "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             , " "
+             , show df
+             ]
+    show (DuplexState   connId connThread _handle) =
+      concat [ "DuplexState "
+             , show connId
+             , " "
+             , show (asyncThreadId connThread)
+             ]
+    show (TerminatingState connId connThread handleError) =
+      concat ([ "TerminatingState "
+              , show connId
+              , " "
+              , show (asyncThreadId connThread)
+              ]
+              ++ maybeToList ((' ' :) . show <$> handleError))
+    show (TerminatedState handleError) =
+      concat (["TerminatedState"]
+              ++ maybeToList ((' ' :) . show <$> handleError))
+
+
+-- | Return 'True' for states in which the connection was already closed.
+--
+connectionTerminated :: ConnectionState peerAddr handle handleError version m
+                     -> Bool
+connectionTerminated TerminatingState {} = True
+connectionTerminated TerminatedState  {} = True
+connectionTerminated _                   = False

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
@@ -19,7 +19,7 @@ module Ouroboros.Network.ConnectionManager.State
 import Control.Monad.Class.MonadAsync
 import Control.Concurrent.Class.MonadSTM.Strict
 import Data.Function (on)
-import Data.Map (Map)
+import Data.Map.Strict (Map)
 import Data.Maybe (maybeToList)
 import Data.Proxy (Proxy (..))
 import Data.Typeable (Typeable)

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -177,7 +177,8 @@ import System.Random (StdGen)
 import Network.Mux.Types (HasInitiator, HasResponder, MiniProtocolDir)
 import Network.Mux.Types qualified as Mux
 
-import Ouroboros.Network.ConnectionId (ConnectionId)
+import Ouroboros.Network.ConnectionId (ConnectionId (..))
+import Ouroboros.Network.ConnectionManager.ConnMap (ConnMap)
 import Ouroboros.Network.MuxMode
 
 
@@ -423,9 +424,9 @@ data HandleErrorType =
 -- connections.
 --
 type PrunePolicy peerAddr = StdGen
-                         -> Map peerAddr ConnectionType
+                         -> Map (ConnectionId peerAddr) ConnectionType
                          -> Int
-                         -> Set peerAddr
+                         -> Set (ConnectionId peerAddr)
 
 
 -- | The simplest 'PrunePolicy', it should only be used for tests.
@@ -500,7 +501,7 @@ type IncludeInboundConnection socket peerAddr handle handleError m
     -- ^ inbound connections hard limit.
     -- NOTE: Check TODO over at includeInboundConnectionImpl
     -- definition.
-    -> socket -> peerAddr -> m (Connected peerAddr handle handleError)
+    -> socket -> ConnectionId peerAddr -> m (Connected peerAddr handle handleError)
 
 
 -- | Outbound connection manager API.
@@ -509,7 +510,7 @@ data OutboundConnectionManager (muxMode :: Mux.Mode) socket peerAddr handle hand
     OutboundConnectionManager
       :: HasInitiator muxMode ~ True
       => { ocmAcquireConnection :: AcquireOutboundConnection peerAddr handle handleError m
-         , ocmReleaseConnection :: peerAddr -> m (OperationResult AbstractState)
+         , ocmReleaseConnection :: ConnectionId peerAddr -> m (OperationResult AbstractState)
          }
       -> OutboundConnectionManager muxMode socket peerAddr handle handleError m
 
@@ -522,10 +523,10 @@ data InboundConnectionManager (muxMode :: Mux.Mode) socket peerAddr handle handl
     InboundConnectionManager
       :: HasResponder muxMode ~ True
       => { icmIncludeConnection    :: IncludeInboundConnection socket peerAddr handle handleError m
-         , icmReleaseConnection    :: peerAddr -> m (OperationResult DemotedToColdRemoteTr)
-         , icmPromotedToWarmRemote :: peerAddr -> m (OperationResult AbstractState)
+         , icmReleaseConnection    :: ConnectionId peerAddr -> m (OperationResult DemotedToColdRemoteTr)
+         , icmPromotedToWarmRemote :: ConnectionId peerAddr -> m (OperationResult AbstractState)
          , icmDemotedToColdRemote
-                                   :: peerAddr -> m (OperationResult AbstractState)
+                                   :: ConnectionId peerAddr -> m (OperationResult AbstractState)
          , icmNumberOfConnections  :: STM m Int
          }
       -> InboundConnectionManager muxMode socket peerAddr handle handleError m
@@ -548,13 +549,13 @@ data ConnectionManager (muxMode :: Mux.Mode) socket peerAddr handle handleError 
               (InboundConnectionManager  muxMode socket peerAddr handle handleError m),
 
         readState
-          :: STM m (Map peerAddr AbstractState),
+          :: STM m (ConnMap peerAddr AbstractState),
 
         -- | This STM action will block until the given connection is fully
         -- closed/terminated. If the connection manager doesn't have any connection to
         -- that peer it won't block.
         waitForOutboundDemotion
-          :: peerAddr
+          :: ConnectionId peerAddr
           -> STM m ()
       }
 
@@ -584,7 +585,7 @@ acquireOutboundConnection =
 releaseOutboundConnection
     :: HasInitiator muxMode ~ True
     => ConnectionManager muxMode socket peerAddr handle handleError m
-    -> peerAddr
+    -> ConnectionId peerAddr
     -> m (OperationResult AbstractState)
     -- ^ reports the from-state.
 releaseOutboundConnection =
@@ -603,7 +604,7 @@ releaseOutboundConnection =
 promotedToWarmRemote
     :: HasResponder muxMode ~ True
     => ConnectionManager muxMode socket peerAddr handle handleError m
-    -> peerAddr -> m (OperationResult AbstractState)
+    -> ConnectionId peerAddr -> m (OperationResult AbstractState)
 promotedToWarmRemote =
     icmPromotedToWarmRemote . withResponderMode . getConnectionManager
 
@@ -619,7 +620,7 @@ promotedToWarmRemote =
 demotedToColdRemote
     :: HasResponder muxMode ~ True
     => ConnectionManager muxMode socket peerAddr handle handleError m
-    -> peerAddr -> m (OperationResult AbstractState)
+    -> ConnectionId peerAddr -> m (OperationResult AbstractState)
 demotedToColdRemote =
     icmDemotedToColdRemote . withResponderMode . getConnectionManager
 
@@ -636,7 +637,7 @@ includeInboundConnection
 includeInboundConnection =
     icmIncludeConnection . withResponderMode . getConnectionManager
 
--- | Release outbound connection. Returns if the operation was successful.
+-- | Release inbound connection. Returns if the operation was successful.
 --
 -- This executes:
 --
@@ -645,7 +646,7 @@ includeInboundConnection =
 releaseInboundConnection
     :: HasResponder muxMode ~ True
     => ConnectionManager muxMode socket peerAddr handle handleError m
-    -> peerAddr -> m (OperationResult DemotedToColdRemoteTr)
+    -> ConnectionId peerAddr -> m (OperationResult DemotedToColdRemoteTr)
 releaseInboundConnection =
     icmReleaseConnection . withResponderMode . getConnectionManager
 
@@ -838,10 +839,10 @@ connectionManagerErrorFromException x = do
 --
 data AssertionLocation peerAddr
   = ReleaseInboundConnection  !(Maybe (ConnectionId peerAddr)) !AbstractState
-  | AcquireOutboundConnection    !(Maybe (ConnectionId peerAddr)) !AbstractState
+  | AcquireOutboundConnection !(Maybe (ConnectionId peerAddr)) !AbstractState
   | ReleaseOutboundConnection !(Maybe (ConnectionId peerAddr)) !AbstractState
-  | PromotedToWarmRemote         !(Maybe (ConnectionId peerAddr)) !AbstractState
-  | DemotedToColdRemote          !(Maybe (ConnectionId peerAddr)) !AbstractState
+  | PromotedToWarmRemote      !(Maybe (ConnectionId peerAddr)) !AbstractState
+  | DemotedToColdRemote       !(Maybe (ConnectionId peerAddr)) !AbstractState
   deriving Show
 
 
@@ -888,7 +889,7 @@ mkAbsTransition from to = Transition { fromState = from
                                      }
 
 data TransitionTrace' peerAddr state = TransitionTrace
-    { ttPeerAddr   :: peerAddr
+    { ttPeerAddr   :: peerAddr -- TODO: use ConnectionId
     , ttTransition :: Transition' state
     }
   deriving Functor

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -211,12 +211,12 @@ with
                )
             <> Map.foldMapWithKey
                  (    firstMuxToFinish
+                   <> firstPeerDemotedToCold
+                   <> firstPeerCommitRemote
                    <> firstMiniProtocolToFinish connectionDataFlow
                    <> firstPeerPromotedToWarm
                    <> firstPeerPromotedToHot
                    <> firstPeerDemotedToWarm
-                   <> firstPeerDemotedToCold
-                   <> firstPeerCommitRemote
 
                    :: EventSignal muxMode initiatorCtx peerAddr versionData m a b
                  )

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -403,8 +403,7 @@ with
           -- @
           -- NOTE: `demotedToColdRemote` doesn't throw, hence exception handling
           -- is not needed.
-          res <- demotedToColdRemote connectionManager
-                                     (remoteAddress connId)
+          res <- demotedToColdRemote connectionManager connId
           traceWith tracer (TrWaitIdleRemote connId res)
           case res of
             TerminatedConnection {} -> do
@@ -445,8 +444,7 @@ with
           --
           -- NOTE: `promotedToWarmRemote` doesn't throw, hence exception handling
           -- is not needed.
-          res <- promotedToWarmRemote connectionManager
-                                      (remoteAddress connId)
+          res <- promotedToWarmRemote connectionManager connId
           traceWith tracer (TrPromotedToWarmRemote connId res)
 
           when (resultInState res == UnknownConnectionSt) $ do
@@ -479,8 +477,7 @@ with
         CommitRemote connId -> do
           -- NOTE: `releaseInboundConnection` doesn't throw, hence exception
           -- handling is not needed.
-          res <- releaseInboundConnection connectionManager
-                                          (remoteAddress connId)
+          res <- releaseInboundConnection connectionManager connId
           traceWith tracer $ TrDemotedToColdRemote connId res
           case res of
             UnsupportedState {} -> do

--- a/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/InboundGovernor.hs
@@ -39,8 +39,8 @@ module Ouroboros.Network.InboundGovernor
 import Control.Applicative (Alternative)
 import Control.Concurrent.Class.MonadSTM qualified as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict
-import Control.Exception (SomeAsyncException (..), assert)
-import Control.Monad (foldM, when)
+import Control.Exception (SomeAsyncException (..))
+import Control.Monad (foldM)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTime.SI
@@ -447,20 +447,16 @@ with
           res <- promotedToWarmRemote connectionManager connId
           traceWith tracer (TrPromotedToWarmRemote connId res)
 
-          when (resultInState res == UnknownConnectionSt) $ do
-            traceWith tracer (TrUnexpectedlyFalseAssertion
-                                (InboundGovernorLoop
-                                  (Just connId)
-                                  UnknownConnectionSt)
-                             )
-            evaluate (assert False ())
-
-          let state' = updateRemoteState
-                         connId
-                         RemoteWarm
-                         state
-
-          return (Just connId, state')
+          case resultInState res of
+            UnknownConnectionSt -> do
+              let state' = unregisterConnection connId state
+              return (Just connId, state')
+            _ -> do
+              let state' = updateRemoteState
+                             connId
+                             RemoteWarm
+                             state
+              return (Just connId, state')
 
         RemotePromotedToHot connId -> do
           traceWith tracer (TrPromotedToHotRemote connId)

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -1077,14 +1077,14 @@ mkSnocket state tr = Snocket { getLocalAddr
                                                    (Map.delete (normaliseId connId))
                         >> throwIO e)
                     $ unmask . atomically . runFirstToFinish $
-                        (FirstToFinish $ do
+                        FirstToFinish (do
                           LazySTM.readTVar timeoutVar >>= check
                           modifyTVar (nsConnections state)
                                      (Map.delete (normaliseId connId))
                           return Nothing
                         )
                         <>
-                        (FirstToFinish $ do
+                        FirstToFinish (do
                           mbConn <- Map.lookup (normaliseId connId)
                                 <$> readTVar (nsConnections state)
                           case mbConn of

--- a/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
+++ b/ouroboros-network-framework/testlib/Ouroboros/Network/ConnectionManager/Test/Utils.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Ouroboros.Network.ConnectionManager.Test.Utils where
 
@@ -193,20 +194,22 @@ validTransitionMap t@Transition { fromState, toState } =
 -- Assuming all transitions in the transition list are valid, we only need to
 -- look at the 'toState' of the current transition and the 'fromState' of the
 -- next transition.
-verifyAbstractTransitionOrder :: Bool -- ^ Check last transition: useful for
+verifyAbstractTransitionOrder :: forall a. Show a
+                              => (a -> AbstractTransition)
+                              -> Bool -- ^ Check last transition: useful for
                                       --    distinguish Diffusion layer tests
                                       --    vs non-Diffusion ones.
-                              -> [AbstractTransition]
+                              -> [a]
                               -> All
-verifyAbstractTransitionOrder _ [] = mempty
-verifyAbstractTransitionOrder checkLast (h:t) = go t h
+verifyAbstractTransitionOrder _ _ [] = mempty
+verifyAbstractTransitionOrder get checkLast (h:t) = go t h
   where
-    go :: [AbstractTransition] -> AbstractTransition -> All
+    go :: [a] -> a -> All
     -- All transitions must end in the 'UnknownConnectionSt', and since we
     -- assume that all transitions are valid we do not have to check the
     -- 'fromState'.
-    go [] (Transition _ UnknownConnectionSt) = mempty
-    go [] tr@(Transition _ _)          =
+    go [] a | (Transition _ UnknownConnectionSt) <- get a = mempty
+    go [] a | tr@(Transition _ _) <- get a =
       All
         $ counterexample
             ("\nUnexpected last transition: " ++ show tr)
@@ -214,14 +217,14 @@ verifyAbstractTransitionOrder checkLast (h:t) = go t h
     -- All transitions have to be in a correct order, which means that the
     -- current state we are looking at (current toState) needs to be equal to
     -- the next 'fromState', in order for the transition chain to be correct.
-    go (next@(Transition nextFromState _) : ts)
-        curr@(Transition _ currToState) =
+    go (a : as) b | (Transition nextFromState _) <- get a
+                  , (Transition _ currToState) <- get b =
          All
            (counterexample
               ("\nUnexpected transition order!\nWent from: "
-              ++ show curr ++ "\nto: " ++ show next)
+              ++ show b ++ "\nto: " ++ show a)
               (property (currToState == nextFromState)))
-         <> go ts next
+         <> go as a
 
 
 -- | List of all valid transition's names.

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -44,7 +44,6 @@ import System.Random (mkStdGen)
 
 import Network.DNS.Types qualified as DNS
 
-import Ouroboros.Network.Block (BlockNo (..))
 import Ouroboros.Network.BlockFetch (PraosFetchMode (..),
            TraceFetchClientState (..))
 import Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace)
@@ -167,8 +166,6 @@ tests =
       , nightlyTest $ testProperty "steps"
                         (testWithIOSimPOR prop_churn_steps 10000)
       ]
-    , testGroup "unit"
-      [ nightlyTest $ testProperty "unit cm" unit_cm_valid_transitions ]
     ]
   , testGroup "IOSim"
     [ testProperty "no failure"
@@ -297,154 +294,6 @@ testWithIOSimPOR f traceNumber bi ds =
     $ exploreSimTrace id sim $ \_ ioSimTrace ->
         f ioSimTrace  traceNumber
 
--- | This test checks a IOSimPOR false positive bug with the connection
--- manager state transition traces no longer happens.
---
-unit_cm_valid_transitions :: Property
-unit_cm_valid_transitions =
-  let bi = AbsBearerInfo
-            { abiConnectionDelay         = SmallDelay
-            , abiInboundAttenuation      = NoAttenuation FastSpeed
-            , abiOutboundAttenuation     = NoAttenuation FastSpeed
-            , abiInboundWriteFailure     = Nothing
-            , abiOutboundWriteFailure    = Just 0
-            , abiAcceptFailure           = Nothing
-            , abiSDUSize                 = LargeSDU
-            }
-      ds = DiffusionScript
-            (SimArgs 1 10)
-            (Script ((Map.empty, ShortDelay) :| [(Map.empty, LongDelay)]))
-            [ ( NodeArgs
-                  (-2)
-                  InitiatorAndResponderDiffusionMode
-                  (Just 269)
-                  (Map.fromList [(RelayAccessAddress "0:71:0:1:0:1:0:1" 65534,
-                                  DoAdvertisePeer)])
-                  GenesisMode
-                  (Script (DontUseBootstrapPeers :| []))
-                  (TestAddress (IPAddr (read "0:79::1:0:0") 3))
-                  PeerSharingDisabled
-                  [ (HotValency {getHotValency = 1},
-                     WarmValency {getWarmValency = 1},
-                     Map.fromList [(RelayAccessAddress "0:71:0:1:0:1:0:1" 65534,
-                                    (DoAdvertisePeer, IsTrustable))])
-                   ]
-                  (Script (LedgerPools [] :| []))
-                  (ConsensusModePeerTargets
-                    { deadlineTargets = PeerSelectionTargets
-                        { targetNumberOfRootPeers                 = 4
-                        , targetNumberOfKnownPeers                = 4
-                        , targetNumberOfEstablishedPeers          = 3
-                        , targetNumberOfActivePeers               = 2
-                        , targetNumberOfKnownBigLedgerPeers       = 4
-                        , targetNumberOfEstablishedBigLedgerPeers = 1
-                        , targetNumberOfActiveBigLedgerPeers      = 1
-                        }
-                    , syncTargets = PeerSelectionTargets
-                        { targetNumberOfRootPeers                 = 0
-                        , targetNumberOfKnownPeers                = 4
-                        , targetNumberOfEstablishedPeers          = 0
-                        , targetNumberOfActivePeers               = 0
-                        , targetNumberOfKnownBigLedgerPeers       = 4
-                        , targetNumberOfEstablishedBigLedgerPeers = 4
-                        , targetNumberOfActiveBigLedgerPeers      = 3
-                        }
-                    })
-                  (Script (DNSTimeout {getDNSTimeout = 0.325} :| []))
-                  (Script (DNSLookupDelay {getDNSLookupDelay = 0.1} :|
-                    [DNSLookupDelay {getDNSLookupDelay = 0.072}]))
-                  Nothing
-                  False
-                  (Script (FetchModeBulkSync :| [FetchModeBulkSync]))
-                  , [JoinNetwork 0.5]
-                )
-              , ( NodeArgs
-                  0
-                  InitiatorAndResponderDiffusionMode
-                  (Just 90)
-                  Map.empty
-                  GenesisMode
-                  (Script (DontUseBootstrapPeers :| []))
-                  (TestAddress (IPAddr (read "0:71:0:1:0:1:0:1") 65534))
-                  PeerSharingEnabled
-                  [ (HotValency {getHotValency = 1},
-                     WarmValency {getWarmValency = 1},
-                     Map.fromList [(RelayAccessAddress "0:79::1:0:0" 3,
-                                    (DoNotAdvertisePeer, IsTrustable))])
-                   ]
-                  (Script (LedgerPools [] :| []))
-                  (ConsensusModePeerTargets
-                    { deadlineTargets = PeerSelectionTargets
-                        { targetNumberOfRootPeers                 = 1
-                        , targetNumberOfKnownPeers                = 1
-                        , targetNumberOfEstablishedPeers          = 1
-                        , targetNumberOfActivePeers               = 1
-                        , targetNumberOfKnownBigLedgerPeers       = 4
-                        , targetNumberOfEstablishedBigLedgerPeers = 3
-                        , targetNumberOfActiveBigLedgerPeers      = 3
-                        }
-                    , syncTargets = PeerSelectionTargets
-                        { targetNumberOfRootPeers                 = 0
-                        , targetNumberOfKnownPeers                = 1
-                        , targetNumberOfEstablishedPeers          = 1
-                        , targetNumberOfActivePeers               = 1
-                        , targetNumberOfKnownBigLedgerPeers       = 4
-                        , targetNumberOfEstablishedBigLedgerPeers = 2
-                        , targetNumberOfActiveBigLedgerPeers      = 2
-                        }
-                    })
-                  (Script (DNSTimeout {getDNSTimeout = 0.18} :| []))
-                  (Script (DNSLookupDelay {getDNSLookupDelay = 0.125} :| []))
-                  (Just (BlockNo 2))
-                  False
-                  (Script (FetchModeDeadline :| []))
-                  , [JoinNetwork 1.484848484848]
-                )
-            ]
-      s = ControlAwait
-            [ ScheduleMod
-                (RacyThreadId [3,1,3,1,2,3,2,1], 7)
-                ControlDefault
-                [ (RacyThreadId [3,1,3,1,2,3,2], 32)
-                , (RacyThreadId [3,1,3,1,2,3,2], 33)
-                , (RacyThreadId [2,1,3,1,4], 8)
-                , (RacyThreadId [2,1,3,1,4], 9)
-                , (RacyThreadId [2,1,3,1,4], 10)
-                , (RacyThreadId [2,1,3,1,4], 11)
-                , (RacyThreadId [2,1,3,1,4], 12)
-                , (RacyThreadId [2,1,3,1,4,1], 0)
-                , (RacyThreadId [2,1,3,1,4,1], 1)
-                , (RacyThreadId [2,1,3,1,4,1], 2)
-                , (RacyThreadId [2,1,3,1,4,1], 3)
-                , (RacyThreadId [2,1,3,1,4,1], 4)
-                , (RacyThreadId [2,1,3,1,4,1], 5)
-                , (RacyThreadId [2,1,3,1,4,1], 6)
-                , (RacyThreadId [2,1,3,1,4,1], 7)
-                , (RacyThreadId [2,1,3,1,4,1], 8)
-                , (RacyThreadId [2,1,3,1,4,1,1], 0)
-                , (RacyThreadId [2,1,3,1,4,1,1], 1)
-                , (RacyThreadId [2,1,3,1,4,1,1], 2)
-                , (RacyThreadId [2,1,3,1,4,1,1], 3)
-                , (RacyThreadId [2,1,3,1,4,1], 9)
-                , (RacyThreadId [2,1,3,1,4,1], 10)
-                , (RacyThreadId [2,1,3,1,4,1], 11)
-                , (RacyThreadId [2,1,3,1,4,1], 12)
-                , (RacyThreadId [2,1,3,1,4,1], 13)
-                , (RacyThreadId [2,1,3,1,4,1], 14)
-                , (RacyThreadId [2,1,3,1,4,1], 15)
-                , (RacyThreadId [2,1,3,1,4], 13)
-                , (RacyThreadId [2,1,3,1,4], 14)
-                , (RacyThreadId [2,1,3,1,4], 15)
-                , (RacyThreadId [2,1,3,1,4], 16)
-                , (RacyThreadId [3,1,3,1,2,3,2], 34)
-                ]
-            ]
-      sim :: forall s. IOSim s Void
-      sim = do
-        exploreRaces
-        diffusionSimulation (toBearerInfo bi) ds iosimTracer
-  in exploreSimTrace (\a -> a { explorationReplay = Just s }) sim $ \_ ioSimTrace ->
-       prop_diffusion_cm_valid_transition_order_iosim_por ioSimTrace 10000
 
 -- | As a basic property we run the governor to explore its state space a bit
 -- and check it does not throw any exceptions (assertions such as invariant


### PR DESCRIPTION
# Description

We used to identify connections just be remote IP address and its port, but
since we bind to `0.0.0.0`, this is not good enough.  We might get two
connections from the same remote host to different interfaces (or the same
interface but a different IP). Such connections wouldn't be distinguished.  For
this reason we switch the internal data type to something isomorphic to

```hs
-- map from remote address, maybe local address to connection data
Map peerAddr (Map (Maybe peerAddr) connectionData)
```

The reason we use `Maybe` is that we insert outbound connections before we know
their local address.

- **connection-manager: moved ConnectionState to its own module**
- **connection-manager: use strict map**
- **connection-manager: identify connections by local & remote address**
- **connection-manager: small code refactoring**
- **connection-manager: updated ouroboros-network-framework tests & demos**
- **connection-manager: fixed tests**
- **connection-manager: added TODO**
- **inbound-governor: handle unknown connection**
- **inbound-governor: changed order of events**
- **connection-manager: removed IOSimPOR unit test**
- **connection-manager: improve test trace**
- **connection-manager: trace state changes through `traceTMVar`**

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
