### PR TITLE
Fix rethrow policy

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -21,6 +21,7 @@
 * Use `LocalRootConfig` instead of a tuple.
 * Extended `LocalRootConfig` with `diffusionMode :: DiffusionMode` field.
 * Added `diConnStateSupply` record field to `Ouroboros.Network.Diffusion.P2P.Interfaces`.
+* UnknownMiniProtocol error should not crash the node
 
 ### Non-Breaking changes
 

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/P2P.hs
@@ -745,11 +745,8 @@ runM Interfaces
           Nothing -> mempty)
       <>
       RethrowPolicy (\ctx err -> case  (ctx, fromException err) of
-                        -- mux unknown mini-protocol errors on the outbound
-                        -- side are fatal, since this is misconfiguration of the
-                        -- ouroboros-network stack.
                         (OutboundError, Just Mx.UnknownMiniProtocol {})
-                          -> ShutdownNode
+                          -> ShutdownPeer
                         _ -> mempty)
 
 


### PR DESCRIPTION
# Description

UnknownMiniProtocol errors, even on the outbound side, should not trigger a node shutdown.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
