### PR TITLE
Renamed test modules

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -16,6 +16,13 @@
   affects its API.
 * Added `connStateSupply` record field to
   `Ouroboros.Network.ConnectionManager.Core.Arguments`.
+* Renamed modules in `ouroboros-network:testlib`:
+  `Ouroboros.Network.Test.Orphans -> Test.Ouroboros.Network.Orphans`
+  `Ouroboros.Network.ConnectionManager.Test.Experiments -> Test.Ouroboros.Network.ConnectionManager.Experiments`
+  `Ouroboros.Network.ConnectionManager.Test.Timeouts -> Test.Ouroboros.Network.ConnectionManager.Timeouts`
+  `Ouroboros.Network.ConnectionManager.Test.Utils -> Test.Ouroboros.Network.ConnectionManager.Utils`
+  `Ouroboros.Network.InboundGovernor.Test.Utils -> Test.Ouroboros.Network.InboundGovernor.Utils`
+
 
 ### Non-breaking changes
 

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Driver.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Driver.hs
@@ -60,7 +60,7 @@ import Control.Monad.Class.MonadTimer.SI
 import Control.Monad.IOSim
 import Control.Tracer
 
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/RawBearer.hs
@@ -8,8 +8,8 @@ module Test.Ouroboros.Network.RawBearer where
 
 import Ouroboros.Network.IOManager
 import Ouroboros.Network.RawBearer
-import Ouroboros.Network.RawBearer.Test.Utils
 import Ouroboros.Network.Snocket
+import Test.Ouroboros.Network.RawBearer.Utils
 
 import Control.Concurrent.Class.MonadMVar
 import Control.Monad.Class.MonadThrow (catchJust, finally)

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Server2/IO.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Server2/IO.hs
@@ -27,9 +27,9 @@ import Ouroboros.Network.IOManager
 import Ouroboros.Network.Snocket (socketSnocket)
 import Ouroboros.Network.Socket (configureSocket)
 
-import Ouroboros.Network.ConnectionManager.Test.Experiments
-import Ouroboros.Network.ConnectionManager.Test.Timeouts
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.ConnectionManager.Experiments
+import Test.Ouroboros.Network.ConnectionManager.Timeouts
+import Test.Ouroboros.Network.Orphans ()
 
 tests :: TestTree
 tests =

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Socket.hs
@@ -65,7 +65,7 @@ import Ouroboros.Network.Protocol.Handshake.Codec
 import Ouroboros.Network.Protocol.Handshake.Unversioned
 import Ouroboros.Network.Protocol.Handshake.Version
 
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck
 import Test.Tasty (DependencyType (..), TestTree, after, testGroup)

--- a/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/io-tests/Test/Ouroboros/Network/Subscription.hs
@@ -66,7 +66,7 @@ import Ouroboros.Network.Subscription.Subscriber
 import Ouroboros.Network.Subscription.Worker (LocalAddresses (..),
            WorkerParams (..))
 
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -125,12 +125,12 @@ library testlib
   visibility: public
   hs-source-dirs: testlib
   exposed-modules:
-    Ouroboros.Network.ConnectionManager.Test.Experiments
-    Ouroboros.Network.ConnectionManager.Test.Timeouts
-    Ouroboros.Network.ConnectionManager.Test.Utils
-    Ouroboros.Network.InboundGovernor.Test.Utils
-    Ouroboros.Network.RawBearer.Test.Utils
-    Ouroboros.Network.Test.Orphans
+    Test.Ouroboros.Network.ConnectionManager.Experiments
+    Test.Ouroboros.Network.ConnectionManager.Timeouts
+    Test.Ouroboros.Network.ConnectionManager.Utils
+    Test.Ouroboros.Network.InboundGovernor.Utils
+    Test.Ouroboros.Network.Orphans
+    Test.Ouroboros.Network.RawBearer.Utils
 
   other-modules:
   build-depends:

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -61,13 +61,14 @@ import Test.Tasty.QuickCheck (testProperty)
 import Ouroboros.Network.ConnectionId (ConnectionId (..))
 import Ouroboros.Network.ConnectionManager.Core qualified as CM
 import Ouroboros.Network.ConnectionManager.State qualified as CM
-import Ouroboros.Network.ConnectionManager.Test.Utils (verifyAbstractTransition)
 import Ouroboros.Network.ConnectionManager.Types
 import Ouroboros.Network.MuxMode
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.Server.RateLimiting
 import Ouroboros.Network.Snocket (Accept (..), Accepted (..),
            AddressFamily (TestFamily), Snocket (..), TestAddress (..))
+
+import Test.Ouroboros.Network.ConnectionManager.Utils (verifyAbstractTransition)
 
 import Ouroboros.Network.ConnectionManager.InformationChannel
            (newInformationChannel)

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/RawBearer.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/RawBearer.hs
@@ -9,7 +9,6 @@ module Test.Ouroboros.Network.RawBearer where
 import Ouroboros.Network.IOManager
 import Ouroboros.Network.RawBearer
 import Ouroboros.Network.Snocket
-import Ouroboros.Network.Testing.Data.AbsBearerInfo
 
 import Control.Concurrent.Class.MonadMVar
 import Control.Exception (Exception)
@@ -34,6 +33,7 @@ import System.Directory (removeFile)
 import System.IO.Error (ioeGetErrorType, isDoesNotExistErrorType)
 import System.IO.Unsafe
 
+import Test.Ouroboros.Network.Data.AbsBearerInfo
 import Test.Simulation.Network.Snocket (toBearerInfo)
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -98,19 +98,18 @@ import Ouroboros.Network.Testing.Data.AbsBearerInfo hiding (delay)
 import Ouroboros.Network.Testing.Utils (WithName (..), WithTime (..),
            genDelayWithPrecision, nightlyTest, sayTracer, tracerWithTime)
 
-import Ouroboros.Network.Test.Orphans ()
-import Test.Simulation.Network.Snocket hiding (tests)
-
-import Ouroboros.Network.ConnectionManager.Test.Experiments
-import Ouroboros.Network.ConnectionManager.Test.Timeouts
-import Ouroboros.Network.ConnectionManager.Test.Utils
+import Test.Ouroboros.Network.ConnectionManager.Experiments
+import Test.Ouroboros.Network.ConnectionManager.Timeouts
+import Test.Ouroboros.Network.ConnectionManager.Utils
            (abstractStateIsFinalTransition, allValidTransitionsNames,
            validTransitionMap, verifyAbstractTransition,
            verifyAbstractTransitionOrder)
-import Ouroboros.Network.InboundGovernor.Test.Utils
+import Test.Ouroboros.Network.InboundGovernor.Utils
            (allValidRemoteTransitionsNames, remoteStrIsFinalTransition,
            validRemoteTransitionMap, verifyRemoteTransition,
            verifyRemoteTransitionOrder)
+import Test.Ouroboros.Network.Orphans ()
+import Test.Simulation.Network.Snocket hiding (tests)
 
 tests :: TestTree
 tests =

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server2/Sim.hs
@@ -94,21 +94,20 @@ import Ouroboros.Network.Snocket qualified as Snocket
 
 import Simulation.Network.Snocket
 
-import Ouroboros.Network.Testing.Data.AbsBearerInfo hiding (delay)
-import Ouroboros.Network.Testing.Utils (WithName (..), WithTime (..),
-           genDelayWithPrecision, nightlyTest, sayTracer, tracerWithTime)
-
 import Test.Ouroboros.Network.ConnectionManager.Experiments
 import Test.Ouroboros.Network.ConnectionManager.Timeouts
 import Test.Ouroboros.Network.ConnectionManager.Utils
            (abstractStateIsFinalTransition, allValidTransitionsNames,
            validTransitionMap, verifyAbstractTransition,
            verifyAbstractTransitionOrder)
+import Test.Ouroboros.Network.Data.AbsBearerInfo hiding (delay)
 import Test.Ouroboros.Network.InboundGovernor.Utils
            (allValidRemoteTransitionsNames, remoteStrIsFinalTransition,
            validRemoteTransitionMap, verifyRemoteTransition,
            verifyRemoteTransitionOrder)
 import Test.Ouroboros.Network.Orphans ()
+import Test.Ouroboros.Network.Utils (WithName (..), WithTime (..),
+           genDelayWithPrecision, nightlyTest, sayTracer, tracerWithTime)
 import Test.Simulation.Network.Snocket hiding (tests)
 
 tests :: TestTree

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Socket.hs
@@ -67,7 +67,7 @@ import Ouroboros.Network.Protocol.Handshake.Codec
 import Ouroboros.Network.Protocol.Handshake.Unversioned
 import Ouroboros.Network.Protocol.Handshake.Version
 
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck
 import Test.Tasty (DependencyType (..), TestTree, after, testGroup)

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Subscription.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Subscription.hs
@@ -66,7 +66,7 @@ import Ouroboros.Network.Subscription.Subscriber
 import Ouroboros.Network.Subscription.Worker (LocalAddresses (..),
            WorkerParams (..))
 
-import Ouroboros.Network.Test.Orphans ()
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
@@ -59,7 +59,7 @@ import Network.TypedProtocol.ReqResp.Client
 import Network.TypedProtocol.ReqResp.Server
 import Network.TypedProtocol.ReqResp.Type
 
-import Ouroboros.Network.Testing.Data.AbsBearerInfo
+import Test.Ouroboros.Network.Data.AbsBearerInfo
 import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck hiding (Result (..))

--- a/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Simulation/Network/Snocket.hs
@@ -59,8 +59,8 @@ import Network.TypedProtocol.ReqResp.Client
 import Network.TypedProtocol.ReqResp.Server
 import Network.TypedProtocol.ReqResp.Type
 
-import Ouroboros.Network.Test.Orphans ()
 import Ouroboros.Network.Testing.Data.AbsBearerInfo
+import Test.Ouroboros.Network.Orphans ()
 
 import Test.QuickCheck hiding (Result (..))
 import Test.QuickCheck.Instances.ByteString ()

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/State.hs
@@ -38,7 +38,7 @@ import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.ConnectionManager.ConnMap as ConnMap
 import Ouroboros.Network.ConnectionManager.Types
 
-import Ouroboros.Network.Testing.Utils (WithName (..))
+import Test.Ouroboros.Network.Utils (WithName (..))
 
 -- | 'ConnectionManager' state: for each peer we keep a 'ConnectionState' in
 -- a mutable variable, which reduces congestion on the 'TMVar' which keeps

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -84,7 +84,7 @@ import Ouroboros.Network.ConnectionManager.Types (AddressType (..))
 import Ouroboros.Network.RawBearer
 import Ouroboros.Network.Snocket
 
-import Ouroboros.Network.Testing.Data.Script (Script (..), stepScriptSTM)
+import Test.Ouroboros.Network.Data.Script (Script (..), stepScriptSTM)
 
 data Connection m addr = Connection
     { -- | Attenuated channels of a connection.

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
@@ -97,10 +97,10 @@ import Ouroboros.Network.Server2 (RemoteTransitionTrace)
 import Ouroboros.Network.Server2 qualified as Server
 import Ouroboros.Network.Snocket (Snocket)
 import Ouroboros.Network.Snocket qualified as Snocket
-import Ouroboros.Network.Testing.Utils (WithName (..))
 
 import Test.Ouroboros.Network.ConnectionManager.Timeouts
 import Test.Ouroboros.Network.Orphans ()
+import Test.Ouroboros.Network.Utils (WithName (..))
 
 import Ouroboros.Network.ConnectionManager.InformationChannel
            (newInformationChannel)

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
@@ -21,7 +21,7 @@
 -- | This module contains experiments which can be executed either in `IO` or
 -- in `IOSim`.
 --
-module Ouroboros.Network.ConnectionManager.Test.Experiments
+module Test.Ouroboros.Network.ConnectionManager.Experiments
   ( ClientAndServerData (..)
   , unidirectionalExperiment
   , bidirectionalExperiment
@@ -99,12 +99,11 @@ import Ouroboros.Network.Snocket (Snocket)
 import Ouroboros.Network.Snocket qualified as Snocket
 import Ouroboros.Network.Testing.Utils (WithName (..))
 
-import Ouroboros.Network.Test.Orphans ()
--- import           Test.Simulation.Network.Snocket hiding (tests)
+import Test.Ouroboros.Network.ConnectionManager.Timeouts
+import Test.Ouroboros.Network.Orphans ()
 
 import Ouroboros.Network.ConnectionManager.InformationChannel
            (newInformationChannel)
-import Ouroboros.Network.ConnectionManager.Test.Timeouts
 
 
 --

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Timeouts.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Timeouts.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase     #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Ouroboros.Network.ConnectionManager.Test.Timeouts
+module Test.Ouroboros.Network.ConnectionManager.Timeouts
   ( verifyAllTimeouts
   , SimAddr
   , SimAddr_

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Utils.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Utils.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Network.ConnectionManager.Test.Utils where
+module Test.Ouroboros.Network.ConnectionManager.Utils where
 
 import Prelude hiding (read)
 

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/InboundGovernor/Utils.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/InboundGovernor/Utils.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE NamedFieldPuns  #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns    #-}
-module Ouroboros.Network.InboundGovernor.Test.Utils where
+
+module Test.Ouroboros.Network.InboundGovernor.Utils where
 
 import Test.QuickCheck
 import Test.QuickCheck.Monoids

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/Orphans.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/Orphans.hs
@@ -1,5 +1,5 @@
 {-# OPTIONS_GHC -Wno-orphans     #-}
-module Ouroboros.Network.Test.Orphans () where
+module Test.Ouroboros.Network.Orphans () where
 
 import Network.TypedProtocol.PingPong.Type (PingPong)
 import Network.TypedProtocol.ReqResp.Type (ReqResp)

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/RawBearer/Utils.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/RawBearer/Utils.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
-module Ouroboros.Network.RawBearer.Test.Utils where
+module Test.Ouroboros.Network.RawBearer.Utils where
 
 import Ouroboros.Network.RawBearer
 import Ouroboros.Network.Snocket

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 
+* Renamed `Test.Ouroboros.Network.Testing.Utils -> Test.Ouroboros.Network.Protocol.Utils`
 * Removed deprecated APIs:
   * `chainSyncClientNull`
   * `localStateQueryClientNull`

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -172,7 +172,7 @@ library testlib
     Test.ChainProducerState
     Test.Data.CDDL
     Test.Data.PipeliningDepth
-    Test.Ouroboros.Network.Testing.Utils
+    Test.Ouroboros.Network.Protocol.Utils
 
   build-depends:
     QuickCheck,

--- a/ouroboros-network-protocols/test/Test/Chain.hs
+++ b/ouroboros-network-protocols/test/Test/Chain.hs
@@ -18,9 +18,9 @@ import Test.Tasty.QuickCheck (testProperty)
 import Ouroboros.Network.Block (blockPrevHash, pattern GenesisPoint, pointHash)
 import Ouroboros.Network.Mock.Chain (Chain (..))
 import Ouroboros.Network.Mock.Chain qualified as Chain
-import Ouroboros.Network.Testing.Serialise (prop_serialise)
 
 import Test.ChainGenerators hiding (tests)
+import Test.Ouroboros.Network.Serialise (prop_serialise)
 
 
 --

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -45,7 +45,7 @@ import Ouroboros.Network.Protocol.BlockFetch.Type
 import Test.Data.PipeliningDepth (PipeliningDepth (..))
 
 import Test.ChainGenerators (TestChainAndPoints (..))
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import Test.QuickCheck

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -53,7 +53,7 @@ import Test.Data.PipeliningDepth (PipeliningDepth (..))
 
 import Test.ChainGenerators ()
 import Test.ChainProducerState (ChainProducerStateForkTest (..))
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import Test.QuickCheck hiding (Result)

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/Handshake/Test.hs
@@ -45,7 +45,7 @@ import Network.Mux.Types (MiniProtocolDir (..), MiniProtocolNum (..),
 import Network.TypedProtocol.Codec
 import Network.TypedProtocol.Proofs
 
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import Ouroboros.Network.Channel
@@ -165,8 +165,7 @@ tests =
 -- wrongly encoded data (protocol version & associated version data mismatch)
 --
 
--- |
--- Testing version number
+-- | Testing version number
 --
 data VersionNumber
   = Version_0

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/KeepAlive/Test.hs
@@ -34,7 +34,7 @@ import Ouroboros.Network.Protocol.KeepAlive.Examples
 import Ouroboros.Network.Protocol.KeepAlive.Server
 import Ouroboros.Network.Protocol.KeepAlive.Type
 
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_valid_cbor_encoding,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_valid_cbor_encoding,
            splits2, splits3)
 
 

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalStateQuery/Test.hs
@@ -51,7 +51,7 @@ import Ouroboros.Network.Protocol.LocalStateQuery.Server
 import Ouroboros.Network.Protocol.LocalStateQuery.Type
 
 import Test.ChainGenerators ()
-import Test.Ouroboros.Network.Testing.Utils
+import Test.Ouroboros.Network.Protocol.Utils
 
 import Test.QuickCheck as QC hiding (Result)
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
@@ -36,7 +36,7 @@ import Ouroboros.Network.Protocol.LocalTxMonitor.Server
 import Ouroboros.Network.Protocol.LocalTxMonitor.Type
 
 import Test.ChainGenerators ()
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 import Test.QuickCheck hiding (Result)
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxSubmission/Test.hs
@@ -44,7 +44,7 @@ import Ouroboros.Network.Protocol.LocalTxSubmission.Server
 import Ouroboros.Network.Protocol.LocalTxSubmission.Type
 
 import Test.Data.CDDL (Any (..))
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import Control.DeepSeq

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/PeerSharing/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/PeerSharing/Test.hs
@@ -36,7 +36,7 @@ import Ouroboros.Network.Protocol.PeerSharing.Examples
            (peerSharingClientCollect, peerSharingServerReplicate)
 import Ouroboros.Network.Protocol.PeerSharing.Server (peerSharingServerPeer)
 import Ouroboros.Network.Protocol.PeerSharing.Type
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 import Test.QuickCheck.Function (Fun, applyFun)
 import Test.Tasty (TestTree, testGroup)

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/TxSubmission2/Test.hs
@@ -51,7 +51,7 @@ import Ouroboros.Network.Protocol.TxSubmission2.Server
 import Ouroboros.Network.Protocol.TxSubmission2.Type
 
 import Test.Data.CDDL (Any (..))
-import Test.Ouroboros.Network.Testing.Utils (prop_codec_cborM,
+import Test.Ouroboros.Network.Protocol.Utils (prop_codec_cborM,
            prop_codec_valid_cbor_encoding, splits2, splits3)
 
 import Control.DeepSeq

--- a/ouroboros-network-protocols/testlib/Test/Ouroboros/Network/Protocol/Utils.hs
+++ b/ouroboros-network-protocols/testlib/Test/Ouroboros/Network/Protocol/Utils.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
--- TODO rename to `Test.Ouroboros.Network.Protocols.Utils`
-module Test.Ouroboros.Network.Testing.Utils where
+module Test.Ouroboros.Network.Protocol.Utils where
 
 import Codec.CBOR.FlatTerm qualified as CBOR
 import Codec.CBOR.Read qualified as CBOR

--- a/ouroboros-network-protocols/testlib/Test/Ouroboros/Network/Testing/Utils.hs
+++ b/ouroboros-network-protocols/testlib/Test/Ouroboros/Network/Testing/Utils.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE NamedFieldPuns   #-}
 {-# LANGUAGE RankNTypes       #-}
+-- TODO rename to `Test.Ouroboros.Network.Protocols.Utils`
 module Test.Ouroboros.Network.Testing.Utils where
 
 import Codec.CBOR.FlatTerm qualified as CBOR

--- a/ouroboros-network-testing/CHANGELOG.md
+++ b/ouroboros-network-testing/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Breaking changes
 
+* Renamed modules from `Ouroboros.Network.Testing.*` to `Test.Ouroboros.Network.*`
 * Added `IOError` field to `ErrorInterval :: AbsAttenuation` constructor.
 
 ### Non-Breaking changes

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -29,12 +29,12 @@ library
   -- At this experiment/prototype stage everything is exposed.
   -- This has to be tidied up once the design becomes clear.
   exposed-modules:
-    Ouroboros.Network.Testing.Data.AbsBearerInfo
-    Ouroboros.Network.Testing.Data.Script
-    Ouroboros.Network.Testing.Data.Signal
-    Ouroboros.Network.Testing.QuickCheck
-    Ouroboros.Network.Testing.Serialise
-    Ouroboros.Network.Testing.Utils
+    Test.Ouroboros.Network.Data.AbsBearerInfo
+    Test.Ouroboros.Network.Data.Script
+    Test.Ouroboros.Network.Data.Signal
+    Test.Ouroboros.Network.QuickCheck
+    Test.Ouroboros.Network.Serialise
+    Test.Ouroboros.Network.Utils
 
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -98,7 +98,7 @@ test-suite test
   type: exitcode-stdio-1.0
   main-is: Main.hs
   hs-source-dirs: test
-  other-modules: Test.Ouroboros.Network.Testing.Data.AbsBearerInfo
+  other-modules: Test.Ouroboros.Network.Data.AbsBearerInfo.Test
   build-depends:
     QuickCheck,
     base >=4.14 && <4.21,

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/AbsBearerInfo.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/AbsBearerInfo.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE NamedFieldPuns     #-}
 {-# LANGUAGE NumericUnderscores #-}
 
-module Ouroboros.Network.Testing.Data.AbsBearerInfo
+module Test.Ouroboros.Network.Data.AbsBearerInfo
   ( AbsBearerInfoScript (..)
   , canFail
   , NonFailingAbsBearerInfo (..)
@@ -24,22 +24,21 @@ module Ouroboros.Network.Testing.Data.AbsBearerInfo
   , AbsIOErrType (..)
   ) where
 
-import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (..), addTime)
+import Control.Monad.Class.MonadTime.SI (DiffTime, Time (..), addTime)
 
-import qualified Data.List as List
-import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Monoid (Any (..))
-import           GHC.IO.Exception (IOException (..), IOErrorType (..))
-import           Foreign.C.Error (Errno (..), eCONNABORTED)
+import Data.List qualified as List
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Monoid (Any (..))
+import Foreign.C.Error (Errno (..), eCONNABORTED)
+import GHC.IO.Exception (IOErrorType (..), IOException (..))
 
-import           Network.Mux.Bearer.AttenuatedChannel (Size,
-                     SuccessOrFailure (..))
-import           Network.Mux.Types (SDUSize (..))
+import Network.Mux.Bearer.AttenuatedChannel (Size, SuccessOrFailure (..))
+import Network.Mux.Types (SDUSize (..))
 
-import           Ouroboros.Network.Testing.Data.Script (Script (..))
-import           Ouroboros.Network.Testing.Utils (Delay (..))
+import Test.Ouroboros.Network.Data.Script (Script (..))
+import Test.Ouroboros.Network.Utils (Delay (..))
 
-import           Test.QuickCheck hiding (Result (..))
+import Test.QuickCheck hiding (Result (..))
 
 
 data AbsDelay = SmallDelay

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/Script.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/Script.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE TupleSections     #-}
 
-module Ouroboros.Network.Testing.Data.Script
+module Test.Ouroboros.Network.Data.Script
   ( -- * Test scripts
     Script (..)
   , NonEmpty (..)
@@ -31,23 +31,23 @@ module Ouroboros.Network.Testing.Data.Script
   , interpretPickScript
   ) where
 
-import           Data.Functor (($>))
-import           Data.List.NonEmpty (NonEmpty (..))
-import qualified Data.List.NonEmpty as NonEmpty
-import           Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Functor (($>))
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty qualified as NonEmpty
+import Data.Set (Set)
+import Data.Set qualified as Set
 
-import           Control.Concurrent.Class.MonadSTM.Strict
-import           Control.Concurrent.Class.MonadSTM (TVar)
-import qualified Control.Concurrent.Class.MonadSTM as LazySTM
-import           Control.Monad.Class.MonadAsync
-import           Control.Monad.Class.MonadFork
-import           Control.Monad.Class.MonadTimer.SI
-import           Control.Tracer (Tracer, traceWith)
+import Control.Concurrent.Class.MonadSTM (TVar)
+import Control.Concurrent.Class.MonadSTM qualified as LazySTM
+import Control.Concurrent.Class.MonadSTM.Strict
+import Control.Monad.Class.MonadAsync
+import Control.Monad.Class.MonadFork
+import Control.Monad.Class.MonadTimer.SI
+import Control.Tracer (Tracer, traceWith)
 
-import           Ouroboros.Network.Testing.Utils (ShrinkCarefully,
-                     prop_shrink_nonequal, shrinkVector)
-import           Test.QuickCheck
+import Test.Ouroboros.Network.Utils (ShrinkCarefully, prop_shrink_nonequal,
+           shrinkVector)
+import Test.QuickCheck
 
 --
 -- Test script abstraction

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/Signal.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/Data/Signal.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE DeriveFoldable      #-}
+{-# LANGUAGE DeriveFunctor       #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Ouroboros.Network.Testing.Data.Signal
+module Test.Ouroboros.Network.Data.Signal
   ( -- * Events
     Events
   , eventsFromList
@@ -47,23 +47,23 @@ module Ouroboros.Network.Testing.Data.Signal
   , keyedUntil
   ) where
 
-import           Prelude hiding (scanl, until)
+import Prelude hiding (scanl, until)
 
-import           Data.Bool (bool)
-import qualified Data.Foldable as Deque (toList)
-import           Data.List (groupBy)
-import           Data.Maybe (maybeToList)
-import           Data.OrdPSQ (OrdPSQ)
-import qualified Data.OrdPSQ as PSQ
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Deque.Lazy (Deque)
-import qualified Deque.Lazy as Deque
+import Data.Bool (bool)
+import Data.Foldable qualified as Deque (toList)
+import Data.List (groupBy)
+import Data.Maybe (maybeToList)
+import Data.OrdPSQ (OrdPSQ)
+import Data.OrdPSQ qualified as PSQ
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Deque.Lazy (Deque)
+import Deque.Lazy qualified as Deque
 
-import           Control.Monad.Class.MonadTime.SI (DiffTime, Time (..), addTime)
+import Control.Monad.Class.MonadTime.SI (DiffTime, Time (..), addTime)
 
 
-import           Test.QuickCheck
+import Test.QuickCheck
 
 --
 -- Time stamps and events

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/QuickCheck.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/QuickCheck.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE RankNTypes #-}
 
-module Ouroboros.Network.Testing.QuickCheck
+module Test.Ouroboros.Network.QuickCheck
   ( runSimGen
   , monadicSim
   ) where
 
-import           Test.QuickCheck
-import           Test.QuickCheck.Gen.Unsafe (Capture (..), capture)
-import           Test.QuickCheck.Monadic
+import Test.QuickCheck
+import Test.QuickCheck.Gen.Unsafe (Capture (..), capture)
+import Test.QuickCheck.Monadic
 
-import           Control.Monad.IOSim
+import Control.Monad.IOSim
 
 -- | 'IOSim' analogue of 'runSTGen'
 --

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/Serialise.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/Serialise.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE CPP #-}
-module Ouroboros.Network.Testing.Serialise
+module Test.Ouroboros.Network.Serialise
   ( -- * Class
     Serialise (..)
   , prop_serialise
@@ -7,10 +7,9 @@ module Ouroboros.Network.Testing.Serialise
   , prop_serialise_roundtrip
   ) where
 
-import           Codec.CBOR.FlatTerm
-import           Codec.Serialise
-import           Test.QuickCheck (Property, counterexample, property, (.&&.),
-                     (===))
+import Codec.CBOR.FlatTerm
+import Codec.Serialise
+import Test.QuickCheck (Property, counterexample, property, (.&&.), (===))
 
 -- Class properties
 --

--- a/ouroboros-network-testing/src/Test/Ouroboros/Network/Utils.hs
+++ b/ouroboros-network-testing/src/Test/Ouroboros/Network/Utils.hs
@@ -5,12 +5,12 @@
 {-# LANGUAGE LambdaCase                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
-module Ouroboros.Network.Testing.Utils
+module Test.Ouroboros.Network.Utils
   ( -- * Arbitrary Delays
     Delay (..)
   , genDelayWithPrecision
   , SmallDelay (..)
-  -- * Set properties
+    -- * Set properties
   , isSubsetProperty
   , disjointSetsProperty
     -- * QuickCheck Utils
@@ -19,7 +19,7 @@ module Ouroboros.Network.Testing.Utils
   , ShrinkCarefully (..)
   , prop_shrink_nonequal
   , prop_shrink_valid
-  -- * Tracing Utils
+    -- * Tracing Utils
   , WithName (..)
   , WithTime (..)
   , tracerWithName
@@ -28,36 +28,35 @@ module Ouroboros.Network.Testing.Utils
   , swapTimeWithName
   , swapNameWithTime
   , splitWithNameTrace
-  -- * Tracers
+    -- * Tracers
   , debugTracer
   , sayTracer
-  -- * Tasty Utils
+    -- * Tasty Utils
   , nightlyTest
   , ignoreTest
-  -- * Auxiliary functions
+    -- * Auxiliary functions
   , renderRanges
   ) where
 
-import           Control.Monad.Class.MonadSay
-import           Control.Monad.Class.MonadTime.SI
-import           Control.Tracer (Contravariant (contramap), Tracer (..),
-                     contramapM)
+import Control.Monad.Class.MonadSay
+import Control.Monad.Class.MonadTime.SI
+import Control.Tracer (Contravariant (contramap), Tracer (..), contramapM)
 
-import           Data.Bitraversable (bimapAccumR)
-import           Data.List (delete)
-import           Data.List.Trace (Trace)
-import qualified Data.List.Trace as Trace
-import qualified Data.Map as Map
-import           Data.Maybe (fromJust, isJust)
-import           Data.Ratio
-import           Data.Set (Set)
-import qualified Data.Set as Set
-import           Text.Pretty.Simple (pPrint)
+import Data.Bitraversable (bimapAccumR)
+import Data.List (delete)
+import Data.List.Trace (Trace)
+import Data.List.Trace qualified as Trace
+import Data.Map qualified as Map
+import Data.Maybe (fromJust, isJust)
+import Data.Ratio
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Text.Pretty.Simple (pPrint)
 
-import           Test.QuickCheck
-import           Test.Tasty (TestTree)
-import           Test.Tasty.ExpectedFailure (ignoreTest)
-import           Debug.Trace (traceShowM)
+import Debug.Trace (traceShowM)
+import Test.QuickCheck
+import Test.Tasty (TestTree)
+import Test.Tasty.ExpectedFailure (ignoreTest)
 
 
 newtype Delay = Delay { getDelay :: DiffTime }
@@ -142,7 +141,7 @@ renderRanges r n = show lower ++ " -- " ++ show upper
     lower = n - n `mod` r
     upper = lower + (r-1)
 
--- 
+--
 -- Set properties
 --
 

--- a/ouroboros-network-testing/test/Main.hs
+++ b/ouroboros-network-testing/test/Main.hs
@@ -1,8 +1,8 @@
 module Main (main) where
 
-import           Test.Tasty
+import Test.Tasty
 
-import qualified Test.Ouroboros.Network.Testing.Data.AbsBearerInfo as AbsBearerInfo
+import Test.Ouroboros.Network.Data.AbsBearerInfo.Test qualified as AbsBearerInfo
 
 main :: IO ()
 main = defaultMain tests

--- a/ouroboros-network-testing/test/Test/Ouroboros/Network/Data/AbsBearerInfo/Test.hs
+++ b/ouroboros-network-testing/test/Test/Ouroboros/Network/Data/AbsBearerInfo/Test.hs
@@ -1,15 +1,15 @@
-module Test.Ouroboros.Network.Testing.Data.AbsBearerInfo (tests) where
+module Test.Ouroboros.Network.Data.AbsBearerInfo.Test (tests) where
 
-import qualified Data.List.NonEmpty as NonEmpty
+import Data.List.NonEmpty qualified as NonEmpty
 
-import           Ouroboros.Network.Testing.Data.AbsBearerInfo (AbsBearerInfo,
-                     AbsBearerInfoScript (..),
-                     NonFailingAbsBearerInfoScript (..), canFail)
-import           Ouroboros.Network.Testing.Data.Script (Script (Script))
+import Test.Ouroboros.Network.Data.AbsBearerInfo (AbsBearerInfo,
+           AbsBearerInfoScript (..), NonFailingAbsBearerInfoScript (..),
+           canFail)
+import Test.Ouroboros.Network.Data.Script (Script (Script))
 
-import           Test.QuickCheck (Arbitrary (..), Fixed (..))
-import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.QuickCheck (testProperty)
+import Test.QuickCheck (Arbitrary (..), Fixed (..))
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
 
 tests :: TestTree
 tests =

--- a/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
@@ -46,10 +46,10 @@ import Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
            noTimeLimitsHandshake)
 import Ouroboros.Network.Protocol.Handshake.Version (acceptableVersion,
            queryVersion)
-import Ouroboros.Network.Testing.Serialise
 import Ouroboros.Network.Util.ShowProxy
 
 import Test.ChainGenerators (TestBlockChainAndUpdates (..))
+import Test.Ouroboros.Network.Serialise
 
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import Test.QuickCheck

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/BlockFetch.hs
@@ -46,6 +46,7 @@ import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.ClientRegistry
 import Ouroboros.Network.BlockFetch.ClientState
+import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import Ouroboros.Network.BlockFetch.DeltaQ
 import Ouroboros.Network.BlockFetch.Examples
 import Ouroboros.Network.Driver (TraceSendRecv)
@@ -54,8 +55,7 @@ import Ouroboros.Network.Mock.ConcreteBlock
 import Ouroboros.Network.NodeToNode.Version (NodeToNodeVersion)
 import Ouroboros.Network.Protocol.BlockFetch.Type (BlockFetch)
 
-import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
-import Ouroboros.Network.Testing.Utils
+import Test.Ouroboros.Network.Utils
 
 
 --

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/LedgerPeers.hs
@@ -44,7 +44,8 @@ import Ouroboros.Network.PeerSelection.LedgerPeers.Utils
            (recomputeRelativeStake)
 import Ouroboros.Network.PeerSelection.RelayAccessPoint
 import Ouroboros.Network.PeerSelection.RootPeersDNS
-import Ouroboros.Network.Testing.Data.Script
+
+import Test.Ouroboros.Network.Data.Script
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS
 import Test.QuickCheck
 import Test.Tasty

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection.hs
@@ -83,15 +83,15 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRo
 import Ouroboros.Network.Point
 import Ouroboros.Network.Protocol.PeerSharing.Type (PeerSharingResult (..))
 
-import Ouroboros.Network.Testing.Data.Script
-import Ouroboros.Network.Testing.Data.Signal (E (E), Events, Signal, TS (TS),
+import Test.Ouroboros.Network.Data.Script
+import Test.Ouroboros.Network.Data.Signal (E (E), Events, Signal, TS (TS),
            signalProperty)
-import Ouroboros.Network.Testing.Data.Signal qualified as Signal
-import Ouroboros.Network.Testing.Utils (disjointSetsProperty, isSubsetProperty,
-           nightlyTest)
+import Test.Ouroboros.Network.Data.Signal qualified as Signal
 import Test.Ouroboros.Network.PeerSelection.Instances
 import Test.Ouroboros.Network.PeerSelection.MockEnvironment hiding (tests)
 import Test.Ouroboros.Network.PeerSelection.PeerGraph
+import Test.Ouroboros.Network.Utils (disjointSetsProperty, isSubsetProperty,
+           nightlyTest)
 
 import Control.Monad.IOSim
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Instances.hs
@@ -37,7 +37,8 @@ import Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint (..),
            RelayAccessPoint (..))
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers
            (LocalRootConfig (..))
-import Ouroboros.Network.Testing.Utils (ShrinkCarefully, prop_shrink_nonequal,
+
+import Test.Ouroboros.Network.Utils (ShrinkCarefully, prop_shrink_nonequal,
            prop_shrink_valid)
 import Test.QuickCheck
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/LocalRootPeers.hs
@@ -22,9 +22,9 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig (..), LocalRootPeers (..), WarmValency (..))
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRootPeers
 
-import Ouroboros.Network.Testing.Utils (ShrinkCarefully, prop_shrink_nonequal,
-           prop_shrink_valid, renderRanges)
 import Test.Ouroboros.Network.PeerSelection.Instances
+import Test.Ouroboros.Network.Utils (ShrinkCarefully, prop_shrink_nonequal,
+           prop_shrink_valid, renderRanges)
 
 
 import Test.QuickCheck

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/MockEnvironment.hs
@@ -24,7 +24,7 @@ module Test.Ouroboros.Network.PeerSelection.MockEnvironment
   , selectPeerSelectionTraceEvents
   , selectPeerSelectionTraceEventsUntil
   , peerShareReachablePeers
-  , module Ouroboros.Network.Testing.Data.Script
+  , module Test.Ouroboros.Network.Data.Script
   , module Ouroboros.Network.PeerSelection.Types
   , tests
   , prop_shrink_nonequal_GovernorMockEnvironment
@@ -66,19 +66,18 @@ import Ouroboros.Network.PeerSelection.Governor qualified as Governor
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRootPeers
 import Ouroboros.Network.Point
 
-import Ouroboros.Network.Testing.Data.Script (PickScript, Script (..),
+import Test.Ouroboros.Network.Data.Script (PickScript, Script (..),
            ScriptDelay (..), TimedScript, arbitraryPickScript,
            arbitraryScriptOf, initScript, initScript', interpretPickScript,
            playTimedScript, prop_shrink_Script, shrinkScriptWith,
            singletonScript, singletonTimedScript, stepScript, stepScriptSTM,
            stepScriptSTM')
-import Ouroboros.Network.Testing.Utils (ShrinkCarefully, arbitrarySubset,
-           nightlyTest, prop_shrink_nonequal, prop_shrink_valid)
-
 import Test.Ouroboros.Network.PeerSelection.Instances
 import Test.Ouroboros.Network.PeerSelection.LocalRootPeers as LocalRootPeers hiding
            (tests)
 import Test.Ouroboros.Network.PeerSelection.PeerGraph
+import Test.Ouroboros.Network.Utils (ShrinkCarefully, arbitrarySubset,
+           nightlyTest, prop_shrink_nonequal, prop_shrink_valid)
 
 import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..),

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerGraph.hs
@@ -34,11 +34,11 @@ import Data.Tree qualified as Tree
 
 import Control.Monad.Class.MonadTime.SI
 
-import Ouroboros.Network.Testing.Data.Script (Script (..),
-           ScriptDelay (NoDelay), TimedScript, arbitraryScriptOf)
-import Ouroboros.Network.Testing.Utils (ShrinkCarefully (..),
-           prop_shrink_nonequal, prop_shrink_valid, renderRanges)
+import Test.Ouroboros.Network.Data.Script (Script (..), ScriptDelay (NoDelay),
+           TimedScript, arbitraryScriptOf)
 import Test.Ouroboros.Network.PeerSelection.Instances
+import Test.Ouroboros.Network.Utils (ShrinkCarefully (..), prop_shrink_nonequal,
+           prop_shrink_valid, renderRanges)
 
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
 import Test.QuickCheck

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -43,7 +43,7 @@ import Control.Monad.IOSim
 
 import NoThunks.Class
 
-import Ouroboros.Network.Testing.Data.Script
+import Test.Ouroboros.Network.Data.Script
 
 import Test.QuickCheck
 import Test.QuickCheck.Monoids

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PublicRootPeers.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/PublicRootPeers.hs
@@ -13,9 +13,9 @@ import Data.Set qualified as Set
 import Ouroboros.Network.PeerSelection.PublicRootPeers (PublicRootPeers)
 import Ouroboros.Network.PeerSelection.PublicRootPeers qualified as PublicRootPeers
 
-import Ouroboros.Network.Testing.Utils (ShrinkCarefully, prop_shrink_nonequal,
-           prop_shrink_valid)
 import Test.Ouroboros.Network.PeerSelection.Instances
+import Test.Ouroboros.Network.Utils (ShrinkCarefully, prop_shrink_nonequal,
+           prop_shrink_valid)
 
 
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -67,7 +67,7 @@ import Ouroboros.Network.PeerSelection.RootPeersDNS.LocalRootPeers
 import Ouroboros.Network.PeerSelection.RootPeersDNS.PublicRootPeers
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency (..),
            LocalRootConfig (..), WarmValency (..))
-import Ouroboros.Network.Testing.Data.Script (Script (Script), initScript',
+import Test.Ouroboros.Network.Data.Script (Script (Script), initScript',
            scriptHead, singletonScript, stepScript')
 import Test.Ouroboros.Network.PeerSelection.Instances ()
 import Test.QuickCheck

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -47,12 +47,12 @@ import Network.DNS.Types qualified as DNS
 
 import Ouroboros.Network.BlockFetch (PraosFetchMode (..),
            TraceFetchClientState (..))
-import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.ConnectionManager.Core qualified as CM
 import Ouroboros.Network.ConnectionManager.State qualified as CM
 import Ouroboros.Network.ConnectionManager.Types
+import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import Ouroboros.Network.Mock.ConcreteBlock (BlockHeader)
 import Ouroboros.Network.NodeToNode (DiffusionMode (..))
@@ -79,21 +79,21 @@ import Ouroboros.Network.PeerSelection.State.LocalRootPeers qualified as LocalRo
 import Ouroboros.Network.PeerSelection.Types
 import Ouroboros.Network.PeerSharing (PeerSharingResult (..))
 import Ouroboros.Network.Server2 qualified as Server
-import Ouroboros.Network.Testing.Data.AbsBearerInfo
-import Ouroboros.Network.Testing.Data.Script
-import Ouroboros.Network.Testing.Data.Signal
-import Ouroboros.Network.Testing.Data.Signal qualified as Signal
-import Ouroboros.Network.Testing.Utils hiding (SmallDelay, debugTracer)
 
 import Simulation.Network.Snocket (BearerInfo (..))
 
 import Test.Ouroboros.Network.ConnectionManager.Timeouts
 import Test.Ouroboros.Network.ConnectionManager.Utils
+import Test.Ouroboros.Network.Data.AbsBearerInfo
+import Test.Ouroboros.Network.Data.Script
+import Test.Ouroboros.Network.Data.Signal
+import Test.Ouroboros.Network.Data.Signal qualified as Signal
 import Test.Ouroboros.Network.InboundGovernor.Utils
 import Test.Ouroboros.Network.LedgerPeers (LedgerPools (..))
 import Test.Ouroboros.Network.Testnet.Internal
 import Test.Ouroboros.Network.Testnet.Node (config_REPROMOTE_DELAY)
 import Test.Ouroboros.Network.Testnet.Node.Kernel
+import Test.Ouroboros.Network.Utils hiding (SmallDelay, debugTracer)
 import Test.QuickCheck
 import Test.QuickCheck.Monoids
 import Test.Tasty

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -47,30 +47,18 @@ import Network.DNS.Types qualified as DNS
 
 import Ouroboros.Network.BlockFetch (PraosFetchMode (..),
            TraceFetchClientState (..))
+import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.ConnectionHandler (ConnectionHandlerTrace (..))
 import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.ConnectionManager.Core qualified as CM
 import Ouroboros.Network.ConnectionManager.State qualified as CM
-import Ouroboros.Network.ConnectionManager.Test.Timeouts (TestProperty (..),
-           classifyActivityType, classifyEffectiveDataFlow,
-           classifyNegotiatedDataFlow, classifyPrunings, classifyTermination,
-           groupConns, mkProperty, ppTransition, verifyAllTimeouts)
-import Ouroboros.Network.ConnectionManager.Test.Utils
-           (abstractStateIsFinalTransition,
-           abstractStateIsFinalTransitionTVarTracing, connectionManagerTraceMap,
-           validTransitionMap, verifyAbstractTransition,
-           verifyAbstractTransitionOrder)
 import Ouroboros.Network.ConnectionManager.Types
-import Ouroboros.Network.ConsensusMode
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
-import Ouroboros.Network.InboundGovernor qualified as IG
-import Ouroboros.Network.InboundGovernor.Test.Utils (inboundGovernorTraceMap,
-           remoteStrIsFinalTransition, serverTraceMap, validRemoteTransitionMap,
-           verifyRemoteTransition, verifyRemoteTransitionOrder)
 import Ouroboros.Network.Mock.ConcreteBlock (BlockHeader)
 import Ouroboros.Network.NodeToNode (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..),
            requiresBootstrapPeers)
+import Ouroboros.Network.InboundGovernor qualified as IG
 import Ouroboros.Network.PeerSelection.Governor hiding (PeerSelectionState (..))
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor
 import Ouroboros.Network.PeerSelection.LedgerPeers
@@ -99,6 +87,9 @@ import Ouroboros.Network.Testing.Utils hiding (SmallDelay, debugTracer)
 
 import Simulation.Network.Snocket (BearerInfo (..))
 
+import Test.Ouroboros.Network.ConnectionManager.Timeouts
+import Test.Ouroboros.Network.ConnectionManager.Utils
+import Test.Ouroboros.Network.InboundGovernor.Utils
 import Test.Ouroboros.Network.LedgerPeers (LedgerPools (..))
 import Test.Ouroboros.Network.Testnet.Internal
 import Test.Ouroboros.Network.Testnet.Node (config_REPROMOTE_DELAY)
@@ -106,7 +97,7 @@ import Test.Ouroboros.Network.Testnet.Node.Kernel
 import Test.QuickCheck
 import Test.QuickCheck.Monoids
 import Test.Tasty
-import Test.Tasty.QuickCheck (testProperty)
+import Test.Tasty.QuickCheck
 
 tests :: TestTree
 tests =

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Internal.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Internal.hs
@@ -106,11 +106,10 @@ import Ouroboros.Network.Snocket (Snocket, TestAddress (..))
 
 import Ouroboros.Network.Block (BlockNo)
 import Ouroboros.Network.Mock.ConcreteBlock (Block (..), BlockHeader (..))
-import Ouroboros.Network.Testing.Data.Script
-import Ouroboros.Network.Testing.Utils
 import Simulation.Network.Snocket (BearerInfo (..), FD, SnocketTrace,
            WithAddr (..), makeFDBearer, withSnocket)
 
+import Test.Ouroboros.Network.Data.Script
 import Test.Ouroboros.Network.PeerSelection.Instances qualified as PeerSelection
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS (DNSLookupDelay (..),
            DNSTimeout (..))
@@ -120,6 +119,7 @@ import Test.Ouroboros.Network.Testnet.Node qualified as Node
 import Test.Ouroboros.Network.Testnet.Node.Kernel (BlockGeneratorArgs, NtCAddr,
            NtCVersion, NtCVersionData, NtNAddr, NtNAddr_ (IPAddr), NtNVersion,
            NtNVersionData, ntnAddrToRelayAccessPoint, randomBlockGenerationArgs)
+import Test.Ouroboros.Network.Utils
 
 import Data.Bool (bool)
 import Data.Function (on)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet/Node.hs
@@ -90,7 +90,6 @@ import Ouroboros.Network.Server.RateLimiting (AcceptedConnectionsLimit (..))
 import Ouroboros.Network.Snocket (MakeBearer, Snocket, TestAddress (..),
            invalidFileDescriptor)
 
-import Ouroboros.Network.Testing.Data.Script (Script (..), stepScriptSTM')
 
 import Simulation.Network.Snocket (AddressType (..), FD)
 
@@ -106,6 +105,8 @@ import Ouroboros.Network.PeerSelection.RelayAccessPoint (DomainAccessPoint,
 import Ouroboros.Network.PeerSelection.RootPeersDNS.DNSActions (DNSLookupType)
 import Ouroboros.Network.PeerSelection.State.LocalRootPeers (HotValency,
            LocalRootConfig, WarmValency)
+
+import Test.Ouroboros.Network.Data.Script (Script (..), stepScriptSTM')
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS (DNSLookupDelay,
            DNSTimeout, mockDNSActions)
 import Test.Ouroboros.Network.Testnet.Node.ChainDB (addBlock, getBlockPointSet)

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/TxSubmission.hs
@@ -57,7 +57,7 @@ import Ouroboros.Network.TxSubmission.Mempool.Reader
 import Ouroboros.Network.TxSubmission.Outbound
 import Ouroboros.Network.Util.ShowProxy
 
-import Ouroboros.Network.Testing.Utils
+import Test.Ouroboros.Network.Utils
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)


### PR DESCRIPTION

# Description

- **socket: generalised simpleMuxCallback**
- **ouroboros-network-framework: renamed modules in testlib**
- **ouroboros-network-testing: renamed modules**
- **ouroboros-network-protocols:testlib: renamed Utils module**

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
