### PR TITLE
SRV implementation

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -22,6 +22,11 @@
   `Ouroboros.Network.PeerSelection.LedgerPeers/Type` to there.
 - Removed `lpGetLedgerStateJudgment` from `LedgerConsensusInterface` and added
   `extraAPI` type parameter to it.
+* Removed `DomainAccessPoint` type
+* Added `RelayAccessSRVDomain` tag to `RelayAccessPoint`
+* Removed `RelayAccessPointCoded` type
+* Bumped LedgerPeerSnapshot version to 2 to directly
+  leverage JSON and CBOR instances for `RelayAccessPoint`
 
 ## 0.12.0.0 -- 2025-01-02
 

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BlockArguments             #-}
 {-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE DerivingVia                #-}
@@ -29,20 +30,16 @@ module Ouroboros.Network.PeerSelection.LedgerPeers.Type
   , compareLedgerPeerSnapshotApproximate
   ) where
 
-import Control.Monad (forM)
-import Data.ByteString.Char8 qualified as BS
-import Data.List.NonEmpty (NonEmpty)
-import Data.Text.Encoding (decodeUtf8)
 import GHC.Generics (Generic)
-import Text.Read (readMaybe)
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Cardano.Binary qualified as Codec
 import Cardano.Slotting.Slot (SlotNo (..), WithOrigin (..))
 import Control.Concurrent.Class.MonadSTM
 import Control.DeepSeq (NFData (..))
+import Control.Monad (forM)
 import Data.Aeson
-import Data.Aeson.Types
+import Data.List.NonEmpty (NonEmpty)
 import NoThunks.Class
 
 import Ouroboros.Network.PeerSelection.RelayAccessPoint
@@ -52,8 +49,8 @@ import Ouroboros.Network.PeerSelection.RelayAccessPoint
 -- to connect to when syncing.
 --
 data LedgerPeerSnapshot =
-  LedgerPeerSnapshotV1 (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
-  -- ^ Internal use for version 1, use pattern synonym for public API
+  LedgerPeerSnapshotV2 (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
+  -- ^ Internal use for version 2, use pattern synonym for public API
   deriving (Eq, Show)
 
 -- |Public API to access snapshot data. Currently access to only most recent version is available.
@@ -62,8 +59,8 @@ data LedgerPeerSnapshot =
 --
 pattern LedgerPeerSnapshot :: (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
                            -> LedgerPeerSnapshot
-pattern LedgerPeerSnapshot payload <- LedgerPeerSnapshotV1 payload where
-  LedgerPeerSnapshot payload = LedgerPeerSnapshotV1 payload
+pattern LedgerPeerSnapshot payload <- LedgerPeerSnapshotV2 payload where
+  LedgerPeerSnapshot payload = LedgerPeerSnapshotV2 payload
 
 {-# COMPLETE LedgerPeerSnapshot #-}
 
@@ -92,33 +89,36 @@ compareLedgerPeerSnapshotApproximate baseline candidate =
 --
 migrateLedgerPeerSnapshot :: LedgerPeerSnapshot
                           -> Maybe (WithOrigin SlotNo, [(AccPoolStake, (PoolStake, NonEmpty RelayAccessPoint))])
-migrateLedgerPeerSnapshot (LedgerPeerSnapshotV1 lps) = Just lps
+migrateLedgerPeerSnapshot (LedgerPeerSnapshotV2 lps) = Just lps
 
 instance ToJSON LedgerPeerSnapshot where
-  toJSON (LedgerPeerSnapshotV1 (slot, pools)) =
-    object [ "version" .= (1 :: Int)
+  toJSON (LedgerPeerSnapshotV2 (slot, pools)) =
+    object [ "version" .= (2 :: Int)
            , "slotNo" .= slot
-           , "bigLedgerPools" .= [ object [ "accumulatedStake" .= fromRational @Double accStake
-                                          , "relativeStake"  .= fromRational @Double relStake
-                                          , "relays"   .= relays']
-                                 | (AccPoolStake accStake, (PoolStake relStake, relays)) <- pools
-                                 , let relays' = fmap RelayAccessPointCoded relays]]
+           , "bigLedgerPools" .= [ object
+                                   [ "accumulatedStake" .= fromRational @Double accStake
+                                   , "relativeStake"  .= fromRational @Double relStake
+                                   , "relays"   .= relays]
+                                   | (AccPoolStake accStake, (PoolStake relStake, relays)) <- pools
+                                   ]]
 
 instance FromJSON LedgerPeerSnapshot where
   parseJSON = withObject "LedgerPeerSnapshot" $ \v -> do
     vNum :: Int <- v .: "version"
     parsedSnapshot <-
       case vNum of
-        1 -> do
+        2 -> do
           slot <- v .: "slotNo"
           bigPools <- v .: "bigLedgerPools"
-          bigPools' <- (forM bigPools . withObject "bigLedgerPools" $ \poolV -> do
-            AccPoolStakeCoded accStake <- poolV .: "accumulatedStake"
-            PoolStakeCoded reStake <- poolV .: "relativeStake"
-            relays <- fmap unRelayAccessPointCoded <$> poolV .: "relays"
-            return (accStake, (reStake, relays))) <?> Key "bigLedgerPools"
+          bigPools' <- forM (zip [0 :: Int ..] bigPools) \(idx, poolO) -> do
+                         let f poolV = do
+                                 AccPoolStakeCoded accStake <- poolV .: "accumulatedStake"
+                                 PoolStakeCoded reStake <- poolV .: "relativeStake"
+                                 relays <- poolV .: "relays"
+                                 return (accStake, (reStake, relays))
+                         withObject ("bigLedgerPools[" <> show idx <> "]") f (Object poolO)
 
-          return $ LedgerPeerSnapshotV1 (slot, bigPools')
+          return $ LedgerPeerSnapshotV2 (slot, bigPools')
         _ -> fail $ "Network.LedgerPeers.Type: parseJSON: failed to parse unsupported version " <> show vNum
     case migrateLedgerPeerSnapshot parsedSnapshot of
       Just payload -> return $ LedgerPeerSnapshot payload
@@ -148,26 +148,26 @@ instance FromCBOR WithOriginCoded where
       _      -> fail "LedgerPeers.Type: Unrecognized list length while decoding WithOrigin SlotNo"
 
 instance ToCBOR LedgerPeerSnapshot where
-  toCBOR (LedgerPeerSnapshotV1 (wOrigin, pools)) =
+  toCBOR (LedgerPeerSnapshotV2 (wOrigin, pools)) =
        Codec.encodeListLen 2
-    <> Codec.encodeWord8 1
+    <> Codec.encodeWord8 2
     <> toCBOR (WithOriginCoded wOrigin, pools')
     where
       pools' =
-        [(AccPoolStakeCoded accPoolStake, (PoolStakeCoded relStake, neRelayAccessPointCoded))
+        [(AccPoolStakeCoded accPoolStake, (PoolStakeCoded relStake, relays))
         | (accPoolStake, (relStake, relays)) <- pools
-        , let neRelayAccessPointCoded = fmap RelayAccessPointCoded relays]
+        ]
 
 instance FromCBOR LedgerPeerSnapshot where
   fromCBOR = do
     Codec.decodeListLenOf 2
     version <- Codec.decodeWord8
     case version of
-      1 -> LedgerPeerSnapshotV1 <$> do
+      2 -> LedgerPeerSnapshotV2 <$> do
              (WithOriginCoded wOrigin, pools) <- fromCBOR
-             let pools' = [(accStake, (relStake, relays'))
+             let pools' = [(accStake, (relStake, relays))
                           | (AccPoolStakeCoded accStake, (PoolStakeCoded relStake, relays)) <- pools
-                          , let relays' = unRelayAccessPointCoded <$> relays]
+                          ]
              return (wOrigin, pools')
       _ -> fail $ "LedgerPeers.Type: no decoder could be found for version " <> show version
 

--- a/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/PeerSelection/LedgerPeers/Type.hs
@@ -243,34 +243,3 @@ data LedgerPeersConsensusInterface extraAPI m = LedgerPeersConsensusInterface {
 mapExtraAPI :: (a -> b) -> LedgerPeersConsensusInterface a m -> LedgerPeersConsensusInterface b m
 mapExtraAPI f lpci@LedgerPeersConsensusInterface{ lpExtraAPI = api } =
   lpci { lpExtraAPI = f api }
-
-instance ToJSON RelayAccessPointCoded where
-  toJSON (RelayAccessPointCoded (RelayAccessDomain domain port)) =
-    object
-      [ "domain" .= decodeUtf8 domain
-      , "port"   .= (fromIntegral port :: Int)]
-
-  toJSON (RelayAccessPointCoded (RelayAccessAddress ip port)) =
-    object
-      [ "address" .= show ip
-      , "port" .= (fromIntegral port :: Int)]
-
-instance FromJSON RelayAccessPointCoded where
-  parseJSON = withObject "RelayAccessPointCoded" $ \v -> do
-    domain <- fmap BS.pack <$> v .:? "domain"
-    port <- fromIntegral @Int <$> v .: "port"
-    case domain of
-      Nothing ->
-            v .: "address"
-        >>= \case
-               Nothing -> fail "RelayAccessPointCoded: invalid IP address"
-               Just addr ->
-                 return . RelayAccessPointCoded $ RelayAccessAddress addr port
-            . readMaybe
-
-      Just domain'
-        | Just (_, '.') <- BS.unsnoc domain' ->
-          return . RelayAccessPointCoded $ RelayAccessDomain domain' port
-        | otherwise ->
-          let fullyQualified = domain' `BS.snoc` '.'
-          in return . RelayAccessPointCoded $ RelayAccessDomain fullyQualified port

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,7 +4,22 @@
 
 ### Non-breaking changes
 
+* Tracing of DNS results is now directly performed by `dnsLookupWithTTL`,
+  which is captured by the new `DNSTrace` type. Results are tagged with
+  the new `DNSLookupResult` type. The type of peer that traces are tagged with
+  are captured by the `DNSPeersKind` type, which also distinguishes the type
+  of ledger peer.
+* Added `dispatchLookupWithTTL`
+
 ### Breaking changes
+
+- Removed `TraceLedgerPeersResult` and `TraceLedgerPeersFailure`
+- Changed `TraceLedgerPeersDomains` to accept `[RelayAccessPoint]`
+- Removed `TraceLocalRootResult` and changed some other constructors to
+  accept `RelayAccessPoint` in lieu of `DomainAccessPoint`, which was removed
+- Removed `TracePublicRootResult` and `TracePublicRootFailure`
+- Changed signature of `resolveLedgerPeers`, `localRootPeersProvider`, `publicRootPeersProvider`,
+  `withPeerSelectionActions` to accept random seed for DNS SRV lookup.
 
 ## 0.20.0.0 -- 2025-02-25
 
@@ -206,7 +221,7 @@
 * APIs removed from `Ouroboros.Network.{NodeToClient,NodeToNode}` modules:
   * NetworkServerTracers
   * NetworkMutableState APIs
-  * withServer 
+  * withServer
   * ErrorPolicies
   * WithAddr
   * SuspendDecision
@@ -226,7 +241,6 @@
 * Use `LocalRootConfig` instead of a tuple.
 * Extended `LocalRootConfig` with `diffusionMode :: DiffusionMode` field.
 * Added `diConnStateSupply` record field to `Ouroboros.Network.Diffusion.P2P.Interfaces`.
-* UnknownMiniProtocol error should not crash the node
 
 ### Non-breaking changes
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -262,8 +262,8 @@ runM Interfaces
     (churnRng,       rng3) = split rng2
     (fuzzRng,        rng4) = split rng3
     (cmLocalStdGen,  rng5) = split rng4
-    (cmStdGen1, cmStdGen2) = split rng5
-
+    (cmStdGen1,      rng6) = split rng5
+    (cmStdGen2, peerSelectionActionsRng) = split rng6
 
     mkInboundPeersMap :: IG.PublicState ntnAddr ntnVersionData
                       -> Map ntnAddr PeerSharing
@@ -646,6 +646,7 @@ runM Interfaces
                                          wlpGetLedgerPeerSnapshot = daReadLedgerPeerSnapshot,
                                          wlpSemaphore             = dnsSemaphore
                                        }
+                                       peerSelectionActionsRng
 
           peerSelectionGovernor'
             :: Tracer m (DebugPeerSelection extraState extraFlags extraPeers ntnAddr)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -202,6 +202,7 @@ runM Interfaces
        , dtLocalConnectionManagerTracer
        , dtLocalServerTracer
        , dtLocalInboundGovernorTracer
+       , dtDnsTracer
        }
      Arguments
        { daIPv4Address
@@ -576,7 +577,7 @@ runM Interfaces
       let dnsActions =
             PeerActionsDNS {
               paToPeerAddr = diNtnToPeerAddr
-            , paDnsActions = diDnsActions lookupReqs
+            , paDnsActions = diDnsActions dtDnsTracer lookupReqs diNtnToPeerAddr
             }
       --
       -- Run peer selection (p2p governor)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
@@ -383,6 +383,7 @@ data Arguments extraState extraDebugState extraFlags extraPeers
                    -> (Map ntnAddr PeerAdvertise -> extraPeers)
                    -> ( (NumberOfPeers -> LedgerPeersKind -> m (Maybe (Set ntnAddr, DiffTime)))
                    -> LedgerPeersKind
+                   -> StdGen
                    -> Int
                    -> m (PublicRootPeers extraPeers ntnAddr, DiffTime)))
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
@@ -193,6 +193,8 @@ data Tracers ntnAddr ntnVersion ntnVersionData
     , dtInboundGovernorTransitionTracer
         :: Tracer m (IG.RemoteTransitionTrace ntnAddr)
 
+    , dtDnsTracer :: Tracer m DNSTrace
+
       --
       -- NodeToClient tracers
       --
@@ -243,6 +245,7 @@ nullTracers = Tracers {
   , dtLocalConnectionManagerTracer               = nullTracer
   , dtLocalServerTracer                          = nullTracer
   , dtLocalInboundGovernorTracer                 = nullTracer
+  , dtDnsTracer                                  = nullTracer
   }
 
 -- | Common DiffusionArguments interface between P2P and NonP2P
@@ -665,7 +668,10 @@ data Interfaces ntnFd ntnAddr ntnVersion ntnVersionData
         -- | diffusion dns actions
         --
         diDnsActions
-          :: DNSLookupType -> DNSActions resolver resolverError m,
+          :: Tracer m DNSTrace
+          -> DNSLookupType
+          -> (IP -> Socket.PortNumber -> ntnAddr)
+          -> DNSActions ntnAddr resolver resolverError m,
 
         -- | Update `ntnVersionData` for initiator-only local roots.
         diUpdateVersionData

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection.hs
@@ -37,6 +37,6 @@ import Ouroboros.Network.PeerSelection.PeerStateActions as PeerSelection.PeerSta
 import Ouroboros.Network.PeerSelection.PublicRootPeers as PeerSelection.PublicRootPeers
            (PublicRootPeers)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint as PeerSelection.RelayAccessPoint
-           (DomainAccessPoint (..), IP (..), PortNumber, RelayAccessPoint (..))
+           (IP (..), PortNumber, RelayAccessPoint (..))
 import Ouroboros.Network.PeerSelection.Types as PeerSelection
 import Ouroboros.Network.PeerSelection.Types as PeerSelection.Types

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -389,7 +389,7 @@ data PeerSelectionActions extraState extraFlags extraPeers extraAPI extraCounter
        -- It also makes a distinction between normal and big ledger peers to be
        -- fetched.
        --
-       requestPublicRootPeers   :: LedgerPeersKind -> Int -> m (PublicRootPeers extraPeers peeraddr, DiffTime),
+       requestPublicRootPeers   :: LedgerPeersKind -> StdGen -> Int -> m (PublicRootPeers extraPeers peeraddr, DiffTime),
 
        -- | The action to contact a known peer and request a sample of its
        -- known peers.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/DNSActions.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE NamedFieldPuns      #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 
 module Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
   ( -- * DNS based actions for local and public root providers
@@ -11,17 +14,30 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
     -- * DNSActions IO
   , ioDNSActions
   , DNSLookupType (..)
+  , DNSLookupResult
     -- * Utils
     -- ** Resource
   , Resource (..)
   , retryResource
   , constantResource
+    -- ** Exposed for testing purposes
+  , dispatchLookupWithTTL
     -- ** Error type
   , DNSorIOError (..)
+    -- * Tracing types
+  , DNSTrace (..)
+  , DNSPeersKind (..)
   ) where
 
+import Data.ByteString.Char8 qualified as BS
+import Data.Foldable qualified as Fold
 import Data.Function (fix)
+import Data.List (sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NE
+import Data.Map qualified as Map
+import Data.Maybe (fromJust, listToMaybe)
+import Data.Word (Word16)
 
 import Control.Exception (IOException)
 import Control.Monad.Class.MonadAsync
@@ -44,11 +60,33 @@ import Control.Tracer (Tracer (..), traceWith)
 import System.Directory (getModificationTime)
 #endif
 
-import Data.IP (IP (..))
-import Network.DNS (DNSError)
+import Network.DNS (DNSError, DNSMessage)
 import Network.DNS qualified as DNS
-import Network.Socket (PortNumber)
+import System.Random
 
+import Ouroboros.Network.PeerSelection.LedgerPeers.Type (LedgerPeersKind)
+import Ouroboros.Network.PeerSelection.RelayAccessPoint
+
+-- | Bundled with DNS lookup trace for observability
+--
+data DNSPeersKind = DNSLocalPeer | DNSPublicPeer | DNSLedgerPeer !LedgerPeersKind
+  deriving (Show)
+
+-- | Provides DNS lookup trace information
+--
+data DNSTrace = DNSResult
+                  DNSPeersKind
+                  DNS.Domain
+                  -- ^ source of addresses
+                  (Maybe DNS.Domain)
+                  -- ^ SRV domain, if relevant
+                  [(IP, PortNumber, DNS.TTL)]
+                  -- ^ payload
+              | DNSTraceLookupError !DNSPeersKind !(Maybe DNSLookupType) !DNS.Domain !DNS.DNSError
+              | DNSSRVFail
+                 !DNSPeersKind
+                 !DNS.Domain -- ^ SRV domain
+  deriving (Show)
 
 data DNSLookupType = LookupReqAOnly
                    | LookupReqAAAAOnly
@@ -59,6 +97,11 @@ data DNSorIOError exception
     = DNSError !DNSError
     | IOError  !exception
   deriving Show
+
+-- | Wraps lookup result for client code
+--
+type DNSLookupResult peerAddr =
+    Either [DNS.DNSError] [(peerAddr, DNS.TTL)]
 
 instance Exception exception => Exception (DNSorIOError exception) where
 
@@ -144,7 +187,7 @@ data TimedResolver
 
 -- | Dictionary of DNS actions vocabulary
 --
-data DNSActions resolver exception m = DNSActions {
+data DNSActions peerAddr resolver exception m = DNSActions {
 
     -- |
     --
@@ -170,10 +213,12 @@ data DNSActions resolver exception m = DNSActions {
     -- DNS library timeouts do not work reliably on Windows (#1873), hence the
     -- additional timeout.
     --
-    dnsLookupWithTTL         :: DNS.ResolvConf
+    dnsLookupWithTTL         :: DNSPeersKind
+                             -> RelayAccessPoint
+                             -> DNS.ResolvConf
                              -> resolver
-                             -> DNS.Domain
-                             -> m ([DNS.DNSError], [(IP, DNS.TTL)])
+                             -> StdGen
+                             -> m (DNSLookupResult peerAddr)
   }
 
 
@@ -183,7 +228,7 @@ data DNSActions resolver exception m = DNSActions {
 -- `DNSActions`?
 data PeerActionsDNS peeraddr resolver exception m = PeerActionsDNS {
   paToPeerAddr :: IP -> PortNumber -> peeraddr,
-  paDnsActions :: DNSActions resolver exception m
+  paDnsActions :: DNSActions peeraddr resolver exception m
   }
 
 
@@ -207,15 +252,22 @@ getResolver resolvConf = do
 --
 -- It guarantees that returned TTLs are strictly greater than 0.
 --
-ioDNSActions :: DNSLookupType
-             -> DNSActions DNS.Resolver IOException IO
-ioDNSActions =
-    \reqs -> DNSActions {
-               dnsResolverResource      = resolverResource,
-               dnsAsyncResolverResource = asyncResolverResource,
-               dnsLookupWithTTL         = lookupWithTTL reqs
-             }
+ioDNSActions :: Tracer IO DNSTrace
+             -> DNSLookupType
+             -> (IP -> PortNumber -> peerAddr)
+             -> DNSActions peerAddr DNS.Resolver IOException IO
+ioDNSActions tracer lookupType toPeerAddr =
+    DNSActions {
+      dnsResolverResource      = resolverResource,
+      dnsAsyncResolverResource = asyncResolverResource,
+      dnsLookupWithTTL         = dispatchLookupWithTTL lookupType mkResolveDNSIOAction tracer toPeerAddr
+      }
   where
+    mkResolveDNSIOAction resolver resolvConf domain ofType =
+      timeout (microsecondsAsIntToDiffTime
+               $ DNS.resolvTimeout resolvConf)
+              (DNS.lookupRaw resolver domain ofType)
+
     -- |
     --
     -- TODO: it could be useful for `publicRootPeersProvider`.
@@ -325,86 +377,208 @@ ioDNSActions =
                 Right resolver' ->
                   return (Right resolver', go filePath resourceVar)
 
+-- NB: A deliberately limited subset of SRV is supported.
+-- An SRV record is resolved into a list of follow-up
+-- candidate lookups. Targets marked "." are filtered out,
+-- and the result is sorted and grouped by priority levels.
+-- Only the top priority level (ie. lowest numerical value)
+-- is considered. A weighted random sampling is then performed to
+-- draw a domain to retrieve the final addresses from. If the lookup
+-- fails, the SRV lookup is not resumed.
+-- (cf. https://www.ietf.org/rfc/rfc2782.txt)
+--
+srvRecordLookupWithTTL :: forall peerAddr m. (MonadAsync m)
+                       => DNSLookupType
+                       -> Tracer m DNSTrace
+                       -> (IP -> PortNumber -> peerAddr)
+                       -> DNSPeersKind
+                       -> DNS.Domain
+                       -> (   DNS.Domain
+                           -> DNS.TYPE
+                       -> m (Maybe (Either DNSError DNSMessage)))
+                       -> StdGen
+                       -> m (DNSLookupResult peerAddr)
+srvRecordLookupWithTTL ofType tracer toPeerAddr peerType domainSRV resolveDNS rng = do
+    reply <- resolveDNS domainSRV DNS.SRV
+    case reply of
+      Nothing          -> do
+        traceWith tracer $ DNSTraceLookupError peerType Nothing domainSRV DNS.TimeoutExpired
+        return . Left $ [DNS.TimeoutExpired]
+      Just (Left  err) -> do
+        traceWith tracer $ DNSTraceLookupError peerType Nothing domainSRV err
+        return . Left $ [err]
+      Just (Right msg) ->
+        case DNS.fromDNSMessage msg selectSRV of
+          Left err -> do
+            traceWith tracer $ DNSTraceLookupError peerType Nothing domainSRV err
+            return . Left $ [err]
+          Right services -> do
+            let srvByPriority = filter ((BS.pack "." /=) . pickDomain) $ sortOn priority services
+                grouped       = NE.groupWith priority srvByPriority
+            (result, domain) <- do
+              case listToMaybe grouped of
+                Just topPriority ->
+                  case topPriority of
+                    (domain, _, _, port, ttl) NE.:| [] -> do -- fast path
+                      result <- domainLookupWithTTL tracer ofType domain peerType resolveDNS
+                      let result' = ipsttlsWithPort port ttl <$> result
+                      return (result', domain)
+                    many -> -- general path
+                      runWeightedLookup many
+                Nothing -> return (Right [], "")
+            case result of
+              Left {} -> traceWith tracer $ DNSSRVFail peerType domainSRV
+              Right ipsttls ->
+                traceWith tracer $ DNSResult peerType domain (Just domainSRV) ipsttls
+            return $ map (\(ip, port, ttl) -> (toPeerAddr ip port, ttl)) <$> result
 
-    -- | Like 'DNS.lookupA' but also return the TTL for the results.
-    --
-    -- DNS library timeouts do not work reliably on Windows (#1873), hence the
-    -- additional timeout.
-    --
-    lookupAWithTTL :: DNS.ResolvConf
-                   -> DNS.Resolver
-                   -> DNS.Domain
-                   -> IO (Either DNS.DNSError [(IP, DNS.TTL)])
-    lookupAWithTTL resolvConf resolver domain = do
-        labelThisThread "lookupAWithTTL"
-        reply <- timeout (microsecondsAsIntToDiffTime
-                           $ DNS.resolvTimeout resolvConf)
-                         (DNS.lookupRaw resolver domain DNS.A)
-        case reply of
-          Nothing          -> return (Left DNS.TimeoutExpired)
-          Just (Left  err) -> return (Left err)
-          Just (Right ans) -> return (DNS.fromDNSMessage ans selectA)
-          --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
       where
-        selectA DNS.DNSMessage { DNS.answer } =
-          [ (IPv4 addr, fixupTTL ttl)
+        ipsttlsWithPort port ttl = map (\(ip, _ttl) -> (ip, fromIntegral port, ttl))
+
+        runWeightedLookup :: NonEmpty (DNS.Domain, Word16, Word16, Word16, DNS.TTL)
+                          -> m (Either [DNSError] [(IP, PortNumber, DNS.TTL)], DNS.Domain)
+        runWeightedLookup services =
+           let (upperBound, cdf) = Fold.foldl' aggregate (0, []) services
+               mapCdf = Map.fromList cdf
+               (pick, _) = randomR (0, upperBound) rng
+               (domain, _, _, port, ttl) = snd . fromJust $ Map.lookupGE pick mapCdf
+           in (,domain) . fmap (ipsttlsWithPort port ttl) <$> domainLookupWithTTL tracer ofType domain peerType resolveDNS
+
+        aggregate (!upper, !cdf) srv =
+          let upper' = weight srv + upper
+           in (upper', (upper', srv):cdf)
+
+        selectSRV DNS.DNSMessage { DNS.answer } =
+          [ (domain', priority', weight', port, ttl)
           | DNS.ResourceRecord {
-              DNS.rdata = DNS.RD_A addr,
+              DNS.rdata = DNS.RD_SRV priority' weight' port domain',
               DNS.rrttl = ttl
             } <- answer
           ]
 
-
-    lookupAAAAWithTTL :: DNS.ResolvConf
-                      -> DNS.Resolver
-                      -> DNS.Domain
-                      -> IO (Either DNS.DNSError [(IP, DNS.TTL)])
-    lookupAAAAWithTTL resolvConf resolver domain = do
-        labelThisThread "lookupAAAAWithTTL"
-        reply <- timeout (microsecondsAsIntToDiffTime
-                           $ DNS.resolvTimeout resolvConf)
-                         (DNS.lookupRaw resolver domain DNS.AAAA)
-        case reply of
-          Nothing          -> return (Left DNS.TimeoutExpired)
-          Just (Left  err) -> return (Left err)
-          Just (Right ans) -> return (DNS.fromDNSMessage ans selectAAAA)
-          --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
-      where
-        selectAAAA DNS.DNSMessage { DNS.answer } =
-          [ (IPv6 addr, fixupTTL ttl)
-          | DNS.ResourceRecord {
-              DNS.rdata = DNS.RD_AAAA addr,
-              DNS.rrttl = ttl
-            } <- answer
-          ]
+        weight   (_, _, w, _, _)   = w
+        priority (_, p, _, _, _)   = p
+        pickDomain (d, _, _, _, _) = d
 
 
-    lookupWithTTL :: DNSLookupType
-                  -> DNS.ResolvConf
-                  -> DNS.Resolver
-                  -> DNS.Domain
-                  -> IO ([DNS.DNSError], [(IP, DNS.TTL)])
-    lookupWithTTL LookupReqAOnly resolvConf resolver domain = do
-        res <- lookupAWithTTL resolvConf resolver domain
-        case res of
-             Left err -> return ([err], [])
-             Right r  -> return ([], r)
+dispatchLookupWithTTL :: (MonadAsync m)
+                      => DNSLookupType
+                      -> (   resolver
+                          -> resolvConf
+                          -> DNS.Domain
+                          -> DNS.TYPE
+                          -> m (Maybe (Either DNSError DNSMessage)))
+                      -> Tracer m DNSTrace
+                      -> (IP -> PortNumber -> peerAddr)
+                      -> DNSPeersKind
+                      -> RelayAccessPoint
+                      -> resolvConf
+                      -> resolver
+                      -> StdGen
+                      -> m (DNSLookupResult peerAddr)
+dispatchLookupWithTTL lookupType mkResolveDNS tracer toPeerAddr peerType domain conf resolver rng =
+  let resolveDNS = mkResolveDNS resolver conf
+  in case domain of
+    RelayAccessDomain d p -> do
+      result <- domainLookupWithTTL tracer lookupType d peerType resolveDNS
+      let trace = map (\(ip, ttl) -> (ip, p, ttl)) <$> result
+      Fold.traverse_ (traceWith tracer . DNSResult peerType d Nothing) trace
+      return $ map (\(ip, _ttl) -> (toPeerAddr ip p, _ttl)) <$> result
+    RelayAccessSRVDomain d -> srvRecordLookupWithTTL lookupType tracer toPeerAddr peerType d resolveDNS rng
+    RelayAccessAddress addr p  -> return . Right $ [(toPeerAddr addr p, maxBound)]
 
-    lookupWithTTL LookupReqAAAAOnly resolvConf resolver domain = do
-        res <- lookupAAAAWithTTL resolvConf resolver domain
-        case res of
-             Left err -> return ([err], [])
-             Right r  -> return ([], r)
 
-    lookupWithTTL LookupReqAAndAAAA resolvConf resolver domain = do
-        (r_ipv6, r_ipv4) <- concurrently (lookupAAAAWithTTL resolvConf resolver domain)
-                                         (lookupAWithTTL resolvConf resolver domain)
-        case (r_ipv6, r_ipv4) of
-             (Left  e6, Left  e4) -> return ([e6, e4], [])
-             (Right r6, Left  e4) -> return ([e4], r6)
-             (Left  e6, Right r4) -> return ([e6], r4)
-             (Right r6, Right r4) -> return ([], r6 <> r4)
+domainLookupWithTTL :: (MonadAsync m)
+                    => Tracer m DNSTrace
+                    -> DNSLookupType
+                    -> DNS.Domain
+                    -> DNSPeersKind
+                    -> (   DNS.Domain
+                        -> DNS.TYPE
+                    -> m (Maybe (Either DNSError DNSMessage)))
+                    -> m (Either [DNSError] [(IP, DNS.TTL)])
+domainLookupWithTTL tracer look@LookupReqAOnly d peerType resolveDNS = do
+    res <- domainALookupWithTTL (resolveDNS d DNS.A)
+    case res of
+         Left err -> do
+           traceWith tracer $ DNSTraceLookupError peerType (Just look) d err
+           return . Left $ [err]
+         Right r  -> return . Right $ r
 
+domainLookupWithTTL tracer look@LookupReqAAAAOnly d peerType resolveDNS = do
+    res <- domainAAAALookupWithTTL (resolveDNS d DNS.AAAA)
+    case res of
+         Left err -> do
+           traceWith tracer $ DNSTraceLookupError peerType (Just look) d err
+           return . Left $ [err] --([err], [])
+         Right r  -> return . Right $ r
+
+domainLookupWithTTL tracer LookupReqAAndAAAA d peerType resolveDNS = do
+    (r_ipv6, r_ipv4) <- concurrently (domainAAAALookupWithTTL (resolveDNS d DNS.AAAA))
+                                     (domainALookupWithTTL (resolveDNS d DNS.A))
+    case (r_ipv6, r_ipv4) of
+         (Left  e6, Left  e4) -> do
+           traceWith tracer $ DNSTraceLookupError
+                                peerType (Just LookupReqAOnly) d e4
+           traceWith tracer $ DNSTraceLookupError
+                                peerType (Just LookupReqAAAAOnly) d e6
+           return . Left $ [e6, e4]
+         (Right r6, Left  e4) -> do
+           traceWith tracer $ DNSTraceLookupError
+                                peerType (Just LookupReqAOnly) d e4
+           return . Right $ r6
+         (Left  e6, Right r4) -> do
+           traceWith tracer $ DNSTraceLookupError
+                                peerType (Just LookupReqAAAAOnly) d e6
+           return . Right $ r4
+         (Right r6, Right r4) -> return . Right $ r6 <> r4
+
+
+-- | Like 'DNS.lookupA' but also return the TTL for the results.
+--
+-- DNS library timeouts do not work reliably on Windows (#1873), hence the
+-- additional timeout.
+--
+domainALookupWithTTL :: (MonadThread m)
+               => m (Maybe (Either DNSError DNSMessage))
+               -> m (Either DNS.DNSError [(IP, DNS.TTL)])
+domainALookupWithTTL action = do
+    labelThisThread "domainALookupWithTTL"
+    reply <- action
+    case reply of
+      Nothing          -> return (Left DNS.TimeoutExpired)
+      Just (Left  err) -> return (Left err)
+      Just (Right ans) -> return (DNS.fromDNSMessage ans selectA)
+      --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
+  where
+    selectA DNS.DNSMessage { DNS.answer } =
+      [ (IPv4 addr, fixupTTL ttl)
+      | DNS.ResourceRecord {
+          DNS.rdata = DNS.RD_A addr,
+          DNS.rrttl = ttl
+        } <- answer
+      ]
+
+
+domainAAAALookupWithTTL :: (MonadThread m)
+                  => m (Maybe (Either DNSError DNSMessage))
+                  -> m (Either DNS.DNSError [(IP, DNS.TTL)])
+domainAAAALookupWithTTL action = do
+    labelThisThread "domainAAAALookupWithTTL"
+    reply <- action
+    case reply of
+      Nothing          -> return (Left DNS.TimeoutExpired)
+      Just (Left  err) -> return (Left err)
+      Just (Right ans) -> return (DNS.fromDNSMessage ans selectAAAA)
+      --TODO: we can get the SOA TTL on NXDOMAIN here if we want to
+  where
+    selectAAAA DNS.DNSMessage { DNS.answer } =
+      [ (IPv6 addr, fixupTTL ttl)
+      | DNS.ResourceRecord {
+          DNS.rdata = DNS.RD_AAAA addr,
+          DNS.rrttl = ttl
+        } <- answer
+      ]
 
 --
 -- Utils

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/LocalRootPeers.hs
@@ -12,11 +12,13 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
   , TraceLocalRootPeers (..)
   ) where
 
+import Data.Bifunctor (second)
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Void (Void, absurd)
 import Data.Word (Word32)
+import System.Random
 
 import Control.Applicative (Alternative, (<|>))
 import Control.Concurrent.Class.MonadSTM.Strict
@@ -29,7 +31,6 @@ import Control.Tracer (Tracer (..), contramap, traceWith)
 
 import Network.DNS qualified as DNS
 
-import Data.Bifunctor (second)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint
 import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
 import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore (DNSSemaphore,
@@ -41,17 +42,16 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRo
 data TraceLocalRootPeers extraFlags peerAddr exception =
        TraceLocalRootDomains (LocalRootPeers.Config extraFlags RelayAccessPoint)
        -- ^ 'Int' is the configured valency for the local producer groups
-     | TraceLocalRootWaiting DomainAccessPoint DiffTime
-     | TraceLocalRootResult  DomainAccessPoint [(IP, DNS.TTL)]
+     | TraceLocalRootWaiting RelayAccessPoint DiffTime
      | TraceLocalRootGroups  (LocalRootPeers.Config extraFlags peerAddr)
        -- ^ This traces the results of the local root peer provider
-     | TraceLocalRootDNSMap  (Map DomainAccessPoint [peerAddr])
+     | TraceLocalRootDNSMap  (Map RelayAccessPoint [peerAddr])
        -- ^ This traces the results of the domain name resolution
      | TraceLocalRootReconfigured (LocalRootPeers.Config extraFlags RelayAccessPoint) -- ^ Old value
                                   (LocalRootPeers.Config extraFlags RelayAccessPoint) -- ^ New value
-     | TraceLocalRootFailure DomainAccessPoint (DNSorIOError exception)
+     | TraceLocalRootFailure RelayAccessPoint (DNSorIOError exception)
        --TODO: classify DNS errors, config error vs transitory
-     | TraceLocalRootError   DomainAccessPoint SomeException
+     | TraceLocalRootError DNS.Domain SomeException
   deriving Show
 
 -- | Resolve 'RelayAddress'-es of local root peers using dns if needed.  Local
@@ -71,6 +71,7 @@ localRootPeersProvider
   => Tracer m (TraceLocalRootPeers extraFlags peerAddr exception)
   -> PeerActionsDNS peerAddr resolver exception m
   -> DNS.ResolvConf
+  -> StdGen
   -> STM m [( HotValency
             , WarmValency
             , Map RelayAccessPoint (LocalRootConfig extraFlags))]
@@ -89,6 +90,7 @@ localRootPeersProvider tracer
                          }
                        }
                        resolvConf
+                       rng0
                        readLocalRootPeers
                        rootPeersGroupVar =
       atomically do
@@ -109,15 +111,18 @@ localRootPeersProvider tracer
       traceWith tracer (TraceLocalRootDomains domainsGroups)
       rr <- dnsAsyncResolverResource resolvConf
       let
-          -- Get only DomainAccessPoint to monitor and perform DNS resolution
-          -- on them.
-          domains :: [DomainAccessPoint]
-          domains = [ domain
+          -- filter domains to monitor and perform DNS resolutions on
+          domains :: [RelayAccessPoint]
+          domains = [ rap
                     | (_, _, m) <- domainsGroups
-                    , (RelayDomainAccessPoint domain, _) <- Map.toList m ]
+                    , (rap, _) <- Map.toList m
+                    , case rap of
+                        RelayAccessAddress {} -> False
+                        _otherwise            -> True
+                    ]
 
           -- Initial DNS Domain Map has all domains entries empty
-          initialDNSDomainMap :: Map DomainAccessPoint [peerAddr]
+          initialDNSDomainMap :: Map RelayAccessPoint [peerAddr]
           initialDNSDomainMap =
             Map.fromList $ map (, []) domains
 
@@ -162,28 +167,6 @@ localRootPeersProvider tracer
       -- all the monitoring threads are killed.
       loop varRng dnsSemaphore domainsGroups'
 
-    resolveDomain
-      :: DNSSemaphore m
-      -> resolver
-      -> DomainAccessPoint
-      -> m (Either [DNS.DNSError] [(peerAddr, DNS.TTL)])
-    resolveDomain dnsSemaphore resolver
-                  domain@DomainAccessPoint {dapDomain, dapPortNumber} = do
-      (errs, results) <- withDNSSemaphore dnsSemaphore
-                                          (dnsLookupWithTTL
-                                            resolvConf
-                                            resolver
-                                            dapDomain)
-      mapM_ (traceWith tracer . TraceLocalRootFailure domain . DNSError)
-            errs
-
-      if null errs
-         then do
-           traceWith tracer (TraceLocalRootResult domain results)
-           return $ Right [ ( toPeerAddr addr dapPortNumber
-                            , _ttl)
-                          | (addr, _ttl) <- results ]
-         else return $ Left errs
 
     -- | Function that runs on a monitoring thread. This function will, every
     -- TTL, issue a DNS resolution request and collect the results for its
@@ -204,6 +187,11 @@ localRootPeersProvider tracer
                                     (1 :| [3, 6, 9, 12])
                                     rr0))
       where
+        domain' = case domain of
+          RelayAccessDomain d _p -> d
+          RelayAccessSRVDomain d -> d
+          _otherwise             -> error "LocalRootPeers.monitorDomain: impossible!"
+
         go :: DiffTime
            -> Resource m resolver
            -> m Void
@@ -270,7 +258,7 @@ localRootPeersProvider tracer
     -- It does so by reading a DNS Domain Map and replacing all instances of a
     -- DomainAccessPoint in the static configuration with the values from the
     -- map.
-    getLocalRootPeersGroups :: Map DomainAccessPoint [peerAddr]
+    getLocalRootPeersGroups :: Map RelayAccessPoint [peerAddr]
                             -> [( HotValency
                                 , WarmValency
                                 , Map RelayAccessPoint (LocalRootConfig extraFlags))]
@@ -291,11 +279,10 @@ localRootPeersProvider tracer
                          -> case rap of
                              RelayAccessAddress ip port ->
                                Map.insert (toPeerAddr ip port) pa accMap
-                             RelayDomainAccessPoint dap ->
-                               let newEntries = maybe Map.empty
-                                                      Map.fromList
-                                              $ fmap (, pa)
-                                              <$> Map.lookup dap dnsMap
+                             dap ->
+                               let newEntries =
+                                     maybe Map.empty (Map.fromList . fmap (, pa))
+                                           $ Map.lookup dap dnsMap
                                 in accMap <> newEntries
                       )
                    Map.empty
@@ -310,7 +297,7 @@ ttlForResults :: [DNS.TTL] -> DiffTime
 -- This case says we have a successful reply but there is no answer.
 -- This covers for example non-existent TLDs since there is no authority
 -- to say that they should not exist.
-ttlForResults []   = ttlForDnsError DNS.NameError 0
+ttlForResults []   = ttlForDnsError 0 DNS.NameError
 ttlForResults ttls = clipTTLBelow
                    . clipTTLAbove
                    . (fromIntegral :: Word32 -> DiffTime)
@@ -324,9 +311,9 @@ clipTTLAbove = min 86400  -- and 24hrs
 -- | Policy for TTL for negative results
 -- Cache negative response for 3hrs
 -- Otherwise, use exponential backoff, up to a limit
-ttlForDnsError :: DNS.DNSError -> DiffTime -> DiffTime
-ttlForDnsError DNS.NameError _ = 10800
-ttlForDnsError _           ttl = clipTTLAbove (ttl * 2 + 5)
+ttlForDnsError :: DiffTime -> DNS.DNSError -> DiffTime
+ttlForDnsError _   DNS.NameError = 10800
+ttlForDnsError ttl _             = clipTTLAbove (ttl * 2 + 5)
 
 -- | `withAsyncAll`, but the actions are tagged with a context
 withAsyncAllWithCtx :: MonadAsync m => [(ctx, m a)] -> ([(ctx, Async m a)] -> m b) -> m b

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
@@ -68,6 +68,7 @@ publicRootPeersProvider tracer
                           dnsResolverResource,
                           dnsLookupWithTTL
                         }
+                        rng
                         action = do
     domains <- atomically readDomains
     traceWith tracer (TracePublicRootRelayAccessPoint domains)
@@ -107,9 +108,13 @@ publicRootPeersProvider tracer
                             (dnsLookupWithTTL
                               resolvConf
                               resolver
-                              domain)
-                          )
-                  | (RelayAccessDomain domain port, pa) <- Map.assocs domains ]
+                              rng))
+                  | (domain, pa) <- doms
+                  , case domain of
+                      RelayAccessAddress {}   -> False
+                      RelayAccessDomain  {}   -> True
+                      RelayAccessSRVDomain {} -> True
+                  ]
             -- The timeouts here are handled by the 'lookupWithTTL'. They're
             -- configured via the DNS.ResolvConf resolvTimeout field and defaults
             -- to 3 sec.

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/RootPeersDNS/PublicRootPeers.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -10,26 +11,26 @@ module Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
   , TracePublicRootPeers (..)
   ) where
 
+import Data.List (partition)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Word (Word32)
+import System.Random
 
 import Control.Concurrent.Class.MonadSTM.Strict
-import Control.Monad (when)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadFork
 import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTime.SI
 import Control.Tracer (Tracer (..), traceWith)
 
-
+import Network.DNS (DNSError)
 import Network.DNS qualified as DNS
 import Network.Socket qualified as Socket
 
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint
-import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions (DNSActions (..),
-           DNSorIOError (..), Resource (..))
+import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions
 import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore (DNSSemaphore,
            withDNSSemaphore)
 
@@ -39,13 +40,10 @@ import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSSemaphore (DNSSemaphore,
 
 data TracePublicRootPeers =
        TracePublicRootRelayAccessPoint (Map RelayAccessPoint PeerAdvertise)
-     | TracePublicRootDomains [DomainAccessPoint]
-     | TracePublicRootResult  DNS.Domain [(IP, DNS.TTL)]
-     | TracePublicRootFailure DNS.Domain DNS.DNSError
-       --TODO: classify DNS errors, config error vs transitory
+     | TracePublicRootDomains [RelayAccessPoint]
   deriving Show
 
--- |
+-- | fulfills a request from 'requestPublicRootPeers'
 --
 publicRootPeersProvider
   :: forall peerAddr resolver exception a m.
@@ -56,7 +54,8 @@ publicRootPeersProvider
   -> DNSSemaphore m
   -> DNS.ResolvConf
   -> STM m (Map RelayAccessPoint PeerAdvertise)
-  -> DNSActions resolver exception m
+  -> DNSActions peerAddr resolver exception m
+  -> StdGen
   -> ((Int -> m (Map peerAddr PeerAdvertise, DiffTime)) -> m a)
   -> m a
 publicRootPeersProvider tracer
@@ -76,16 +75,6 @@ publicRootPeersProvider tracer
     resourceVar <- newTVarIO rr
     action (requestPublicRootPeers resourceVar)
   where
-    processResult :: ((DomainAccessPoint, PeerAdvertise), ([DNS.DNSError], [(IP, DNS.TTL)]))
-                  -> m ((DomainAccessPoint, PeerAdvertise), [(IP, DNS.TTL)])
-    processResult ((domain, pa), (errs, result)) = do
-        mapM_ (traceWith tracer . TracePublicRootFailure (dapDomain domain))
-              errs
-        when (not $ null result) $
-            traceWith tracer $ TracePublicRootResult (dapDomain domain) result
-
-        return ((domain, pa), result)
-
     requestPublicRootPeers
       :: StrictTVar m (Resource m (Either (DNSorIOError exception) resolver))
       -> Int
@@ -93,19 +82,25 @@ publicRootPeersProvider tracer
     requestPublicRootPeers resourceVar _numRequested = do
         domains <- atomically readDomains
         traceWith tracer (TracePublicRootRelayAccessPoint domains)
-        rr <- atomically $ readTVar resourceVar
+        rr <- readTVarIO resourceVar
         (er, rr') <- withResource rr
         atomically $ writeTVar resourceVar rr'
         case er of
           Left (DNSError err) -> throwIO err
           Left (IOError  err) -> throwIO err
           Right resolver -> do
-            let lookups =
-                  [ ((DomainAccessPoint domain port, pa),)
+            let (doms, relayAddrs) =
+                  flip partition (Map.assocs domains) $ \case
+                    (RelayAccessAddress {}, _) -> False
+                    _otherwise                 -> True
+                lookups =
+                  [ (, pa)
                       <$> (do
                         labelThisThread "dnsLookupWithTTL"
                         withDNSSemaphore dnsSemaphore
                             (dnsLookupWithTTL
+                              DNSPublicPeer
+                              domain
                               resolvConf
                               resolver
                               rng))
@@ -118,25 +113,24 @@ publicRootPeersProvider tracer
             -- The timeouts here are handled by the 'lookupWithTTL'. They're
             -- configured via the DNS.ResolvConf resolvTimeout field and defaults
             -- to 3 sec.
-            results <- withAsyncAll lookups (atomically . mapM waitSTM)
-            results' <- mapM processResult results
-            let successes = [ ( (toPeerAddr ip dapPortNumber, pa)
-                              , ipttl)
-                            | ( (DomainAccessPoint {dapPortNumber}, pa)
-                              , ipttls) <- results'
-                            , (ip, ipttl) <- ipttls
+            results  <- withAsyncAll lookups (atomically . mapM waitSTM)
+            let successes = [ ( (addr, pa)
+                              , ttl')
+                            | ( Right addrttls
+                              , pa) <- results
+                            , (addr, ttl') <- addrttls
                             ]
                 !domainsIps = [(toPeerAddr ip port, pa)
-                              | (RelayAccessAddress ip port, pa) <- Map.assocs domains ]
-                !ips      = Map.fromList (map fst successes) `Map.union` Map.fromList domainsIps
-                !ttl      = if null lookups
-                               then -- Not having any peers with domains configured is not
-                                    -- a DNS error.
-                                    ttlForResults [60]
-                               else ttlForResults (map snd successes)
+                              | (RelayAccessAddress ip port, pa) <- relayAddrs ]
+                !addrs      = Map.fromList (map fst successes) `Map.union` Map.fromList domainsIps
+                !ttl        = if null lookups
+                                then -- Not having any peers with domains configured is not
+                                     -- a DNS error.
+                                     ttlForResults [60]
+                                else ttlForResults (map snd successes)
             -- If all the lookups failed we'll return an empty set with a minimum
             -- TTL, and the governor will invoke its exponential backoff.
-            return (ips, ttl)
+            return (addrs, ttl)
 
 -- Aux
 
@@ -166,6 +160,6 @@ clipTTLAbove = min 86400  -- and 24hrs
 -- | Policy for TTL for negative results
 -- Cache negative response for 3hrs
 -- Otherwise, use exponential backoff, up to a limit
-ttlForDnsError :: DNS.DNSError -> DiffTime -> DiffTime
+ttlForDnsError :: DNSError -> DiffTime -> DiffTime
 ttlForDnsError DNS.NameError _ = 10800
 ttlForDnsError _           ttl = clipTTLAbove (ttl * 2 + 5)

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE BlockArguments        #-}
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
@@ -51,22 +53,24 @@ import Data.Bool (bool)
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BL
 import Data.Function (on)
-import Data.IP (IP (..))
-import Data.List (delete, nubBy)
+import Data.Either (fromLeft, fromRight)
+import Data.Foldable (foldlM)
+import Data.List (delete, nub, partition)
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (catMaybes, fromMaybe, maybeToList)
+import Data.Maybe (fromMaybe, listToMaybe, mapMaybe, maybeToList)
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Time.Clock (secondsToDiffTime)
 import Data.Typeable (Typeable)
 import Data.Void (Void)
+import Network.DNS (Domain)
+import Network.DNS qualified as DNS
 import System.Random (StdGen, mkStdGen)
 import System.Random qualified as Random
 
-import Network.DNS (Domain, TTL)
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.PingPong.Type qualified as PingPong
 
@@ -116,9 +120,14 @@ import Ouroboros.Network.PeerSelection (AfterSlot (..), DomainAccessPoint (..),
 import Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
            TracePeerSelection)
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor
-import Ouroboros.Network.PeerSelection.LedgerPeers (accPoolStake)
-import Ouroboros.Network.PeerSelection.RootPeersDNS (DNSLookupType,
-           TraceLocalRootPeers, TracePublicRootPeers)
+import Ouroboros.Network.PeerSelection.LedgerPeers (AfterSlot (..),
+           LedgerPeersConsensusInterface (..), TraceLedgerPeers,
+           UseLedgerPeers (..), accPoolStake)
+import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
+import Ouroboros.Network.PeerSelection.PeerStateActions
+           (PeerSelectionActionsTrace)
+import Ouroboros.Network.PeerSelection.RelayAccessPoint
+import Ouroboros.Network.PeerSelection.RootPeersDNS
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig, WarmValency (..))
 import Ouroboros.Network.Protocol.BlockFetch.Codec (byteLimitsBlockFetch,
@@ -143,7 +152,7 @@ import Test.Ouroboros.Network.PeerSelection.Cardano.Instances ()
 import Test.Ouroboros.Network.PeerSelection.Instances qualified as PeerSelection
 import Test.Ouroboros.Network.PeerSelection.LocalRootPeers ()
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS (DNSLookupDelay (..),
-           DNSTimeout (..), mockDNSActions)
+           DNSTimeout (..), DomainAccessPoint (..), MockDNSMap, genDomainName)
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS qualified as PeerSelection hiding
            (tests)
 import Test.Ouroboros.Network.Utils
@@ -363,12 +372,12 @@ instance Arbitrary SmallPeerSelectionTargets where
 
 -- | Given a NtNAddr generate the necessary things to run a node in
 -- Simulation
-genNodeArgs :: [RelayAccessInfo]
+genNodeArgs :: [TestnetRelayInfo]
             -> Int
             -> [(HotValency, WarmValency, Map RelayAccessPoint (LocalRootConfig PeerTrustable))]
-            -> RelayAccessInfo
+            -> TestnetRelayInfo
             -> Gen NodeArgs
-genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream $ do
+genNodeArgs relays minConnected localRootPeers self = flip suchThat hasUpstream $ do
   -- Slot length needs to be greater than 0 else we get a livelock on
   -- the IOSim.
   --
@@ -421,12 +430,10 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
   let (ledgerPeersRelays, publicRootsRelays) =
         splitAt (length relays `div` 2) relays
       publicRoots =
-        Map.fromList [ (makeRelayAccessPoint relay', advertise)
-                     | relay' <- publicRootsRelays
-                     , relay' /= relay
-                     , let advertise = case relay' of
-                             RelayAddrInfo        _ip _port adv -> adv
-                             RelayDomainInfo _dns _ip _port adv -> adv
+        Map.fromList [ (other, advertise)
+                     | pubRelay <- publicRootsRelays
+                     , pubRelay /= self
+                     , let (other, _, _, advertise) = pubRelay
                      ]
 
   ledgerPeers :: [[NonEmpty RelayAccessPoint]]
@@ -452,7 +459,7 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
         -- `UseLedgerPeers 0`!
       , naConsensusMode
       , naBootstrapPeers         = bootstrapPeersDomain
-      , naAddr                   = makeNtNAddr relay
+      , naAddr                   = TestAddress ((\(_, ip, port, _) -> IPAddr ip port) self)
       , naLocalRootPeers         = localRootPeers
       , naLedgerPeers            = ledgerPeersScript
       , naPeerTargets            = peerTargets
@@ -464,6 +471,8 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
       , naFetchModeScript        = fetchModeScript
       }
   where
+    makeRelayAccessPoint (relay, _, _, _) = relay
+
     hasActive :: SmallPeerSelectionTargets -> Bool
     hasActive (SmallTargets (PeerSelectionTargets {
                  targetNumberOfActivePeers = y,
@@ -486,83 +495,106 @@ genNodeArgs relays minConnected localRootPeers relay = flip suchThat hasUpstream
 
 -- 'DomainMapScript' describes evolution of domain name resolution.
 --
-type DomainMapScript = TimedScript (Map Domain [(IP, TTL)])
+type DomainMapScript = TimedScript MockDNSMap
 
 
 -- | Make sure that the final domain map can resolve all the domains correctly.
 --
-fixupDomainMapScript :: RelayAccessInfos -> DomainMapScript -> DomainMapScript
-fixupDomainMapScript relays (Script (a@(_, delay) :| as)) =
+fixupDomainMapScript :: MockDNSMap -> DomainMapScript -> DomainMapScript
+fixupDomainMapScript mockMap (Script (a@(_, delay) :| as)) =
     case reverse as of
-      []                  -> Script $ (dnsMap, delay) :| as
-      ((_, delay') : as') -> Script $ a :| reverse ((dnsMap, delay') : as')
-  where
-    dnsMap :: Map Domain [(IP, TTL)]
-    dnsMap = Map.fromListWith (++)
-      [ (domain, [(ip, 300)])
-      | RelayDomainInfo domain ip _ _ <- getRelayAccessInfos relays
-      ]
-
+      []                  -> Script $ (mockMap, delay) :| as
+      ((_, delay') : as') -> Script $ a :| reverse ((mockMap, delay') : as')
 
 -- | Generate a `DomainMapScript`.  Each step contains modification of the full
 -- dns map with at most 20% entries removed and 20% entries modified.  The last
 -- scripted value is the full dns map which ensures that eventually all dns
 -- names resolve to correct ip addresses.
 --
-genDomainMapScript :: RelayAccessInfos -> Gen DomainMapScript
-genDomainMapScript relays = fixupDomainMapScript relays
-                         <$> arbitraryScriptOf 10
-                               ((,) <$> genDomainMap <*> arbitrary)
+genDomainMapScript :: TestnetRelayInfos -> Gen DomainMapScript
+genDomainMapScript relays = do
+  mockMap <- dnsMapGen
+  fixupDomainMapScript mockMap <$>
+    arbitraryScriptOf 10 ((,) <$> alterDomainMap mockMap <*> arbitrary)
   where
-    genDomainMap :: Gen (Map Domain [(IP, TTL)])
-    genDomainMap = do
-      rm <- removedDomains
-      md <- modifiedDomains
-      return $ Map.fromList md `Map.union` foldr Map.delete dnsMap rm
+    them = unTestnetRelays relays
+    dnsType = case relays of
+      TestnetRelays4 {} -> DNS.A
+      TestnetRelays6 {} -> DNS.AAAA
 
-    removedDomains :: Gen [Domain]
-    removedDomains = do
-        as <- vectorOf (length domains) (frequency [(4, pure True), (1, pure False)])
+    alterDomainMap mockMap = do
+      let dnsAssoc = Map.toList mockMap
+      rm <- removedDomains (fst <$> dnsAssoc)
+      md <- modifiedDomains dnsAssoc
+      return $ Map.fromList md `Map.union` foldr Map.delete mockMap rm
+
+    removedDomains domains = do
+        as <- tosses (length domains)
         return $ map fst . filter snd $ zip domains as
-      where
-        domains = Map.keys dnsMap
 
-    modifiedDomains :: Gen [(Domain, [(IP, TTL)])]
-    modifiedDomains = do
-        as <- vectorOf (length domains) (frequency [(4, pure True), (1, pure False)])
-        let ds :: [Domain]
-            ds = map fst . filter snd $ zip domains as
-        ips <- vectorOf (length ds) (case relays of
-                                       IPv4RelayAccessInfos _ -> PeerSelection.genIPv4
-                                       IPv6RelayAccessInfos _ -> PeerSelection.genIPv6)
-        return $ zip ds ((\a -> [(a,ttl)]) <$> ips)
-      where
-        domains = Map.keys dnsMap
+    modifiedDomains assoc = do
+        mask' <- tosses (length assoc)
+        let picked = map fst . filter snd $ zip assoc mask'
+            singleton x = [x]
+        forM picked \(k, v) ->
+          case v of
+            Left _ipsttls -> case relays of
+              TestnetRelays4 {} ->
+                (k,) . Left . singleton . (, ttl) <$> PeerSelection.genIPv4
+              TestnetRelays6 {} ->
+                (k,) . Left . singleton . (, ttl) <$> PeerSelection.genIPv6
+            Right doms -> do
+              (k,) . Right . singleton <$> do
+                case listToMaybe doms of
+                  Just (_, prio, wt, port) -> (, prio, wt, port) <$> genDomainName
+                  Nothing -> error "impossible!"
 
-    dnsMap :: Map Domain [(IP, TTL)]
-    dnsMap = Map.fromListWith (++)
-      [ (domain, [(ip, ttl)])
-      | RelayDomainInfo domain ip _ _ <- getRelayAccessInfos relays
-      ]
+    tosses count = vectorOf count (frequency [(4, pure True), (1, pure False)])
+
+    dnsMapGen = do
+      let (srvs, nonsrvs) = partition isSRV them
+          srvs' = [(k, d, ip, port)
+                  | (relay, k) <- zip srvs [0..]
+                  , let (RelayAccessSRVDomain d, ip, port, _) = relay]
+      srvMap <- foldlM stepSRV Map.empty srvs'
+      let nonSRVMap = foldl stepNonSRV Map.empty nonsrvs
+      return $ Map.union srvMap nonSRVMap
+
+    isSRV = \case
+      (RelayAccessSRVDomain {}, _, _, _) -> True
+      _otherwise -> False
+
+    stepSRV m (k, d, ip, port) = do
+      i <- choose (1, 5)
+      subordinates <- zipWith addTag [0 :: Int ..] <$> vectorOf i genDomainName
+      (_, subs) <- head' <$> PeerSelection.genGroupSrvs [(d, subordinates)]
+      let fixupPort = map relayPort subs
+          lookupSequence =
+            Map.fromList $
+              ((d, DNS.SRV), Right fixupPort)
+              : [((sub, dnsType), Left [(ip, ttl)])
+                | (sub, _, _, _) <- subs]
+      return $ Map.union lookupSequence m
+
+      where
+        head' (x : _xs) = x
+        head' []        = error "impossible!"
+        relayPort (a, b, c', _d) = (a, b, c', port)
+        c = BSC.pack . show
+        addTag i dom = dom <> "_" <> c k <> "_" <> c i
+
+
+    stepNonSRV b (relay, ip, _port, _advAndTrust) = do
+      case relay of
+        RelayAccessAddress {}  -> b
+        RelayAccessDomain d _p -> Map.alter fa (d, dnsType) b
+        RelayAccessSRVDomain _ -> error "impossible!"
+      where
+        fa Nothing               = Just . Left $ [(ip, ttl)]
+        fa (Just (Left ipsttls)) = Just . Left $ (ip, ttl) : ipsttls
+        fa _                     = error "impossible!"
 
     ttl = 300
-
-
-shrinkDomainMapScript :: RelayAccessInfos -> DomainMapScript -> [DomainMapScript]
-shrinkDomainMapScript relays script =
-    catMaybes $
-        -- make sure `fixupDomainMapScript` didn't return something that's
-        -- equal to the original `script`
-        (\script' -> if script == script' then Nothing else Just script')
-     .  fixupDomainMapScript relays
-    <$> shrinkScriptWith (shrinkTuple shrinkMap_ shrink) script
-  where
-    shrinkMap_ :: Ord a => Map a b -> [Map a b]
-    shrinkMap_ = map Map.fromList . shrinkList (const []) . Map.toList
-
-    shrinkTuple :: (a -> [a]) -> (b -> [b]) -> (a, b) -> [(a, b)]
-    shrinkTuple f g (a, b) = [(a', b) | a' <- f a]
-                          ++ [(a, b') | b' <- g b]
 
 --
 -- DiffusionScript
@@ -583,131 +615,28 @@ instance Show DiffusionScript where
     show (DiffusionScript args dnsScript nodes) =
       "DiffusionScript (" ++ show args ++ ") (" ++ show dnsScript ++ ") " ++ show nodes
 
--- | Information describing how nodes can be accessed.
---
-data RelayAccessInfo
-    = RelayAddrInfo          IP PortNumber PeerAdvertise
-    -- ^ relays available using ip / port pair
-    | RelayDomainInfo Domain IP PortNumber PeerAdvertise
-    -- ^ relays available either using the given domain.
-  deriving (Show, Eq)
-
-genRelayAccessInfo :: Gen IP
-                   -> Gen RelayAccessInfo
-genRelayAccessInfo genIP =
-  oneof [ RelayAddrInfo <$> genIP
-                        <*> (fromIntegral <$> (arbitrary :: Gen Int))
-                        <*> arbitrary
-        , (\(DomainAccessPoint domain port) ip advertise -> RelayDomainInfo domain ip port advertise)
-                        <$> arbitrary
-                        <*> genIP
-                        <*> arbitrary
-        ]
-
-makeRelayAccessPoint :: RelayAccessInfo -> RelayAccessPoint
-makeRelayAccessPoint (RelayAddrInfo ip port _) = RelayAccessAddress ip port
-makeRelayAccessPoint (RelayDomainInfo domain _ip port _) = RelayAccessDomain domain port
-
-makeNtNAddr :: RelayAccessInfo -> NtNAddr
-makeNtNAddr (RelayAddrInfo ip port _)        = TestAddress (IPAddr ip port)
-makeNtNAddr (RelayDomainInfo _dns ip port _) = TestAddress (IPAddr ip port)
-
-data RelayAccessInfos
-    -- IPv4 only network
-  = IPv4RelayAccessInfos { getRelayAccessInfos :: [RelayAccessInfo] }
-    -- IPv6 only network
-  | IPv6RelayAccessInfos { getRelayAccessInfos :: [RelayAccessInfo] }
-  deriving Show
-
-fixupRelayAccessInfos :: [RelayAccessInfo] -> [RelayAccessInfo]
-fixupRelayAccessInfos as = f <$> as
-    where
-      -- map domains to the same port number
-      m = Map.fromList [ (domain, port)
-                       | RelayDomainInfo domain _ port _ <- as
-                       ]
-
-      f a@RelayAddrInfo {} = a
-      f (RelayDomainInfo domain ip _ advertise) = RelayDomainInfo domain ip (m Map.! domain) advertise
-
-
--- Generate a list of either IPv4 only or IPv6 only `RelayAccessInfo`.  All
--- `IP`'s using the same domain name are guaranteed to use the same port
--- number.
-instance Arbitrary RelayAccessInfos where
-    arbitrary = oneof
-      [ do -- Limit the number of nodes to run in Simulation in order to limit
-           -- simulation execution (real) time.
-           size <- chooseInt (1,3)
-           IPv4RelayAccessInfos . fixupRelayAccessInfos
-             <$> vectorOf size (genRelayAccessInfo PeerSelection.genIPv4)
-
-      , do -- Limit the number of nodes to run in Simulation in order to limit
-           -- simulation execution (real) time.
-           size <- chooseInt (1,3)
-           IPv6RelayAccessInfos . fixupRelayAccessInfos
-             <$> vectorOf size (genRelayAccessInfo PeerSelection.genIPv6)
-      ]
-
-    shrink (IPv4RelayAccessInfos as) = IPv4RelayAccessInfos . fixupRelayAccessInfos
-                                   <$> shrinkList (const []) as
-    shrink (IPv6RelayAccessInfos as) = IPv6RelayAccessInfos . fixupRelayAccessInfos
-                                   <$> shrinkList (const []) as
-
-
-
--- | Relays access info and dns script.
---
-data RelayAccessInfosWithDNS = RelayAccessInfosWithDNS RelayAccessInfos DomainMapScript
-  deriving Show
-
-
-instance Arbitrary RelayAccessInfosWithDNS where
-    arbitrary =
-      flip suchThat (\(RelayAccessInfosWithDNS infos _)
-                      -> length (getRelayAccessInfos infos) >= 2) $ do
-        infos <- arbitrary
-        domainMapScript <- genDomainMapScript infos
-        return $ RelayAccessInfosWithDNS infos domainMapScript
-
-    shrink (RelayAccessInfosWithDNS infos dnsMapScript) =
-      [ RelayAccessInfosWithDNS infos (fixupDomainMapScript infos' dnsMapScript)
-      | infos' <- shrink infos
-      , length (getRelayAccessInfos infos') >= 2
-      ]
-      ++
-      [ RelayAccessInfosWithDNS infos dnsMapScript'
-      | dnsMapScript' <- shrinkDomainMapScript infos dnsMapScript
-      ]
-
-
-genDiffusionScript :: ([RelayAccessInfo]
-                        -> RelayAccessInfo
-                        -> Gen [( HotValency
+genDiffusionScript :: (   [TestnetRelayInfo]
+                       -> TestnetRelayInfo
+                       -> Gen [( HotValency
                                 , WarmValency
                                 , Map RelayAccessPoint (LocalRootConfig PeerTrustable))])
-                   -> RelayAccessInfosWithDNS
+                   -> TestnetRelayInfos
                    -> Gen (SimArgs, DomainMapScript, [(NodeArgs, [Command])])
 genDiffusionScript genLocalRootPeers
-                   (RelayAccessInfosWithDNS relays dnsMapScript)
+                   relays
                    = do
-    let simArgs = mainnetSimArgs (length relays')
-    nodesWithCommands <- mapM go (nubBy ((==) `on` getRelayIP) relays')
+    let simArgs = mainnetSimArgs (length them)
+    dnsMapScript <- genDomainMapScript relays
+    nodesWithCommands <- mapM go them
     return (simArgs, dnsMapScript, nodesWithCommands)
   where
-    getRelayIP :: RelayAccessInfo -> IP
-    getRelayIP (RelayAddrInfo ip _ _)     = ip
-    getRelayIP (RelayDomainInfo _ ip _ _) = ip
-
-    relays' :: [RelayAccessInfo]
-    relays' = getRelayAccessInfos relays
-
-    go :: RelayAccessInfo -> Gen (NodeArgs, [Command])
-    go relay = do
-      let otherRelays  = relay `delete` relays'
-          minConnected = 3 `max` (length relays' - 1)
-      localRts <- genLocalRootPeers otherRelays relay
-      nodeArgs <- genNodeArgs relays' minConnected localRts relay
+    them = unTestnetRelays relays
+    go self = do
+      let otherRelays  = self `delete` them
+          minConnected = 3 `max` (length them - 1) -- ^ TODO is this ever different from 3?
+                                                   -- since we generate {2,3} relays?
+      localRts <- genLocalRootPeers otherRelays self
+      nodeArgs <- genNodeArgs them minConnected localRts self
       commands <- genCommands localRts
       return (nodeArgs, commands)
 
@@ -718,27 +647,29 @@ genDiffusionScript genLocalRootPeers
 -- or can not be connected to one another. These nodes can also randomly die or
 -- have their local configuration changed.
 --
-genNonHotDiffusionScript :: RelayAccessInfosWithDNS
+genNonHotDiffusionScript :: TestnetRelayInfos
                          -> Gen (SimArgs, DomainMapScript, [(NodeArgs, [Command])])
 genNonHotDiffusionScript = genDiffusionScript genLocalRootPeers
   where
     -- | Generate Local Root Peers
     --
-    genLocalRootPeers :: [RelayAccessInfo]
-                      -> RelayAccessInfo
+    genLocalRootPeers :: [TestnetRelayInfo]
+                      -> TestnetRelayInfo
                       -> Gen [( HotValency
                               , WarmValency
                               , Map RelayAccessPoint (LocalRootConfig PeerTrustable)
                               )]
-    genLocalRootPeers relays _relay = flip suchThat hasUpstream $ do
+    genLocalRootPeers others _self = flip suchThat hasUpstream $ do
       nrGroups <- chooseInt (1, 3)
       -- Remove self from local root peers
-      let size = length relays
+      let size = length others
           sizePerGroup = (size `div` nrGroups) + 1
 
-      peerAdvertise <- vectorOf size arbitrary
-
-      let relaysAdv = zip (makeRelayAccessPoint <$> relays) peerAdvertise
+      localRootConfigs <- vectorOf size arbitrary
+      let relaysAdv = zipWith (\(rap, _ip, _port, _advertise) lrc ->
+                                 (rap, lrc))
+                              others
+                              localRootConfigs
           relayGroups = divvy sizePerGroup relaysAdv
           relayGroupsMap = Map.fromList <$> relayGroups
 
@@ -765,10 +696,43 @@ genNonHotDiffusionScript = genDiffusionScript genLocalRootPeers
                     )]
                 -> Bool
     hasUpstream localRootPeers =
-      any id [ v > 0 && not (Map.null m)
-             | (HotValency v, _, m) <- localRootPeers
-             ]
+      or [ v > 0 && not (Map.null m)
+         | (HotValency v, _, m) <- localRootPeers
+         ]
 
+-- | there's some duplication of information, but saves some silly pattern
+-- matches where we don't care about the particular value of RelayAccessPoint
+--
+type TestnetRelayInfo = (RelayAccessPoint, IP, PortNumber, PeerAdvertise)
+data TestnetRelayInfos = TestnetRelays4 { unTestnetRelays :: [TestnetRelayInfo] }
+                       | TestnetRelays6 { unTestnetRelays :: [TestnetRelayInfo] }
+
+instance Arbitrary TestnetRelayInfos where
+  arbitrary = oneof [ TestnetRelays4 <$> gen PeerSelection.genIPv4
+                    , TestnetRelays6 <$> gen PeerSelection.genIPv6
+                    ]
+    where
+      uniqueIps xs =
+        let ips = (\(_, _, c, _) -> c) <$> xs
+        in length (nub ips) == length ips
+
+      gen genIP = do
+        i <- choose (2,3)
+        (vectorOf i arbitrary >>= traverse (uncurry $ extractOrGen genIP)) `suchThat` uniqueIps
+
+      extractOrGen genIP peerAdvertise = \case
+        raa@(RelayAccessAddress ip port) -> pure (raa, ip, port, peerAdvertise)
+        rad@(RelayAccessDomain _d port) -> (rad,, port, peerAdvertise) <$> genIP
+        ras@(RelayAccessSRVDomain _d) -> (ras,,, peerAdvertise) <$> genIP <*> PeerSelection.genPort
+
+  shrink = \case
+    TestnetRelays4 infos -> TestnetRelays4 <$> go infos
+    TestnetRelays6 infos -> TestnetRelays6 <$> go infos
+    where
+      go infos = [candidate
+                 | candidate <- shrinkList (const []) infos
+                 , length candidate >= 2
+                 ]
 
 -- | Multinode Hot Diffusion Simulator Script
 --
@@ -778,26 +742,26 @@ genNonHotDiffusionScript = genDiffusionScript genLocalRootPeers
 -- active connections. These nodes can not randomly die or have their local
 -- configuration changed. Their local root peers consist of a single group.
 --
-genHotDiffusionScript :: RelayAccessInfosWithDNS
+genHotDiffusionScript :: TestnetRelayInfos
                       -> Gen (SimArgs, DomainMapScript, [(NodeArgs, [Command])])
 genHotDiffusionScript = genDiffusionScript genLocalRootPeers
     where
       -- | Generate Local Root Peers.  This only generates 1 group
       --
-      genLocalRootPeers :: [RelayAccessInfo]
-                        -> RelayAccessInfo
+      genLocalRootPeers :: [TestnetRelayInfo]
+                        -> TestnetRelayInfo
                         -> Gen [( HotValency
                                 , WarmValency
                                 , Map RelayAccessPoint (LocalRootConfig PeerTrustable)
                                 )]
-      genLocalRootPeers relays _relay = flip suchThat hasUpstream $ do
-        let size = length relays
-
-        peerAdvertise <- vectorOf size arbitrary
-
-        let relaysAdv      = zip (makeRelayAccessPoint <$> relays) peerAdvertise
+      genLocalRootPeers others _self = flip suchThat hasUpstream $ do
+        localRootConfigs <- vectorOf (length others) arbitrary
+        let relaysAdv = zipWith (\(rap, _ip, _port, _advertise) lrc ->
+                                    (rap, lrc))
+                              others
+                              localRootConfigs
             relayGroupsMap = Map.fromList relaysAdv
-            warmTarget         = length relaysAdv
+            warmTarget     = length relaysAdv
 
         hotTarget <- choose (0 , warmTarget)
 
@@ -812,32 +776,55 @@ genHotDiffusionScript = genDiffusionScript genLocalRootPeers
                       )]
                   -> Bool
       hasUpstream localRootPeers =
-        any id [ v > 0 && not (Map.null m)
-               | (HotValency v, _, m) <- localRootPeers
-               ]
+        or [ v > 0 && not (Map.null m)
+           | (HotValency v, _, m) <- localRootPeers
+           ]
 
 
 instance Arbitrary DiffusionScript where
   arbitrary = (\(a,b,c) -> DiffusionScript a b c)
-            <$> frequency [ (1, arbitrary >>= genNonHotDiffusionScript)
-                          , (1, arbitrary >>= genHotDiffusionScript)
-                          ]
+              <$> frequency [ (1, arbitrary >>= genNonHotDiffusionScript)
+                            , (1, arbitrary >>= genHotDiffusionScript)]
   -- TODO: shrink dns map
   -- TODO: we should write more careful shrinking than recursively shrinking
   -- `DiffusionScript`!
-  shrink (DiffusionScript _ _ []) = []
-  shrink (DiffusionScript sargs dnsMap ((nargs, cmds):s)) = do
-    shrinkedCmds <- fixupCommands <$> shrinkList shrinkCommand cmds
-    DiffusionScript sa dnsMap' ss <- shrink (DiffusionScript sargs dnsMap s)
-    return (DiffusionScript sa dnsMap' ((nargs, shrinkedCmds) : ss))
+  shrink (DiffusionScript sargs dnsScript cmds0) = shrinkCmds cmds0 ++ shrinkDns
     where
-      shrinkDelay = map fromRational . shrink . toRational
+      shrinkDns =
+        [DiffusionScript sargs script cmds0
+        | script <-
+            mapMaybe
+              -- make sure `fixupDomainMapScript` didn't return something that's
+              -- equal to the original `script`
+              ((\dnsScript' -> if dnsScript == dnsScript' then Nothing else Just dnsScript')
+               .  fixupDomainMapScript (getLast dnsScript))
+              $ shrinkScriptWith (shrinkTuple shrinkMap_ shrink) dnsScript
+        ]
 
-      shrinkCommand :: Command -> [Command]
-      shrinkCommand (JoinNetwork d)     = JoinNetwork <$> shrinkDelay d
-      shrinkCommand (Kill d)            = Kill        <$> shrinkDelay d
-      shrinkCommand (Reconfigure d lrp) = Reconfigure <$> shrinkDelay d
-                                                      <*> pure lrp
+      getLast (Script ne) = fst $ NonEmpty.last ne
+
+      shrinkMap_ :: Ord a => Map a b -> [Map a b]
+      shrinkMap_ = map Map.fromList . shrinkList (const []) . Map.toList
+
+      shrinkTuple :: (a -> [a]) -> (b -> [b]) -> (a, b) -> [(a, b)]
+      shrinkTuple f g (a, b) = [(a', b) | a' <- f a]
+                            ++ [(a, b') | b' <- g b]
+
+      shrinkCmds [] = []
+      shrinkCmds ((nargs, cmds):rest) =
+        let shrunkCmdss = fixupCommands <$> shrinkList shrinkCommand cmds
+            rest' = shrinkCmds rest
+        in [DiffusionScript sargs dnsScript ((nargs, shrunkCmds):rest)
+           | shrunkCmds <- shrunkCmdss] ++ rest'
+        where
+          shrinkDelay = map fromRational . shrink . toRational
+
+          shrinkCommand :: Command -> [Command]
+          shrinkCommand (JoinNetwork d)     = JoinNetwork <$> shrinkDelay d
+          shrinkCommand (Kill d)            = Kill        <$> shrinkDelay d
+          shrinkCommand (Reconfigure d lrp) = Reconfigure <$> shrinkDelay d
+                                                          <*> pure lrp
+
 
 -- | Multinode Hot Diffusion Simulator Script
 --
@@ -935,6 +922,7 @@ data DiffusionTestTrace =
     | DiffusionServerTrace (Server.Trace NtNAddr)
     | DiffusionFetchTrace (TraceFetchClientState BlockHeader)
     | DiffusionDebugTrace String
+    | DiffusionDNSTrace DNSTrace
     deriving (Show)
 
 
@@ -1007,7 +995,7 @@ diffusionSimulation
         -- ^ Node to node Snocket
       -> Snocket m (FD m NtCAddr) NtCAddr
         -- ^ Node to client Snocket
-      -> StrictTVar m (Map Domain [(IP, TTL)])
+      -> StrictTVar m MockDNSMap
         -- ^ Map of domain map TVars to be updated in case a node changes its IP
       -> SimArgs -- ^ Simulation arguments needed in order to run a simulation
       -> NodeArgs -- ^ Simulation arguments needed in order to run a single node
@@ -1061,7 +1049,7 @@ diffusionSimulation
                              , WarmValency
                              , Map RelayAccessPoint (LocalRootConfig PeerTrustable)
                              )]
-            -> StrictTVar m (Map Domain [(IP, TTL)])
+            -> StrictTVar m MockDNSMap
             -> m Void
     runNode SimArgs
             { saSlot                  = bgaSlotDuration
@@ -1271,7 +1259,7 @@ diffusionSimulation
         `catch` \e -> traceWith (diffSimTracer addr) (TrErrored e)
                    >> throwIO e
 
-    domainResolver :: StrictTVar m (Map Domain [(IP, TTL)])
+    domainResolver :: StrictTVar m MockDNSMap
                    -> DNSLookupType
                    -> [DomainAccessPoint]
                    -> m (Map DomainAccessPoint (Set NtNAddr))
@@ -1279,14 +1267,31 @@ diffusionSimulation
     -- / `IPv6` if so requested.  But we should make sure the connectivity graph
     -- is not severely reduced.
     domainResolver dnsMapVar _ daps = do
-      dnsMap <- fmap (map fst) <$> atomically (readTVar dnsMapVar)
+      dnsMap <- readTVarIO dnsMapVar
       let mapDomains :: [(DomainAccessPoint, Set NtNAddr)]
-          mapDomains = [ ( dap
-                         , Set.fromList [ ntnToPeerAddr a p | a <- addrs ]
-                         )
-                       | dap@(DomainAccessPoint d p) <- daps
-                       , addrs <- maybeToList (d `Map.lookup` dnsMap) ]
+          mapDomains =
+            [ ( dap
+              , Set.fromList [ TestAddress (IPAddr a p) | (a, p) <- addrs ]
+              )
+            | dap <- daps
+            , let addrs = case dap of
+                    DomainAccessPoint d p -> (,p) <$> retrieveIPs dnsMap d
+                    DomainSRVAccessPoint dSRV ->
+                      let subordinates = dnsMap Map.! (dSRV, DNS.SRV)
+                          subordinates' = fromRight (error "impossible") subordinates
+                       in case listToMaybe subordinates' of
+                            Just (d, _, _, p) -> (,p) <$> retrieveIPs dnsMap d
+                            Nothing           -> []
+            ]
       return (Map.fromListWith (<>) mapDomains)
+      where
+        retrieveIPs dnsMap d =
+          let ipsttlsI4 = dnsMap Map.! (d, DNS.A)
+              ipsttlsI4' = fromLeft (error "impossible") ipsttlsI4
+              ipsttlsI6 =  dnsMap Map.! (d, DNS.AAAA)
+              ipsttlsI6' = fromLeft (error "impossible") ipsttlsI6
+              ipsttls = ipsttlsI4' <> ipsttlsI6'
+           in fst <$> ipsttls
 
     diffSimTracer :: NtNAddr -> Tracer m DiffusionSimulationTrace
     diffSimTracer ntnAddr = contramap DiffusionDiffusionSimulationTrace
@@ -1372,6 +1377,10 @@ diffusionSimulation
         , Diff.dtLocalConnectionManagerTracer      = nullTracer
         , Diff.dtLocalServerTracer                 = nullTracer
         , Diff.dtLocalInboundGovernorTracer        = nullTracer
+        , Diff.dtDnsTracer                         = contramap DiffusionDNSTrace
+                                                     . tracerWithName ntnAddr
+                                                     . tracerWithTime
+                                                     $ nodeTracer
       }
 
 
@@ -1391,10 +1400,6 @@ timeLimitsPingPong = ProtocolTimeLimits $ \case
 --
 -- Utils
 --
-
-
-ntnToPeerAddr :: IP -> PortNumber -> NtNAddr
-ntnToPeerAddr a b = TestAddress (IPAddr a b)
 
 withAsyncAll :: MonadAsync m => [m a] -> ([Async m a] -> m b) -> m b
 withAsyncAll xs0 action = go [] xs0

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano/Simulation.hs
@@ -52,7 +52,6 @@ import Control.Tracer (Tracer (..), contramap, nullTracer, traceWith)
 import Data.Bool (bool)
 import Data.ByteString.Char8 qualified as BSC
 import Data.ByteString.Lazy qualified as BL
-import Data.Function (on)
 import Data.Either (fromLeft, fromRight)
 import Data.Foldable (foldlM)
 import Data.List (delete, nub, partition)
@@ -113,20 +112,10 @@ import Ouroboros.Network.InboundGovernor (RemoteTransitionTrace)
 import Ouroboros.Network.InboundGovernor qualified as IG
 import Ouroboros.Network.Mock.ConcreteBlock (Block (..), BlockHeader (..))
 import Ouroboros.Network.Mux (MiniProtocolLimits (..))
-import Ouroboros.Network.PeerSelection (AfterSlot (..), DomainAccessPoint (..),
-           LedgerPeersConsensusInterface (..), PeerSelectionActionsTrace,
-           PeerSharing, PortNumber, RelayAccessPoint (..), TraceLedgerPeers,
-           UseLedgerPeers (..))
-import Ouroboros.Network.PeerSelection.Governor (DebugPeerSelection (..),
-           TracePeerSelection)
+import Ouroboros.Network.PeerSelection hiding (peerChurnGovernor,
+           requestPublicRootPeers)
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor
-import Ouroboros.Network.PeerSelection.LedgerPeers (AfterSlot (..),
-           LedgerPeersConsensusInterface (..), TraceLedgerPeers,
-           UseLedgerPeers (..), accPoolStake)
-import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
-import Ouroboros.Network.PeerSelection.PeerStateActions
-           (PeerSelectionActionsTrace)
-import Ouroboros.Network.PeerSelection.RelayAccessPoint
+import Ouroboros.Network.PeerSelection.LedgerPeers (accPoolStake)
 import Ouroboros.Network.PeerSelection.RootPeersDNS
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig, WarmValency (..))
@@ -907,7 +896,7 @@ data DiffusionTestTrace =
       DiffusionLocalRootPeerTrace (TraceLocalRootPeers PeerTrustable NtNAddr SomeException)
     | DiffusionPublicRootPeerTrace TracePublicRootPeers
     | DiffusionLedgerPeersTrace TraceLedgerPeers
-    | DiffusionPeerSelectionTrace (TracePeerSelection Cardano.ExtraState PeerTrustable (Cardano.ExtraPeers NtNAddr) NtNAddr)
+    | DiffusionPeerSelectionTrace (Governor.TracePeerSelection Cardano.ExtraState PeerTrustable (Cardano.ExtraPeers NtNAddr) NtNAddr)
     | DiffusionPeerSelectionActionsTrace (PeerSelectionActionsTrace NtNAddr NtNVersion)
     | DiffusionDebugPeerSelectionTrace (DebugPeerSelection Cardano.ExtraState PeerTrustable (Cardano.ExtraPeers NtNAddr) NtNAddr)
     | DiffusionConnectionManagerTrace

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -83,6 +83,7 @@ instance Arbitrary ArbitraryRelayAccessPoint where
       ArbitraryRelayAccessPoint <$>
         oneof [ RelayAccessAddress (read "1.1.1.1")     . getArbitraryPortNumber <$> arbitrary
               , RelayAccessDomain  "relay.iohk.example" . getArbitraryPortNumber <$> arbitrary
+              , pure $ RelayAccessSRVDomain  "_cardano._tcp.example.org"
               ]
 
 -- TODO: import the `SlotNo` instance from

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -291,8 +291,13 @@ prop_pick100 seed (NonNegative n) (ArbLedgerPeersKind ledgerPeersKind) (MockRoot
 
           withLedgerPeers
                 PeerActionsDNS { paToPeerAddr = curry IP.toSockAddr,
-                                 paDnsActions = (mockDNSActions @SomeException dnsMapVar dnsTimeoutScriptVar dnsLookupDelayScriptVar)
-                               }
+                                 paDnsActions = mockDNSActions @SomeException
+                                                   (Tracer traceM)
+                                                   LookupReqAOnly
+                                                   (curry IP.toSockAddr)
+                                                   dnsMapVar
+                                                   dnsTimeoutScriptVar
+                                                   dnsLookupDelayScriptVar }
                 WithLedgerPeersArgs { wlpRng = rng,
                                       wlpConsensusInterface = interface,
                                       wlpTracer = verboseTracer,
@@ -353,8 +358,13 @@ prop_pick (LedgerPools lps) (ArbLedgerPeersKind ledgerPeersKind) count seed (Moc
 
           withLedgerPeers
                 PeerActionsDNS { paToPeerAddr = curry IP.toSockAddr,
-                                 paDnsActions = mockDNSActions @SomeException dnsMapVar dnsTimeoutScriptVar dnsLookupDelayScriptVar
-                               }
+                                 paDnsActions = mockDNSActions @SomeException
+                                                  (Tracer traceM)
+                                                  LookupReqAOnly
+                                                  (curry IP.toSockAddr)
+                                                  dnsMapVar
+                                                  dnsTimeoutScriptVar
+                                                  dnsLookupDelayScriptVar }
                 WithLedgerPeersArgs { wlpRng = rng,
                                       wlpConsensusInterface = interface,
                                       wlpTracer = verboseTracer,

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -61,8 +61,8 @@ tests = testGroup "Ouroboros.Network.LedgerPeers"
   , testProperty "accumulateBigLedgerStake" prop_accumulateBigLedgerStake
   , testProperty "recomputeRelativeStake" prop_recomputeRelativeStake
   , testProperty "getLedgerPeers invariants" prop_getLedgerPeers
-  , testProperty "LedgerPeerSnapshot CBOR version 1" prop_ledgerPeerSnapshotCBORV1
-  , testProperty "LedgerPeerSnapshot JSON version 1" prop_ledgerPeerSnapshotJSONV1
+  , testProperty "LedgerPeerSnapshot CBOR version 2" prop_ledgerPeerSnapshotCBORV2
+  , testProperty "LedgerPeerSnapshot JSON version 2" prop_ledgerPeerSnapshotJSONV2
   ]
 
 type ExtraTestInterface = ()
@@ -189,7 +189,7 @@ instance Arbitrary ArbStakeMapOverSource where
     (peerMap, bigPeerMap, cachedSlot) <-
       return $ case peerSnapshot of
                  Nothing -> (Map.empty, Map.empty, Nothing)
-                 Just (LedgerPeerSnapshotV1 (At slot, accPools))
+                 Just (LedgerPeerSnapshotV2 (At slot, accPools))
                    -> (Map.fromList accPools, Map.fromList accPools, Just slot)
                  _otherwise -> error "impossible!"
     return $ ArbStakeMapOverSource StakeMapOverSource {
@@ -207,7 +207,7 @@ instance Arbitrary ArbStakeMapOverSource where
       genPeerSnapshot = do
         slotNo <- At . getPositive <$> arbitrary
         pools <- accumulateBigLedgerStake . getLedgerPools <$> arbitrary
-        return $ LedgerPeerSnapshotV1 (slotNo, pools)
+        return $ LedgerPeerSnapshotV2 (slotNo, pools)
 
 -- | This test checks whether requesting ledger peers works as intended
 -- when snapshot data is available. For each request, peers must be returned from the right
@@ -506,10 +506,10 @@ prop_getLedgerPeers (ArbitrarySlotNo curSlot)
 -- | Checks validity of LedgerPeerSnapshot CBOR encoding, and whether
 --   round trip cycle is the identity function
 --
-prop_ledgerPeerSnapshotCBORV1 :: ArbitrarySlotNo
+prop_ledgerPeerSnapshotCBORV2 :: ArbitrarySlotNo
                               -> LedgerPools
                               -> Property
-prop_ledgerPeerSnapshotCBORV1 slotNo
+prop_ledgerPeerSnapshotCBORV2 slotNo
                               ledgerPools =
   counterexample (show snapshot) $
          counterexample ("Invalid CBOR encoding" <> show encoded)
@@ -518,31 +518,31 @@ prop_ledgerPeerSnapshotCBORV1 slotNo
                 (counterexample . ("CBOR round trip failed: " <>) . show <*> (snapshot ==))
                 decoded
   where
-    snapshot = snapshotV1 slotNo ledgerPools
+    snapshot = snapshotV2 slotNo ledgerPools
     encoded = toFlatTerm . toCBOR $ snapshot
     decoded = fromFlatTerm fromCBOR encoded
 
 -- | Tests if LedgerPeerSnapshot JSON round trip is the identity function
 --
-prop_ledgerPeerSnapshotJSONV1 :: ArbitrarySlotNo
+prop_ledgerPeerSnapshotJSONV2 :: ArbitrarySlotNo
                               -> LedgerPools
                               -> Property
-prop_ledgerPeerSnapshotJSONV1 slotNo
+prop_ledgerPeerSnapshotJSONV2 slotNo
                               ledgerPools =
   counterexample (show snapshot) $
      either ((`counterexample` False) . ("JSON decode failed: " <>))
             (counterexample . ("JSON round trip failed: " <>) . show <*> nearlyEqualModuloFullyQualified snapshot)
             roundTrip
   where
-    snapshot = snapshotV1 slotNo ledgerPools
+    snapshot = snapshotV2 slotNo ledgerPools
     roundTrip = case fromJSON . toJSON $ snapshot of
                   Aeson.Success s -> Right s
                   Error str       -> Left str
 
     nearlyEqualModuloFullyQualified snapshotOriginal snapshotRoundTripped =
-      let LedgerPeerSnapshotV1 (wOrigin, relaysWithAccStake) = snapshotOriginal
+      let LedgerPeerSnapshotV2 (wOrigin, relaysWithAccStake) = snapshotOriginal
           strippedRelaysWithAccStake = stripFQN <$> relaysWithAccStake
-          LedgerPeerSnapshotV1 (wOrigin', relaysWithAccStake') = snapshotRoundTripped
+          LedgerPeerSnapshotV2 (wOrigin', relaysWithAccStake') = snapshotRoundTripped
           strippedRelaysWithAccStake' = stripFQN <$> relaysWithAccStake'
       in
              wOrigin === wOrigin'
@@ -555,6 +555,10 @@ prop_ledgerPeerSnapshotJSONV1 slotNo
     step it@(RelayAccessDomain domain port) =
       case BS.unsnoc domain of
         Just (prefix, '.') -> RelayAccessDomain prefix port
+        _otherwise         -> it
+    step it@(RelayAccessSRVDomain domain) =
+      case BS.unsnoc domain of
+        Just (prefix, '.') -> RelayAccessSRVDomain prefix
         _otherwise         -> it
     step it = it
 
@@ -574,11 +578,11 @@ prop_ledgerPeerSnapshotJSONV1 slotNo
 
 -- | helper functions for ledgerpeersnapshot encoding tests
 --
-snapshotV1 :: ArbitrarySlotNo
+snapshotV2 :: ArbitrarySlotNo
            -> LedgerPools
            -> LedgerPeerSnapshot
-snapshotV1 (ArbitrarySlotNo slot)
-           (LedgerPools pools) = LedgerPeerSnapshotV1 (originOrSlot, poolStakeWithAccumulation)
+snapshotV2 (ArbitrarySlotNo slot)
+           (LedgerPools pools) = LedgerPeerSnapshotV2 (originOrSlot, poolStakeWithAccumulation)
   where
     poolStakeWithAccumulation = Map.assocs . accPoolStake $ pools
     originOrSlot = if slot == 0

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -9,18 +9,20 @@
 module Test.Ouroboros.Network.PeerSelection.Instances
   ( -- test types
     PeerAddr (..)
+  , TestSeed (..)
     -- generators
   , genIPv4
   , genIPv6
+  , genPort
     -- generator tests
   , prop_arbitrary_PeerSelectionTargets
   , prop_shrink_PeerSelectionTargets
   ) where
 
+import Data.ByteString.Char8 qualified as BSC
 import Data.Hashable
 import Data.IP qualified as IP
-import Data.Text.Encoding (encodeUtf8)
-import Data.Word (Word32, Word64)
+import Data.Word (Word16, Word32, Word64)
 
 import Cardano.Slotting.Slot (SlotNo (..))
 
@@ -31,8 +33,7 @@ import Ouroboros.Network.PeerSelection.LedgerPeers.Type (AfterSlot (..),
            UseLedgerPeers (..))
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise (..))
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
-import Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
-           RelayAccessPoint (..))
+import Ouroboros.Network.PeerSelection.RelayAccessPoint
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers
            (LocalRootConfig (..))
 
@@ -44,6 +45,15 @@ import Test.QuickCheck
 --
 -- QuickCheck instances
 --
+
+-- | Seed for domain lookups
+--
+newtype TestSeed = TestSeed { unTestSeed :: Int }
+  deriving (Eq, Show)
+
+instance Arbitrary TestSeed where
+  arbitrary = TestSeed <$> chooseInt(minBound, maxBound)
+  shrink _ = []
 
 -- | Simple address representation for the tests
 --
@@ -112,22 +122,13 @@ instance Arbitrary PeerSelectionTargets where
     , let targets' = PeerSelectionTargets r' k' e' a' kb' eb' ab'
     , sanePeerSelectionTargets targets' ]
 
-instance Arbitrary DomainAccessPoint where
-  arbitrary =
-    DomainAccessPoint . encodeUtf8
-      <$> elements domains
-      <*> (fromIntegral <$> (arbitrary :: Gen Int))
-    where
-      domains = [ "test1"
-                , "test2"
-                , "test3"
-                , "test4"
-                , "test5"
-                ]
-
 genIPv4 :: Gen IP.IP
 genIPv4 =
-    IP.IPv4 . IP.toIPv4w <$> arbitrary `suchThat` (> 100)
+    IP.IPv4 . IP.toIPv4w <$> resize 200 arbitrary `suchThat` (> 100)
+
+genPort :: Gen PortNumber
+genPort =
+    fromIntegral <$> (arbitrary :: Gen Word16)
 
 genIPv6 :: Gen IP.IP
 genIPv6 =
@@ -135,18 +136,18 @@ genIPv6 =
   where
     genFourWord32 :: Gen (Word32, Word32, Word32, Word32)
     genFourWord32 =
-       (,,,) <$> arbitrary `suchThat` (> 100)
+       (,,,) <$> resize 200 arbitrary `suchThat` (> 100)
              <*> arbitrary
              <*> arbitrary
              <*> arbitrary
 
 instance Arbitrary RelayAccessPoint where
   arbitrary =
-      oneof [ RelayDomainAccessPoint <$> arbitrary
-            , RelayAccessAddress <$> oneof [genIPv4, genIPv6]
-                                 <*> (fromIntegral
-                                     <$> (arbitrary :: Gen Int))
-            ]
+      frequency [ (4, RelayAccessAddress <$> oneof [genIPv4, genIPv6] <*> genPort)
+                , (4, RelayAccessDomain <$> genDomainName <*> genPort)
+                , (1, RelayAccessSRVDomain <$> genDomainName)]
+    where
+      genDomainName = elements $ (\i -> "test" <> (BSC.pack . show $ i)) <$> [1..6 :: Int]
 
 prop_arbitrary_PeerSelectionTargets :: PeerSelectionTargets -> Bool
 prop_arbitrary_PeerSelectionTargets =

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Json.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Json.hs
@@ -1,11 +1,11 @@
 module Test.Ouroboros.Network.PeerSelection.Json (tests) where
 
 import Data.Aeson (decode, encode, fromJSON, toJSON)
+import Data.ByteString.Char8 (snoc, unsnoc)
 import Test.Ouroboros.Network.PeerSelection.Instances ()
 
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)
-import Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint,
-           RelayAccessPoint)
+import Ouroboros.Network.PeerSelection.RelayAccessPoint (RelayAccessPoint (..))
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -14,27 +14,34 @@ tests :: TestTree
 tests =
   testGroup "Ouroboros.Network.PeerSelection"
   [ testGroup "JSON"
-    [ testProperty "DomainAccessPoint roundtrip" prop_roundtrip_DomainAccessPoint_JSON
-    , testProperty "RelayAccessPoint roundtrip"  prop_roundtrip_RelayAccessPoint_JSON
+    [ testProperty "RelayAccessPoint roundtrip"  prop_roundtrip_RelayAccessPoint_JSON
     , testProperty "PeerAdvertise roundtrip"     prop_roundtrip_PeerAdvertise_JSON
     ]
   ]
 
-prop_roundtrip_DomainAccessPoint_JSON :: DomainAccessPoint -> Property
-prop_roundtrip_DomainAccessPoint_JSON da =
-    decode (encode da) === Just da
-    .&&.
-    fromJSON (toJSON da) === pure da
-
+-- | Test round trip identify, modulo fully qualified domain names
+--
 prop_roundtrip_RelayAccessPoint_JSON :: RelayAccessPoint -> Property
 prop_roundtrip_RelayAccessPoint_JSON ra =
-    decode (encode ra) === Just ra
+    (let tripped = decode (encode ra)
+     in tripped === Just ra .||. tripped === Just (fullyQualified ra))
     .&&.
-    fromJSON (toJSON ra) === pure ra
+    (let tripped = fromJSON (toJSON ra)
+     in tripped === pure ra .||. tripped === pure (fullyQualified ra))
+  where
+    fullyQualified :: RelayAccessPoint -> RelayAccessPoint
+    fullyQualified it@(RelayAccessAddress {}) = it
+    fullyQualified (RelayAccessDomain d p) =
+      RelayAccessDomain (fullyQualified' d) p
+    fullyQualified (RelayAccessSRVDomain d) =
+      RelayAccessSRVDomain (fullyQualified' d)
+
+    fullyQualified' domain = case domain of
+      _ | Just (_, '.') <- unsnoc domain -> domain
+        | otherwise -> domain `snoc` '.'
 
 prop_roundtrip_PeerAdvertise_JSON :: PeerAdvertise -> Property
 prop_roundtrip_PeerAdvertise_JSON pa =
     decode (encode pa) === Just pa
     .&&.
     fromJSON (toJSON pa) === pure pa
-

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -1,10 +1,13 @@
+{-# LANGUAGE BlockArguments      #-}
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE NumericUnderscores  #-}
 {-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
 {-# LANGUAGE TypeApplications    #-}
 
 {-# OPTIONS_GHC -Wno-unused-top-binds #-}
@@ -15,7 +18,12 @@
 module Test.Ouroboros.Network.PeerSelection.RootPeersDNS
   ( tests
   , mockDNSActions
+  , genGroupSrvs
+  , genDomainName
+  , DomainAccessPoint (..)
   , MockRoots (..)
+  , MockDNSMap
+  , MockDNSLookupResult
   , DNSTimeout (..)
   , DNSLookupDelay (..)
   , DelayAndTimeoutScripts (..)
@@ -23,26 +31,34 @@ module Test.Ouroboros.Network.PeerSelection.RootPeersDNS
 
 import Control.Applicative (Alternative)
 import Control.Monad (forever, replicateM_)
+import Data.Bifunctor (bimap)
 import Data.ByteString.Char8 (pack)
 import Data.ByteString.Char8 qualified as BSC
 import Data.Dynamic (Typeable, fromDynamic)
-import Data.Either (rights)
+import Data.Either (fromLeft, rights)
 import Data.Foldable as Foldable (foldl')
 import Data.Function (fix)
 import Data.Functor (void)
-import Data.IP (fromHostAddress, toIPv4w, toSockAddr)
+import Data.IP (fromHostAddress, toSockAddr)
+import Data.List (find, intercalate)
+import Data.List.NonEmpty (NonEmpty (..))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes)
+import Data.Maybe (mapMaybe)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Time.Clock (picosecondsToDiffTime)
 import Data.Void (Void)
-import Network.DNS (DNSError (NameError, TimeoutExpired), Domain, TTL)
+import Data.Word (Word16)
+import Network.DNS (DNSError (NameError), DNSMessage, ResourceRecord (..), TTL,
+           answer, defaultResponse)
+import Network.DNS qualified as DNS
 import Network.DNS.Resolver qualified as DNSResolver
 import Network.Socket (SockAddr (..))
+import System.Random
 
+import Control.Concurrent.Class.MonadSTM qualified as LazySTM
 import Control.Concurrent.Class.MonadSTM.Strict
 import Control.Exception (throw)
 import Control.Monad.Class.MonadAsync
@@ -55,12 +71,8 @@ import Control.Monad.Class.MonadTimer.SI qualified as MonadTimer
 import Control.Monad.IOSim
 import Control.Tracer (Tracer (Tracer), contramap, nullTracer, traceWith)
 
-import Control.Concurrent.Class.MonadSTM qualified as LazySTM
-import Data.List (intercalate)
-import Data.List.NonEmpty (NonEmpty (..))
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
-import Ouroboros.Network.PeerSelection (DomainAccessPoint (..), IP (..),
-           PeerAdvertise (..), RelayAccessPoint (..), TraceLedgerPeers)
+import Ouroboros.Network.PeerSelection
 import Ouroboros.Network.PeerSelection.LedgerPeers
            (resolveTraceToLedgerPeersTrace)
 import Ouroboros.Network.PeerSelection.RootPeersDNS
@@ -68,7 +80,7 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig (..), WarmValency (..))
 import Test.Ouroboros.Network.Data.Script (Script (Script), initScript',
            scriptHead, singletonScript, stepScript')
-import Test.Ouroboros.Network.PeerSelection.Instances ()
+import Test.Ouroboros.Network.PeerSelection.Instances
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -144,41 +156,38 @@ genMockRoots = sized $ \relaysNumber -> do
     --
     relaysPerGroup <- chooseEnum (1, relaysNumber `div` 3)
 
-    localRootRelays <- vectorOf relaysNumber arbitrary
+    -- concat unique identifier to DNS domains to simplify tests
+    taggedLocalRelays <- tagRelays <$> vectorOf relaysNumber arbitrary
     targets <- vectorOf relaysNumber genTargets
-
     peerAdvertise <- blocks relaysPerGroup
                       <$> vectorOf relaysNumber arbitrary
 
-        -- concat unique identifier to DNS domains to simplify tests
-    let taggedLocalRelays = tagRelays localRootRelays
+    let ipsPerDomain = 2
+        genLookup relays = do
+          let (_relayAddress, relayDomains, relaySRVs) =
+                foldl' threeWay ([], [], []) relays
+          lookupIP <- genDomainIPLookupTable ipsPerDomain (dapDomain <$> relayDomains)
+          srvs <- dealDomains relayDomains relaySRVs
+          let srvs' = bimap dapDomain (map dapDomain) <$> srvs
+          lookupSRV <- Map.fromList . map (bimap (,DNS.SRV) Right)
+                       <$> genGroupSrvs srvs'
+          return $ Map.union lookupIP lookupSRV
+
         localRelaysBlocks = blocks relaysPerGroup taggedLocalRelays
         localRelaysMap    = map Map.fromList $ zipWith zip localRelaysBlocks
                                                            peerAdvertise
         localRootPeers    = zipWith (\(h, w) g -> (h, w, g)) targets localRelaysMap
-        localRootDomains  = [ domain
-                            | RelayAccessDomain domain _ <- taggedLocalRelays ]
-
-        ipsPerDomain = 2
 
     lrpDNSMap <- Script . NonEmpty.fromList
-              <$> listOf1 (genDomainLookupTable ipsPerDomain localRootDomains)
+              <$> listOf1 (genLookup taggedLocalRelays)
 
     -- Generate PublicRootPeers
     --
-    publicRootRelays <- vectorOf relaysNumber arbitrary
-    publicRootPeersAdvertise <- vectorOf relaysNumber arbitrary
+    publicRootRelays <- tagRelays <$> vectorOf relaysNumber arbitrary
+    let publicRootAdvertise = vectorOf relaysNumber arbitrary
 
-    let publicRootPeers =
-          Map.fromList (zip (tagRelays publicRootRelays)
-                            publicRootPeersAdvertise)
-
-        publicRootDomains = [ domain
-                            | (RelayAccessDomain domain _, _)
-                                <- Map.assocs publicRootPeers ]
-
-    publicRootPeersDNSMap <- Script . NonEmpty.fromList
-                          <$> listOf1 (genDomainLookupTable ipsPerDomain publicRootDomains)
+    publicRootPeers <- Map.fromList . zip publicRootRelays <$> publicRootAdvertise
+    publicRootPeersDNSMap <- Script . NonEmpty.fromList <$> listOf1 (genLookup publicRootRelays)
 
     return (MockRoots {
       mockLocalRootPeers        = localRootPeers,
@@ -187,57 +196,129 @@ genMockRoots = sized $ \relaysNumber -> do
       mockPublicRootPeersDNSMap = publicRootPeersDNSMap
     })
   where
+    dapDomain (DomainAccessPoint d _p) = d
+    dapDomain (DomainSRVAccessPoint d) = d
+
+    -- assigns some domains to srv records
+    dealDomains :: [DomainAccessPoint]
+                -> [DomainAccessPoint]
+                -> Gen [(DomainAccessPoint, [DomainAccessPoint])]
+    dealDomains = dealDomains' []
+
+    -- kickstart the dealing
+    dealDomains' [] (domain : domains) (srv : srvs') =
+      dealDomains' [(srv, [domain])] domains srvs'
+
+    -- when no more plain domains are available, return empty lookup
+    -- which should trace as an error, but a lookup attempt is registered
+    dealDomains' acc [] (srv : srvs') =
+      dealDomains' ((srv, []):acc) [] srvs'
+
+    -- toss a coin, if True pop a `DomainPlain` and assign it to
+    -- the top srv record. Otherwise, pop the next srv record, and
+    -- associate the plain domain with that one.
+    dealDomains' as'@((s, ds):as) (domain : domains) srvs@(srv : srvs') = do
+      toss <- arbitrary
+      if toss
+        then dealDomains' ((s, domain : ds):as) domains srvs
+        else dealDomains' ((srv, [domain]):as') domains srvs'
+
+    dealDomains' as _ds _srvs = return as
+
+    threeWay :: ([RelayAccessPoint], [DomainAccessPoint], [DomainAccessPoint])
+             -> RelayAccessPoint
+             -> ([RelayAccessPoint], [DomainAccessPoint], [DomainAccessPoint])
+    threeWay (rAddressAcc, rDomainAcc, rSRVAcc) = \case
+      a@RelayAccessAddress {} -> (a : rAddressAcc, rDomainAcc, rSRVAcc)
+      RelayAccessDomain d p  -> (rAddressAcc, DomainAccessPoint d p : rDomainAcc, rSRVAcc)
+      RelayAccessSRVDomain d -> (rAddressAcc, rDomainAcc, DomainSRVAccessPoint d : rSRVAcc)
+
     genTargets :: Gen (HotValency, WarmValency)
     genTargets = do
       warmValency <- WarmValency <$> chooseEnum (1, 5)
       hotValency <- HotValency <$> chooseEnum (1, getWarmValency warmValency)
       return (hotValency, warmValency)
 
-    genDomainLookupTable :: Int -> [Domain] -> Gen (Map Domain [(IP, TTL)])
-    genDomainLookupTable ipsPerDomain localRootDomains = do
+    genDomainIPLookupTable :: Int -> [DNS.Domain] -> Gen (Map (DNS.Domain, DNS.TYPE)
+                                                              MockDNSLookupResult)
+    genDomainIPLookupTable ipsPerDomain localRootDomains = do
       localRootDomainIPs <- blocks ipsPerDomain
               -- Modules under test do not differ by IP version so we only
               -- generate IPv4 addresses.
               <$> vectorOf (ipsPerDomain * length localRootDomains)
-                           (IPv4 . toIPv4w <$> arbitrary)
+                           genIPv4
       localRootDomainTTLs <- blocks ipsPerDomain
               <$> vectorOf (ipsPerDomain * length localRootDomains)
                            (arbitrary :: Gen TTL)
 
       let localRootDomainsIP_TTls = zipWith zip localRootDomainIPs localRootDomainTTLs
-          lrpDNSMap = Map.fromList $ zip localRootDomains localRootDomainsIP_TTls
+          rootDomainKeys = (, DNS.A) <$> localRootDomains
+          lrpDNSMap = Map.fromList $ zip rootDomainKeys (Left <$> localRootDomainsIP_TTls)
 
       return lrpDNSMap
 
-    tagRelays relays =
+    tagRelays =
       zipWith
         (\tag rel
           -> case rel of
-               RelayAccessDomain domain port
-                 -> RelayAccessDomain (domain <> (pack . show) tag) port
+               RelayAccessDomain domain port ->
+                 RelayAccessDomain (domain <> (pack . show) tag) port
+               RelayAccessSRVDomain domain ->
+                 RelayAccessSRVDomain (domain <> (pack . show) tag)
                x -> x
         )
         [(0 :: Int), 1 .. ]
-        relays
 
     blocks _ [] = []
     blocks s l  = take s l : blocks s (drop s l)
 
+-- assigns weights and priorities to SRV record's subordinate domains
+-- such that several subdomains may have the same priority level and port
+-- number, and each one will have a random weight, and result is shuffled
+--
+genGroupSrvs :: (Arbitrary prio, Arbitrary wt)
+             => [(srv, [subordinate])]
+             -> Gen [(srv, [(subordinate, prio, wt, PortNumber)])]
+genGroupSrvs = go []
+ where
+  go acc [] = return acc
+  go acc ((srv, subordinates):srvs) = do
+    let worker grouped 0 _ = shuffle grouped
+        worker grouped count domains' = do
+          howMany <- chooseInt (1, count)
+          port <- genPort
+          prio <- arbitrary
+          wts <- vectorOf howMany arbitrary
+          let group = take howMany domains'
+              smash dom wt = (dom, prio, wt, port)
+              grouped' = zipWith smash group wts
+                         <> grouped
+          worker grouped' (count - howMany) (drop howMany domains')
+    organized <- worker [] (length subordinates) subordinates
+    go ((srv, organized) : acc) srvs
+
 instance Arbitrary MockRoots where
     arbitrary = genMockRoots
-    shrink roots@MockRoots { mockLocalRootPeers
-                           , mockLocalRootPeersDNSMap
-                           , mockPublicRootPeers
-                           , mockPublicRootPeersDNSMap
-                           } =
+    shrink roots@MockRoots
+      { mockLocalRootPeers
+      , mockLocalRootPeersDNSMap
+      , mockPublicRootPeers
+      , mockPublicRootPeersDNSMap
+      } =
       [ roots { mockLocalRootPeers        = lrp
               , mockLocalRootPeersDNSMap  = lrpDNSMap
               }
       | lrp <- shrinkList (const []) mockLocalRootPeers,
         let lrpDomains =
-              Set.fromList [ domain
-                           | RelayAccessDomain domain _
-                              <- concatMap (Map.keys . thrd) lrp ]
+              Set.fromList $
+                concatMap
+                  (mapMaybe
+                    (\case
+                        RelayAccessDomain d _p -> Just (d, DNS.A)
+                        RelayAccessSRVDomain d -> Just (d, DNS.SRV)
+                        _otherwise -> Nothing)
+                    . Map.keys . thrd)
+                  lrp
             lrpDNSMap  = (`Map.restrictKeys` lrpDomains)
                        <$> mockLocalRootPeersDNSMap
       ] ++
@@ -245,9 +326,13 @@ instance Arbitrary MockRoots where
               , mockPublicRootPeersDNSMap = prpDNSMap
               }
       | prp <- shrink mockPublicRootPeers,
-        let prpDomains = Set.fromList [ domain
-                                      | (RelayAccessDomain domain _, _)
-                                          <- Map.assocs prp ]
+        let prpDomains = Set.fromList $
+              mapMaybe
+                ((\case
+                    RelayAccessDomain d _p -> Just (d, DNS.A)
+                    RelayAccessSRVDomain d -> Just (d, DNS.SRV)
+                    _otherwise -> Nothing) . fst)
+               (Map.assocs prp)
             prpDNSMap  = (`Map.restrictKeys` prpDomains)
                        <$> mockPublicRootPeersDNSMap
       ]
@@ -272,7 +357,7 @@ simpleMockRoots = MockRoots localRootPeers dnsMap Map.empty (singletonScript Map
         )
       ]
     dnsMap = singletonScript $ Map.fromList
-              [ ("test.domain", [read "192.1.1.1", read "192.2.2.2"])
+              [ (("test.domain", DNS.A), Left [read "192.1.1.1", read "192.2.2.2"])
               ]
 
 
@@ -313,44 +398,58 @@ instance Arbitrary DNSLookupDelay where
 -- | Mock DNSActions data structure for testing purposes.
 -- Adds DNS Lookup function for IOSim with different timeout and lookup
 -- delays for every attempt.
-mockDNSActions :: forall exception m.
+mockDNSActions :: forall exception peerAddr m.
                   ( MonadDelay m
                   , MonadTimer m
+                  , MonadAsync m
                   )
-               => StrictTVar m (Map Domain [(IP, TTL)])
+               => Tracer m DNSTrace
+               -> DNSLookupType
+               -> (IP -> PortNumber -> peerAddr)
+               -> StrictTVar m MockDNSMap
                -> StrictTVar m (Script DNSTimeout)
                -> StrictTVar m (Script DNSLookupDelay)
-               -> DNSActions () exception m
-mockDNSActions dnsMapVar dnsTimeoutScript dnsLookupDelayScript =
+               -> DNSActions peerAddr () exception m
+mockDNSActions tracer ofType0 toPeerAddr dnsMapVar dnsTimeoutScript dnsLookupDelayScript =
     DNSActions {
       dnsResolverResource,
       dnsAsyncResolverResource,
-      dnsLookupWithTTL
+      dnsLookupWithTTL = dispatchLookupWithTTL ofType0 mockLookup tracer toPeerAddr
     }
  where
    dnsResolverResource      _ = return (Right <$> constantResource ())
    dnsAsyncResolverResource _ = return (Right <$> constantResource ())
 
-   dnsLookupWithTTL :: resolvConf
-                    -> resolver
-                    -> Domain
-                    -> m ([DNSError], [(IP, TTL)])
-   dnsLookupWithTTL _ _ domain = do
+   mockLookup :: resolver
+              -> resolvConf
+              -> DNS.Domain
+              -> DNS.TYPE
+              -> m (Maybe (Either DNSError DNSMessage))
+   mockLookup _ _ domain ofType = do
      dnsMap <- readTVarIO dnsMapVar
      DNSTimeout dnsTimeout <- stepScript' dnsTimeoutScript
      DNSLookupDelay dnsLookupDelay <- stepScript' dnsLookupDelayScript
 
-     dnsLookup <-
-        MonadTimer.timeout dnsTimeout $ do
-          MonadTimer.threadDelay dnsLookupDelay
-          case Map.lookup domain dnsMap of
-            Nothing -> return (Left NameError)
-            Just x  -> return (Right x)
+     MonadTimer.timeout dnsTimeout do
+       MonadTimer.threadDelay dnsLookupDelay
+       case Map.lookup (domain, ofType) dnsMap of
+         Nothing -> return (Left NameError)
+         Just x  -> return (Right $ toDNSMessage x)
 
-     case dnsLookup of
-       Nothing        -> return ([TimeoutExpired], [])
-       Just (Left e)  -> return ([e], [])
-       Just (Right a) -> return ([], a)
+     where
+       toDNSMessage = \case
+         Left ipsttls ->
+           defaultResponse {
+             answer = [ResourceRecord domain DNS.NULL 0 ttl rdata
+                      | (ip, ttl) <- ipsttls
+                      , let rdata = case ip of
+                              IPv4 ip' -> DNS.RD_A ip'
+                              IPv6 ip' -> DNS.RD_AAAA ip']}
+         Right ds ->
+           defaultResponse {
+             answer = [ResourceRecord domain DNS.NULL 0 0 rdata
+                      | (domain', prio, weight, port) <- ds
+                      , let rdata = DNS.RD_SRV prio weight (fromIntegral port) domain']}
 
 -- | 'localRootPeersProvider' running with a given MockRoots env
 --
@@ -363,13 +462,14 @@ mockLocalRootPeersProvider :: forall m.
                               , MonadTraceSTM m
                               , MonadLabelledSTM m
                               )
-                           => Tracer m (TraceLocalRootPeers () SockAddr Failure)
+                           => Tracer m (TestTraceEvent (TraceLocalRootPeers () SockAddr Failure))
                            -> MockRoots
                            -> Script DNSTimeout
                            -> Script DNSLookupDelay
+                           -> TestSeed
                            -> m ()
 mockLocalRootPeersProvider tracer (MockRoots localRootPeers dnsMapScript _ _)
-                           dnsTimeoutScript dnsLookupDelayScript = do
+                           dnsTimeoutScript dnsLookupDelayScript dnsSeed = do
       dnsMapScriptVar <- initScript' dnsMapScript
       dnsMap <- stepScript' dnsMapScriptVar
       dnsMapVar <- newTVarIO dnsMap
@@ -378,20 +478,22 @@ mockLocalRootPeersProvider tracer (MockRoots localRootPeers dnsMapScript _ _)
       dnsLookupDelayScriptVar <- initScript' dnsLookupDelayScript
       localRootPeersVar <- newTVarIO localRootPeers
       resultVar <- newTVarIO mempty
-      _ <- labelTVarIO resultVar "resultVar"
-      _ <- traceTVarIO resultVar
-                       (\_ a -> pure $ TraceDynamic (LocalRootPeersResults a))
       withAsync (updateDNSMap dnsMapScriptVar dnsMapVar) $ \_ -> do
         void $ MonadTimer.timeout 3600 $
-          localRootPeersProvider tracer
+          localRootPeersProvider (contramap Left tracer)
                                  PeerActionsDNS {
                                    paToPeerAddr = curry toSockAddr,
                                    paDnsActions =
-                                     mockDNSActions dnsMapVar
-                                                    dnsTimeoutScriptVar
-                                                    dnsLookupDelayScriptVar
+                                     mockDNSActions
+                                       (contramap Right tracer)
+                                       LookupReqAOnly
+                                       (curry toSockAddr)
+                                       dnsMapVar
+                                       dnsTimeoutScriptVar
+                                       dnsLookupDelayScriptVar
                                  }
                                  DNSResolver.defaultResolvConf
+                                 (mkStdGen $ unTestSeed dnsSeed)
                                  (readTVar localRootPeersVar)
                                  resultVar
         -- if there's no dns domain, `localRootPeersProvider` will never write
@@ -400,8 +502,8 @@ mockLocalRootPeersProvider tracer (MockRoots localRootPeers dnsMapScript _ _)
         -- once.
         atomically $ readTVar resultVar >>= writeTVar resultVar
   where
-    updateDNSMap :: StrictTVar m (Script (Map Domain [(IP, TTL)]))
-                 -> StrictTVar m (Map Domain [(IP, TTL)])
+    updateDNSMap :: StrictTVar m (Script MockDNSMap)
+                 -> StrictTVar m MockDNSMap
                  -> m Void
     updateDNSMap dnsMapScriptVar dnsMapVar =
       forever $ do
@@ -423,14 +525,15 @@ mockPublicRootPeersProvider :: forall m a.
                                , MonadThrow m
                                , MonadTimer m
                                )
-                            => Tracer m TracePublicRootPeers
+                            => Tracer m (TestTraceEvent TracePublicRootPeers)
                             -> MockRoots
                             -> Script DNSTimeout
                             -> Script DNSLookupDelay
+                            -> TestSeed
                             -> ((Int -> m (Map SockAddr PeerAdvertise, DiffTime)) -> m a)
                             -> m ()
 mockPublicRootPeersProvider tracer (MockRoots _ _ publicRootPeers dnsMapScript)
-                            dnsTimeoutScript dnsLookupDelayScript action = do
+                            dnsTimeoutScript dnsLookupDelayScript dnsSeed action = do
       dnsMapScriptVar <- initScript' dnsMapScript
       dnsMap <- stepScript' dnsMapScriptVar
       dnsMapVar <- newTVarIO dnsMap
@@ -443,31 +546,36 @@ mockPublicRootPeersProvider tracer (MockRoots _ _ publicRootPeers dnsMapScript)
         dnsMap' <- stepScript' dnsMapScriptVar
         atomically (writeTVar dnsMapVar dnsMap')
 
-        publicRootPeersProvider tracer
+        publicRootPeersProvider (contramap Left tracer)
                                 (curry toSockAddr)
                                 dnsSemaphore
                                 DNSResolver.defaultResolvConf
                                 (readTVar publicRootPeersVar)
                                 (mockDNSActions @Failure
-                                                dnsMapVar
-                                                dnsTimeoutScriptVar
-                                                dnsLookupDelayScriptVar)
+                                  (contramap Right tracer)
+                                  LookupReqAOnly
+                                  (curry toSockAddr)
+                                  dnsMapVar
+                                  dnsTimeoutScriptVar
+                                  dnsLookupDelayScriptVar)
+                                (mkStdGen $ unTestSeed dnsSeed)
                                 action
 
 -- | 'resolveDomainAddresses' running with a given MockRoots env
 --
 mockResolveLedgerPeers :: ( MonadAsync m
-                         , MonadDelay m
-                         , MonadThrow m
-                         , MonadTimer m
-                         )
-                       => Tracer m TraceLedgerPeers
+                          , MonadDelay m
+                          , MonadThrow m
+                          , MonadTimer m
+                          )
+                       => Tracer m (TestTraceEvent TraceLedgerPeers)
                        -> MockRoots
                        -> Script DNSTimeout
                        -> Script DNSLookupDelay
-                       -> m (Map DomainAccessPoint (Set SockAddr))
+                       -> TestSeed
+                       -> m (Map DNS.Domain (Set SockAddr))
 mockResolveLedgerPeers tracer (MockRoots _ _ publicRootPeers dnsMapScript)
-                       dnsTimeoutScript dnsLookupDelayScript = do
+                       dnsTimeoutScript dnsLookupDelayScript (TestSeed dnsSeed) = do
       dnsMapScriptVar <- initScript' dnsMapScript
       dnsMap <- stepScript' dnsMapScriptVar
       dnsMapVar <- newTVarIO dnsMap
@@ -476,42 +584,41 @@ mockResolveLedgerPeers tracer (MockRoots _ _ publicRootPeers dnsMapScript)
       dnsTimeoutScriptVar <- initScript' dnsTimeoutScript
       dnsLookupDelayScriptVar <- initScript' dnsLookupDelayScript
       resolveLedgerPeers (resolveTraceToLedgerPeersTrace `contramap` tracer)
-                         (curry toSockAddr)
                          dnsSemaphore
                          DNSResolver.defaultResolvConf
-                         (mockDNSActions @Failure dnsMapVar
-                                                  dnsTimeoutScriptVar
-                                                  dnsLookupDelayScriptVar)
-                         [ domain
-                         | (RelayDomainAccessPoint domain, _)
-                              <- Map.assocs publicRootPeers ]
+                         (mockDNSActions @Failure
+                           (contramap Right tracer)
+                           LookupReqAOnly
+                           (curry toSockAddr)
+                           dnsMapVar
+                           dnsTimeoutScriptVar
+                           dnsLookupDelayScriptVar)
+                         AllLedgerPeers
+                         [ dap
+                         | (relay, _) <- Map.assocs publicRootPeers
+                         , dap <- case relay of
+                             RelayAccessAddress {} -> []
+                             x                     -> [x]]
+                         (mkStdGen dnsSeed)
 
 --
 -- Utils for properties
 --
 
-data TestTraceEvent = RootPeerDNSLocal  (TraceLocalRootPeers () SockAddr Failure)
-                    | LocalRootPeersResults [(HotValency, WarmValency, Map SockAddr (LocalRootConfig ()))]
-                    | RootPeerDNSPublic TracePublicRootPeers
-  deriving Show
+type TestTraceEvent a = Either a DNSTrace
 
-tracerTraceLocalRoots :: Tracer (IOSim s) (TraceLocalRootPeers () SockAddr Failure)
-tracerTraceLocalRoots = contramap RootPeerDNSLocal tracerTestTraceEvent
+tracerTraceLocalRoots :: Tracer (IOSim s) (TestTraceEvent (TraceLocalRootPeers () SockAddr Failure))
+tracerTraceLocalRoots = Tracer traceM
 
-tracerTracePublicRoots :: Tracer (IOSim s) TracePublicRootPeers
-tracerTracePublicRoots = contramap RootPeerDNSPublic tracerTestTraceEvent
+tracerTracePublicRoots :: Tracer (IOSim s) (TestTraceEvent TracePublicRootPeers)
+tracerTracePublicRoots = Tracer traceM
 
-tracerTestTraceEvent :: Tracer (IOSim s) TestTraceEvent
-tracerTestTraceEvent = dynamicTracer
-
-dynamicTracer :: Typeable a => Tracer (IOSim s) a
-dynamicTracer = Tracer traceM
-
-selectRootPeerDNSTraceEvents :: SimTrace a -> [(Time, TestTraceEvent)]
-selectRootPeerDNSTraceEvents = go
+selectTestTraceEvents :: (Typeable b) => SimTrace a
+                      -> [(Time, TestTraceEvent b)]
+selectTestTraceEvents = go
   where
     go (SimTrace t _ _ (EventLog e) trace)
-     | Just x <- fromDynamic e       = (t,x) : go trace
+     | Just x <- fromDynamic e = (t, x) : go trace
     go (SimPORTrace t _ _ _ (EventLog e) trace)
      | Just x <- fromDynamic e       = (t,x) : go trace
     go (SimTrace _ _ _ _ trace)      =         go trace
@@ -522,38 +629,39 @@ selectRootPeerDNSTraceEvents = go
     go (TraceInternalError e)        = error ("IOSim: " ++ e)
     go TraceLoop                     = error "IOSimPOR step time limit exceeded"
 
-selectLocalRootPeersEvents :: [(Time, TestTraceEvent)]
-                           -> [(Time, TraceLocalRootPeers () SockAddr Failure)]
-selectLocalRootPeersEvents trace = [ (t, e) | (t, RootPeerDNSLocal e) <- trace ]
+selectLocalRootPeersWithDNSEvents :: SimTrace a
+                                  -> [(Time, TestTraceEvent (TraceLocalRootPeers () SockAddr Failure))]
+selectLocalRootPeersWithDNSEvents = filter them . selectTestTraceEvents
+  where
+    them (_t, Right dns) =
+      case dns of
+        (DNSResult DNSLocalPeer _ _ _)           -> True
+        (DNSTraceLookupError DNSLocalPeer _ _ _) -> True
+        (DNSSRVFail DNSLocalPeer _)              -> True
+        _otherwise                               -> False
+    them _ = True
 
-selectLocalRootPeersResults :: [(Time, TestTraceEvent)]
+selectLocalRootGroupsEvents :: [(Time, TestTraceEvent (TraceLocalRootPeers () SockAddr Failure))]
                             -> [(Time, [(HotValency, WarmValency, Map SockAddr (LocalRootConfig ()))])]
-selectLocalRootPeersResults trace = [ (t, r) | (t, LocalRootPeersResults r) <- trace ]
+selectLocalRootGroupsEvents trace = [ (t, r)
+                                    | (t, Left (TraceLocalRootGroups r)) <- trace ]
 
-selectLocalRootGroupsEvents :: [(Time, TraceLocalRootPeers () SockAddr Failure)]
-                            -> [(Time, [( HotValency
-                                        , WarmValency
-                                        , Map SockAddr (LocalRootConfig ()))])]
-selectLocalRootGroupsEvents trace = [ (t, e) | (t, TraceLocalRootGroups e) <- trace ]
+selectPublicRootPeersWithDNSEvents :: SimTrace a
+                                   -> [(Time, TestTraceEvent TracePublicRootPeers)]
+selectPublicRootPeersWithDNSEvents = filter them . selectTestTraceEvents
+  where
+    them (_t, Right dns) =
+      case dns of
+        (DNSResult DNSPublicPeer _ _ _)           -> True
+        (DNSTraceLookupError DNSPublicPeer _ _ _) -> True
+        (DNSSRVFail DNSPublicPeer _)              -> True
+        _otherwise                                -> False
+    them _ = True
 
-selectLocalRootResultEvents :: [(Time, TraceLocalRootPeers () SockAddr Failure)]
-                            -> [(Time, (Domain, [IP]))]
-selectLocalRootResultEvents trace = [ (t, (domain, map fst r))
-                                    | (t, TraceLocalRootResult (DomainAccessPoint domain _) r) <- trace ]
-
-selectPublicRootPeersEvents :: [(Time, TestTraceEvent)]
-                            -> [(Time, TracePublicRootPeers)]
-selectPublicRootPeersEvents trace = [ (t, e) | (t, RootPeerDNSPublic e) <- trace ]
-
-selectPublicRootFailureEvents :: [(Time, TracePublicRootPeers)]
-                              -> [(Time, Domain)]
-selectPublicRootFailureEvents trace = [ (t, domain)
-                                      | (t, TracePublicRootFailure domain _) <- trace ]
-
-selectPublicRootResultEvents :: [(Time, TracePublicRootPeers)]
-                             -> [(Time, (Domain, [IP]))]
-selectPublicRootResultEvents trace = [ (t, (domain, map fst r))
-                                     | (t, TracePublicRootResult domain r) <- trace ]
+selectDnsResultEvents :: [(Time, TestTraceEvent a)]
+                      -> [(Time, DNSTrace)]
+selectDnsResultEvents trace = [(t, r)
+                              | (t, Right r@(DNSResult {})) <- trace]
 
 --
 -- Local Root Peers Provider Tests
@@ -565,17 +673,20 @@ selectPublicRootResultEvents trace = [ (t, (domain, map fst r))
 prop_local_preservesIPs :: MockRoots
                         -> Script DNSTimeout
                         -> Script DNSLookupDelay
+                        -> TestSeed
                         -> Property
 prop_local_preservesIPs mockRoots@(MockRoots localRoots _ _ _)
                         dnsTimeoutScript
-                        dnsLookupDelayScript =
-    let tr = selectLocalRootPeersResults
-           $ selectRootPeerDNSTraceEvents
+                        dnsLookupDelayScript
+                        dnsSeed =
+    let tr = selectLocalRootGroupsEvents
+           $ selectLocalRootPeersWithDNSEvents
            $ runSimTrace
            $ mockLocalRootPeersProvider tracerTraceLocalRoots
                                         mockRoots
                                         dnsTimeoutScript
                                         dnsLookupDelayScript
+                                        dnsSeed
 
      in counterexample (intercalate "\n" $ map show tr)
       $ classify (length tr > 0) "Actually testing something"
@@ -623,17 +734,20 @@ prop_local_preservesIPs mockRoots@(MockRoots localRoots _ _ _)
 prop_local_preservesGroupNumberAndTargets :: MockRoots
                                           -> Script DNSTimeout
                                           -> Script DNSLookupDelay
+                                          -> TestSeed
                                           -> Property
 prop_local_preservesGroupNumberAndTargets mockRoots@(MockRoots lrp _ _ _)
                                           dnsTimeoutScript
-                                          dnsLookupDelayScript =
-    let tr = selectLocalRootPeersResults
-           $ selectRootPeerDNSTraceEvents
+                                          dnsLookupDelayScript
+                                          dnsSeed =
+    let tr = selectLocalRootGroupsEvents
+           $ selectLocalRootPeersWithDNSEvents
            $ runSimTrace
            $ mockLocalRootPeersProvider tracerTraceLocalRoots
                                         mockRoots
                                         dnsTimeoutScript
                                         dnsLookupDelayScript
+                                        dnsSeed
 
         -- For all LocalRootGroup results, the number of groups should be
         -- preserved, i.e. no new groups are added nor deleted along the
@@ -657,64 +771,77 @@ prop_local_preservesGroupNumberAndTargets mockRoots@(MockRoots lrp _ _ _)
 prop_local_resolvesDomainsCorrectly :: MockRoots
                                     -> Script DNSTimeout
                                     -> Script DNSLookupDelay
+                                    -> TestSeed
                                     -> Property
 prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots localRoots lDNSMap _ _)
                                     dnsTimeoutScript
-                                    dnsLookupDelayScript =
+                                    dnsLookupDelayScript
+                                    dnsSeed =
     let mockRoots' =
           mockRoots { mockLocalRootPeersDNSMap =
                         singletonScript (scriptHead lDNSMap)
                     }
-        tr = selectLocalRootPeersEvents
-           $ selectRootPeerDNSTraceEvents
+        tr = selectLocalRootPeersWithDNSEvents
            $ runSimTrace
            $ mockLocalRootPeersProvider tracerTraceLocalRoots
                                         mockRoots'
                                         dnsTimeoutScript
                                         dnsLookupDelayScript
+                                        dnsSeed
 
         -- local root domains
-        localRootDomains :: Set Domain
+        localRootDomains :: Set (DNS.Domain, DNS.TYPE)
         localRootDomains =
           Set.fromList
-          [ domain
+          [ item
           | (_, _, m) <- localRoots
-          , RelayAccessDomain domain _ <- Map.keys m
+          , item <- flip mapMaybe (Map.keys m) \case
+              RelayAccessDomain d _p -> Just (d, DNS.A)
+              RelayAccessSRVDomain d -> Just (d, DNS.SRV)
+              _otherwise -> Nothing
           ]
 
         -- domains that were resolved during simulation
-        resultMap :: Set Domain
+        resultMap :: Set (DNS.Domain, DNS.TYPE)
         resultMap = Set.fromList
-                  $ map (fst . snd)
-                  $ selectLocalRootResultEvents
-                  $ tr
+                    $ mapMaybe (filtering . snd)
+                    $ selectDnsResultEvents
+                    $ tr
+          where
+            filtering = \case
+              DNSResult _ domain Nothing _ -> Just (domain, DNS.A)
+              DNSResult _ _ (Just domain) _ -> Just (domain, DNS.SRV)
+              _otherwise -> Nothing
 
         -- all domains that could have been resolved in each script
-        maxResultMap :: Script (Set Domain)
+        maxResultMap :: Script (Set (DNS.Domain, DNS.TYPE))
         maxResultMap = Map.keysSet
-                     . (`Map.restrictKeys` localRootDomains)
-                     <$> lDNSMap
+                       . (`Map.restrictKeys` localRootDomains)
+                       <$> lDNSMap
 
         -- all domains that were tried to resolve during the simulation
-        allTriedDomains :: Set Domain
-        allTriedDomains
-          = Set.fromList
-          $ catMaybes
-          [ mbDomain
-          | (_, ev) <- tr
-          , let mbDomain = case ev of
-                  TraceLocalRootResult  (DomainAccessPoint domain _)  _ -> Just domain
-                  TraceLocalRootFailure (DomainAccessPoint domain _)  _ -> Just domain
-                  TraceLocalRootError   (DomainAccessPoint _domain _) _ -> Nothing
-                  _                                                     -> Nothing
-
-          ]
-
-
+        allTriedDomains :: Set (DNS.Domain, DNS.TYPE)
+        allTriedDomains = Set.fromList
+                          $ map filtering
+                          $ mapMaybe (selectDnsTraces . snd)
+                          $ tr
+          where
+            filtering = \case
+              DNSResult _ domain Nothing _ -> (domain, DNS.A)
+              DNSResult _ _ (Just domain) _ -> (domain, DNS.SRV)
+              DNSSRVFail _ domain -> (domain, DNS.SRV)
+              DNSTraceLookupError _ Nothing srvDomain _ -> (srvDomain, DNS.SRV)
+              DNSTraceLookupError _ (Just _) domain _ -> (domain, DNS.A)
+            selectDnsTraces = \case
+              Right trace -> Just trace
+              Left  _ -> Nothing
     in
       -- we verify that we tried to resolve all local root domains, and that the
       -- resolved ones are a subset of `maxResultMap`
-           localRootDomains === allTriedDomains
+           counterexample ("violation: localRootDomains isSubsetOf allTriedDomains\nlocalRootDomains: "
+                           <> show localRootDomains
+                           <> "\nallTriedDomains: " <> show allTriedDomains) $
+           localRootDomains `Set.isSubsetOf` allTriedDomains
       .&&. foldr (\rm r -> counterexample (show resultMap ++ " is subset of "
                                      ++ show rm)
                           (resultMap `Set.isSubsetOf` rm)
@@ -736,22 +863,24 @@ prop_local_resolvesDomainsCorrectly mockRoots@(MockRoots localRoots lDNSMap _ _)
 prop_local_updatesDomainsCorrectly :: MockRoots
                                    -> Script DNSTimeout
                                    -> Script DNSLookupDelay
+                                   -> TestSeed
                                    -> Property
 prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
                                    dnsTimeoutScript
-                                   dnsLookupDelayScript =
-    let tr = selectLocalRootPeersEvents
-           $ selectRootPeerDNSTraceEvents
+                                   dnsLookupDelayScript
+                                   dnsSeed =
+    let tr = selectLocalRootPeersWithDNSEvents
            $ runSimTrace
            $ mockLocalRootPeersProvider tracerTraceLocalRoots
                                         mockRoots
                                         dnsTimeoutScript
                                         dnsLookupDelayScript
+                                        dnsSeed
 
         r = Foldable.foldl' (\(b, (t, x)) (t', y) ->
                     case (x, y) of
                       -- Last result groups value, Current result groups value
-                      (TraceLocalRootGroups lrpg, TraceLocalRootGroups lrpg') ->
+                      (Left (TraceLocalRootGroups lrpg), Left (TraceLocalRootGroups lrpg')) ->
                         let -- Get all IPs present in last group at position
                             -- 'index'
                             ipsAtIndex = Map.keys
@@ -766,15 +895,20 @@ prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
 
                          in (arePreserved && b, (t', y))
                       -- Last DNS lookup result   , Current result groups value
-                      (TraceLocalRootResult da res, TraceLocalRootGroups lrpg) ->
-                            -- create and index db for each group
-                        let db = zip [0,1..] lrp
+                      (Right (DNSResult _ dFollow dSRV ipsttls@(ipttl : _)), Left (TraceLocalRootGroups lrpg)) ->
+                        -- create and index db for each group
+                        let rap =
+                              case dSRV of
+                                Just dSRV' -> RelayAccessSRVDomain dSRV'
+                                Nothing    -> RelayAccessDomain dFollow (port ipttl)
+
+                            db = zip [0,1..] lrp
                             -- since our MockRoots generator generates
                             -- unique domain addresses we can look for
                             -- which group index does a particular domain
                             -- address belongs
                             index = foldr (\(i, (_, _, m)) prev ->
-                                            case Map.lookup (RelayDomainAccessPoint da) m of
+                                            case Map.lookup rap m of
                                               Nothing -> prev
                                               Just _  -> i
                                           ) (-1) db
@@ -784,7 +918,7 @@ prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
                                              case sockAddr of
                                                SockAddrInet _ hostAddr
                                                  -> IPv4 $ fromHostAddress hostAddr
-                                               _ -> error "Impossible happened!"
+                                               _ -> error $ show sockAddr --error "Impossible happened!"
 
                                          ) $ Map.keys
                                            $ thrd
@@ -792,17 +926,21 @@ prop_local_updatesDomainsCorrectly mockRoots@(MockRoots lrp _ _ _)
                             -- Check if all ips from the previous DNS
                             -- lookup result are present in the current
                             -- result group at the correct index
-                            arePresent = all ((`elem` ipsAtIndex) . fst) res
+                            arePresent = all ((`elem` ipsAtIndex) . ip) ipsttls
                          in (arePresent && b, (t', y))
-
-                      (TraceLocalRootResult _ _, _) -> (b, (t, x))
-                      (_, _)                        -> (b, (t', y))
+                      -- the empty DNS result trivially passes
+                      (Right (DNSResult _ _ _ []), Left (TraceLocalRootGroups {})) ->
+                        (b, (t', y))
+                      (Right {}, _) -> (b, (t, x))
+                      (_, _)        -> (b, (t', y))
                    )
               (True, head tr)
               (tail tr)
      in property (fst r)
   where
     thrd (_, _, c) = c
+    port (_, it, _) = it
+    ip   (it, _, _) = it
 
 --
 -- Public Root Peers Provider Tests
@@ -858,32 +996,70 @@ instance Arbitrary DelayAndTimeoutScripts where
 prop_public_resolvesDomainsCorrectly :: MockRoots
                                      -> DelayAndTimeoutScripts
                                      -> Int
+                                     -> TestSeed
                                      -> Property
 prop_public_resolvesDomainsCorrectly
     mockRoots@(MockRoots _ _ _ pDNSMap)
     (DelayAndTimeoutScripts dnsLookupDelayScript dnsTimeoutScript)
     n
+    dnsSeed
   =
-    let mockRoots' =
-          mockRoots { mockPublicRootPeersDNSMap =
-                        singletonScript (scriptHead pDNSMap)
-                    }
+    let pDNSMap' = scriptHead pDNSMap
+        mockPublicRootPeersDNSMap = singletonScript pDNSMap'
+        mockRoots' =
+          mockRoots { mockPublicRootPeersDNSMap }
         tr = runSimTrace
            $ mockPublicRootPeersProvider tracerTracePublicRoots
                                          mockRoots'
                                          dnsTimeoutScript
                                          dnsLookupDelayScript
+                                         dnsSeed
                                          ($ n)
 
-        successes = selectPublicRootResultEvents
-                  $ selectPublicRootPeersEvents
-                  $ selectRootPeerDNSTraceEvents
+        successes = selectDnsResultEvents @TracePublicRootPeers
+                  $ selectTestTraceEvents
                   $ tr
 
-        successesMap = Map.fromList $ map snd successes
+        successes' = map snd successes
 
-     in counterexample (show successes)
-      $ successesMap == (map fst <$> Map.unions pDNSMap)
+        step (DNSResult _ "" (Just srvDomain) []) r =
+          counterexample "SRV record not found in mock lookup map" $
+            Map.member (srvDomain, DNS.SRV) pDNSMap' .&&. r
+        step (DNSResult _ domain srvDomain ipsttls) r =
+          case srvDomain of
+            Nothing ->
+               counterexample "DNS.A IP mismatch error" $
+                 (fromLookup === fromTrace) .&&. r
+               where
+                 fromLookup =
+                  fst <$> fromLeft (error e) (pDNSMap' Map.! (domain, DNS.A))
+                 e = "Domain " <> show domain <> " not found in lookup map"
+                 fromTrace = ip <$> ipsttls
+            Just srvDomain' ->
+              counterexample "SRV lookup error" $
+                case Map.lookup (srvDomain', DNS.SRV) pDNSMap' of
+                  Nothing -> property False
+                  Just (Left {}) -> property False
+                  Just (Right ds) ->
+                    case find ((domain ==) . dFollow) ds of
+                      Nothing -> property False
+                      Just (d, _, _, _) ->
+                        counterexample "IP mismatch" $
+                          fromLookup === fromTrace .&&. r
+                        where
+                          fromLookup =
+                            fst <$> fromLeft (error err) (pDNSMap' Map.! (d, DNS.A))
+                          err = "Domain " <> show d <> " from SRV lookup of " <> show srvDomain'
+                                <> " not found."
+                          fromTrace = ip <$> ipsttls
+
+        step _ _ = error "impossible!"
+     in
+       foldr step (property True) successes'
+  where
+    ip (it, _, _) = it
+    dFollow (it, _, _, _) = it
+
 
 
 -- | Create a resource from a list.


### PR DESCRIPTION
# Description

This change introduces support for DNS SRV record lookups. When a relay is associated via SRV record, a two step resolution is attempted to first identify the relevant domains from which to make a secondary lookup to obtain the final address. All lookups are early bound in the sense that only the domains with top priority (ie. with the lowest priority numeric value in the record) are considered, and afterwards a single domain is randomly sampled it is queried for the address. If the lookup fails it is not retried.

The tracing of dns lookups has been reworked. The tracing happens in the `DNSActions`'s `dnsLookupWithTTL` function, and the corresponding constructors from eg. `TraceLocalRootPeers` (and for Public and Ledger types) have been removed. This simplifies the logic in `localRootsPeersProvider`, `publicRootPeersProvider` and `resolveLedgerPeers` functions since the lookup doesn't have to return additional information regarding the domain names which have been resolved, which is used in the testing framework. But the main impetus was to extend test coverage to include the lookup functionality, which previously was excluded as only a map lookup was performed by the mock. Also, the tracing of dns lookups can now be performed via a dedicated dns tracer, which must be plumbed from the top level.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
