### PR TITLE
add mapTraceFetchClientState

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Non-Breaking changes
 
+* Added the `mapTraceFetchClientState` function
+
 ## 0.18.0.0 -- 2024-10-17
 
 ### Breaking changes


### PR DESCRIPTION
# Description

Merely adding

```
mapTraceFetchClientState ::
     (HeaderHash h1 ~ HeaderHash h2, HasHeader h2)
  => (h1 -> h2) -> TraceFetchClientState h1 -> TraceFetchClientState h2
```

A Consensus PR I'm working on passes in an annotated header to BlockFetch, but I'd like to (at least for now) hide that fact from the downstream tracers. So I need to discard that annotation data from the content of this tracer event, which this function makes possible.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
