### PR TITLE
Mux Readbuffer 

### DIFF
--- a/network-mux/bench/socket_read_write/Main.hs
+++ b/network-mux/bench/socket_read_write/Main.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+
+import Control.Exception (bracket)
+import Control.Concurrent.Class.MonadSTM.Strict
+import Control.Monad (forever, replicateM_)
+import Control.Monad.Class.MonadAsync
+import Control.Monad.Class.MonadTimer.SI
+import Control.Tracer
+import Data.Int
+import qualified Network.Socket as Socket
+import Network.Socket (Socket)
+import qualified Data.ByteString.Lazy as BL
+import Test.Tasty.Bench
+
+import Network.Mux.Bearer
+import Network.Mux
+import Network.Mux.Types
+import Network.Mux.Channel
+
+sduTimeout :: DiffTime
+sduTimeout = 10
+
+numberOfPackets :: Int64
+numberOfPackets = 100000
+
+totalPayloadLen :: Int64 -> Int64
+totalPayloadLen sndSize = sndSize * numberOfPackets
+
+readBenchmark :: StrictTMVar IO Int64 -> Int64 -> Socket.SockAddr -> IO ()
+readBenchmark sndSizeV sndSize addr = do
+  bracket
+    (Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol)
+    Socket.close
+    (\sd -> do
+      atomically $ putTMVar sndSizeV sndSize
+      Socket.connect sd addr
+      bearer <- getBearer makeSocketBearer sduTimeout nullTracer sd
+
+      let chan = muxBearerAsChannel bearer (MiniProtocolNum 42) InitiatorDir
+      doRead (totalPayloadLen sndSize) chan 0
+    )
+ where
+   doRead :: Int64 -> Channel IO -> Int64 -> IO ()
+   doRead maxData _ cnt | cnt >= maxData = return ()
+   doRead maxData chan !cnt = do
+     msg_m <- recv chan
+     case msg_m of
+          Just msg -> do
+             doRead maxData chan (cnt + BL.length msg)
+          Nothing -> error "doRead: nullread"
+
+
+-- Start the server in a separate thread
+startServer :: StrictTMVar IO Int64 -> Socket -> IO ()
+startServer sndSizeV ad = forever $ do
+
+    (sd, _) <- Socket.accept ad
+    bearer <- getBearer makeSocketBearer sduTimeout nullTracer sd
+    sndSize <- atomically $ takeTMVar sndSizeV
+
+    let chan = muxBearerAsChannel bearer (MiniProtocolNum 42) ResponderDir
+        payload = BL.replicate sndSize 0xa5
+        -- maxData = totalPayloadLen bearer
+        maxData = totalPayloadLen sndSize
+        numberOfSdus = fromIntegral $ maxData `div` sndSize
+    replicateM_ numberOfSdus $ do
+      send chan payload
+
+-- Main function to run the benchmarks
+main :: IO ()
+main = do
+    -- Start the server in a separate thread
+
+    bracket
+      (Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol)
+      Socket.close
+      (\ad -> do
+        sndSizeV <- newEmptyTMVarIO
+        muxAddress:_ <- Socket.getAddrInfo Nothing (Just "127.0.0.1") (Just "0")
+        Socket.setSocketOption ad Socket.ReuseAddr 1
+        Socket.bind ad (Socket.addrAddress muxAddress)
+        addr <- Socket.getSocketName ad
+        Socket.listen ad 3
+
+        withAsync (startServer sndSizeV ad) $ \said -> do
+
+          defaultMain [
+              -- Suggested Max SDU size for Socket bearer
+              bench "Read/Write Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 12288 addr
+              -- Payload size for ChainSync's RequestNext
+            , bench "Read/Write Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 914 addr
+              -- Payload size for ChainSync's RequestNext
+            , bench "Read/Write Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 10 addr
+            ]
+          cancel said
+      )

--- a/network-mux/bench/socket_read_write/Main.hs
+++ b/network-mux/bench/socket_read_write/Main.hs
@@ -4,20 +4,23 @@
 
 import Control.Exception (bracket)
 import Control.Concurrent.Class.MonadSTM.Strict
+import Data.Functor (void)
 import Control.Monad (forever, replicateM_)
 import Control.Monad.Class.MonadAsync
 import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer
 import Data.Int
-import qualified Network.Socket as Socket
+import Network.Socket qualified as Socket
 import Network.Socket (Socket)
-import qualified Data.ByteString.Lazy as BL
+import Data.ByteString.Lazy qualified as BL
 import Test.Tasty.Bench
 
 import Network.Mux.Bearer
 import Network.Mux
 import Network.Mux.Types
 import Network.Mux.Channel
+
+import Network.Mux.Timeout (withTimeoutSerial)
 
 sduTimeout :: DiffTime
 sduTimeout = 10
@@ -28,6 +31,9 @@ numberOfPackets = 100000
 totalPayloadLen :: Int64 -> Int64
 totalPayloadLen sndSize = sndSize * numberOfPackets
 
+-- | Run a client that connects to the specified addr.
+-- Signals the message sndSize to the server by writing it
+-- in the provided TMVar.
 readBenchmark :: StrictTMVar IO Int64 -> Int64 -> Socket.SockAddr -> IO ()
 readBenchmark sndSizeV sndSize addr = do
   bracket
@@ -51,48 +57,103 @@ readBenchmark sndSizeV sndSize addr = do
              doRead maxData chan (cnt + BL.length msg)
           Nothing -> error "doRead: nullread"
 
-
--- Start the server in a separate thread
+-- | Run a server that accept connections on `ad`.
 startServer :: StrictTMVar IO Int64 -> Socket -> IO ()
 startServer sndSizeV ad = forever $ do
-
     (sd, _) <- Socket.accept ad
     bearer <- getBearer makeSocketBearer sduTimeout nullTracer sd
     sndSize <- atomically $ takeTMVar sndSizeV
 
     let chan = muxBearerAsChannel bearer (MiniProtocolNum 42) ResponderDir
         payload = BL.replicate sndSize 0xa5
-        -- maxData = totalPayloadLen bearer
         maxData = totalPayloadLen sndSize
         numberOfSdus = fromIntegral $ maxData `div` sndSize
     replicateM_ numberOfSdus $ do
       send chan payload
 
+-- | Like startServer but it uses the `writeMany` function
+-- for vector IO.
+startServerMany :: StrictTMVar IO Int64 -> Socket -> IO ()
+startServerMany sndSizeV ad = forever $ do
+    (sd, _) <- Socket.accept ad
+    bearer <- getBearer makeSocketBearer sduTimeout nullTracer sd
+    sndSize <- atomically $ takeTMVar sndSizeV
+
+    let maxData = totalPayloadLen sndSize
+        numberOfSdus = fromIntegral $ maxData `div` sndSize
+        numberOfCalls = numberOfSdus `div` 10
+        runtSdus = numberOfSdus `mod` 10
+
+    withTimeoutSerial $ \timeoutFn -> do
+      replicateM_ numberOfCalls $ do
+        let sdus = replicate 10 $ wrap $ BL.replicate sndSize 0xa5
+        void $ writeMany bearer timeoutFn sdus
+      if runtSdus > 0
+         then do
+           let sdus = replicate runtSdus $ wrap $ BL.replicate sndSize 0xa5
+           void $ writeMany bearer timeoutFn sdus
+         else return ()
+
+ where
+  -- wrap a 'ByteString' as 'MuxSDU'
+  wrap :: BL.ByteString -> MuxSDU
+  wrap blob = MuxSDU {
+        -- it will be filled when the 'MuxSDU' is send by the 'bearer'
+       msHeader = MuxSDUHeader {
+           mhTimestamp = RemoteClockModel 0,
+           mhNum       = MiniProtocolNum 42,
+           mhDir       = ResponderDir,
+           mhLength    = fromIntegral $ BL.length blob
+          },
+        msBlob = blob
+     }
+
+setupServer :: Socket -> IO Socket.SockAddr
+setupServer ad = do
+  muxAddress:_ <- Socket.getAddrInfo Nothing (Just "127.0.0.1") (Just "0")
+  Socket.setSocketOption ad Socket.ReuseAddr 1
+  Socket.bind ad (Socket.addrAddress muxAddress)
+  addr <- Socket.getSocketName ad
+  Socket.listen ad 3
+
+  return addr
+
 -- Main function to run the benchmarks
 main :: IO ()
 main = do
-    -- Start the server in a separate thread
-
     bracket
-      (Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol)
-      Socket.close
-      (\ad -> do
+      (do
+        ad1 <- Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol
+        ad2 <- Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol
+
+        return (ad1, ad2)
+      )
+      (\(ad1, ad2) -> do
+        Socket.close ad1
+        Socket.close ad2
+      )
+      (\(ad1, ad2) -> do
         sndSizeV <- newEmptyTMVarIO
-        muxAddress:_ <- Socket.getAddrInfo Nothing (Just "127.0.0.1") (Just "0")
-        Socket.setSocketOption ad Socket.ReuseAddr 1
-        Socket.bind ad (Socket.addrAddress muxAddress)
-        addr <- Socket.getSocketName ad
-        Socket.listen ad 3
+        sndSizeMV <- newEmptyTMVarIO
+        addr <- setupServer ad1
+        addrM <- setupServer ad2
 
-        withAsync (startServer sndSizeV ad) $ \said -> do
+        withAsync (startServer sndSizeV ad1) $ \said -> do
+          withAsync (startServerMany sndSizeMV ad2) $ \saidM -> do
 
-          defaultMain [
-              -- Suggested Max SDU size for Socket bearer
-              bench "Read/Write Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 12288 addr
+            defaultMain [
+                -- Suggested Max SDU size for Socket bearer
+                bench "Read/Write Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 12288 addr
+                -- Payload size for ChainSync's RequestNext
+              , bench "Read/Write Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 914 addr
               -- Payload size for ChainSync's RequestNext
-            , bench "Read/Write Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 914 addr
-              -- Payload size for ChainSync's RequestNext
-            , bench "Read/Write Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 10 addr
-            ]
-          cancel said
+              , bench "Read/Write Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 10 addr
+
+                -- Send batches of SDUs at the same time
+              , bench "Read/Write-Many Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 12288 addrM
+              , bench "Read/Write-Many Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 914 addrM
+              , bench "Read/Write-Many Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 10 addrM
+              ]
+            cancel said
+            cancel saidM
       )

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -196,3 +196,35 @@ executable mux-demo
     build-depends:
       directory,
       network,
+
+benchmark socket-read-write
+  type: exitcode-stdio-1.0
+  hs-source-dirs: bench/socket_read_write
+  main-is: Main.hs
+  other-modules:
+
+  build-depends:
+    base >=4.14 && <4.21,
+    bytestring,
+    contra-tracer,
+    io-classes,
+    network,
+    network-mux,
+    si-timers,
+    strict-stm,
+    tasty-bench
+
+  default-extensions: ImportQualifiedPost
+  ghc-options:
+    -threaded
+    -fproc-alignment=64
+    -Wall
+    -Wcompat
+    -Wincomplete-uni-patterns
+    -Wincomplete-record-updates
+    -Wpartial-fields
+    -Widentities
+    -Wredundant-constraints
+    -Wunused-packages
+
+  default-language: Haskell2010

--- a/network-mux/src/Network/Mux/Bearer.hs
+++ b/network-mux/src/Network/Mux/Bearer.hs
@@ -23,7 +23,7 @@ import           Control.Monad.Class.MonadTime.SI
 import           Control.Tracer (Tracer)
 
 import           Data.ByteString.Lazy qualified as BL
-import           Network.Socket (Socket)
+import           Network.Socket (getSocketOption, SocketOption (..), Socket)
 #if defined(mingw32_HOST_OS)
 import           System.Win32 (HANDLE)
 #endif
@@ -58,10 +58,11 @@ pureBearer f = \sduTimeout tr fd -> pure (f sduTimeout tr fd)
 makeSocketBearer :: MakeBearer IO Socket
 makeSocketBearer = MakeBearer $ (\sduTimeout tr fd -> do
     readBuffer <- newTVarIO BL.empty
-    return $ socketAsMuxBearer size readBuffer bufSize sduTimeout tr fd)
+    batch <- getSocketOption fd SendBuffer
+    return $ socketAsMuxBearer size batch readBuffer bufSize sduTimeout tr fd)
   where
     size = SDUSize 12_288
-    bufSize = 16*1024
+    bufSize = 16_384
 
 makePipeChannelBearer :: MakeBearer IO PipeChannel
 makePipeChannelBearer = MakeBearer $ pureBearer (\_ -> pipeAsMuxBearer size)

--- a/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
+++ b/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
@@ -260,8 +260,10 @@ attenuationChannelAsMuxBearer :: forall m.
                               -> MuxBearer m
 attenuationChannelAsMuxBearer sduSize sduTimeout muxTracer chan =
     MuxBearer {
-      read    = readMux,
-      write   = writeMux,
+      read      = readMux,
+      write     = writeMux,
+      writeMany = writeMuxMany,
+      batchSize = fromIntegral $ getSDUSize sduSize,
       sduSize
     }
   where
@@ -295,6 +297,12 @@ attenuationChannelAsMuxBearer sduSize sduTimeout muxTracer chan =
       acWrite chan buf
 
       traceWith muxTracer MuxTraceSendEnd
+      return ts
+
+    writeMuxMany :: TimeoutFn m -> [MuxSDU] -> m Time
+    writeMuxMany timeoutFn sdus = do
+      ts <- getMonotonicTime
+      mapM_ (writeMux timeoutFn) sdus
       return ts
 
 --

--- a/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
@@ -38,8 +38,8 @@ namedPipeAsBearer sduSize tracer h =
         Mx.read      = readNamedPipe,
         Mx.write     = writeNamedPipe,
         Mx.writeMany = writeNamedPipeMany,
-        Mx.sduSize   = sduSize
-        Mx.batchSize = fromIntegral $ getSDUSize sduSize
+        Mx.sduSize   = sduSize,
+        Mx.batchSize = fromIntegral $ Mx.getSDUSize sduSize
       }
   where
     readNamedPipe :: Mx.TimeoutFn IO -> IO (Mx.MuxSDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -116,7 +116,7 @@ socketAsMuxBearer sduSize batchSize readBuffer readBufferSize sduTimeout tracer 
           if BL.null availableData
              then do
 #if defined(mingw32_HOST_OS)
-                 buf <- Win32.Async.recv sd (max l readBufferSize)
+                 buf <- Win32.Async.recv sd (fromIntegral $ max l readBufferSize)
 #else
                  buf <- Socket.recv sd (max l readBufferSize)
 #endif

--- a/network-mux/src/Network/Mux/Codec.hs
+++ b/network-mux/src/Network/Mux/Codec.hs
@@ -47,10 +47,13 @@ decodeMuxSDU buf =
     case Bin.runGetOrFail dec buf of
          Left  (_, _, e)  -> Left $ MuxError MuxDecodeError e
          Right (_, _, h) ->
-             Right $ MuxSDU {
-                   msHeader = h
-                 , msBlob   = BL.empty
-                 }
+           if mhLength h > 0
+             then
+               Right $ MuxSDU {
+                     msHeader = h
+                   , msBlob   = BL.empty
+                   }
+             else Left $ MuxError MuxDecodeError "short SDU"
   where
     dec = do
         mhTimestamp <- RemoteClockModel <$> Bin.getWord32be

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -213,10 +213,14 @@ msLength = mhLength . msHeader
 data MuxBearer m = MuxBearer {
     -- | Timestamp and send MuxSDU.
       write   :: TimeoutFn m -> MuxSDU -> m Time
+    -- | Timestamp and send many MuxSDU.
+    , writeMany   :: TimeoutFn m -> [MuxSDU] -> m Time
     -- | Read a MuxSDU
     , read    :: TimeoutFn m -> m (MuxSDU, Time)
     -- | Return a suitable MuxSDU payload size.
     , sduSize :: SDUSize
+    -- | Retirn a suitable batch size
+    , batchSize :: Int
     }
 
 newtype SDUSize = SDUSize { getSDUSize :: Word16 }

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -265,7 +265,7 @@ instance Arbitrary ArbitrarySDU where
             ts  <- arbitrary
             mid <- choose (6, 0x7fff) -- ClientChainSynWithBlocks with 5 is the highest valid mid
             mode <- oneof [return 0x0, return 0x8000]
-            len <- arbitrary
+            len <- choose (1, 0xffff)
             p <- arbitrary
 
             return $ ArbitraryInvalidSDU (InvalidSDU (RemoteClockModel ts) (mid .|. mode) len
@@ -274,8 +274,9 @@ instance Arbitrary ArbitrarySDU where
         invalidLenght = do
             ts  <- arbitrary
             mid <- arbitrary
-            len <- arbitrary
-            realLen <- choose (0, 7) -- Size of mux header is 8
+            realLen <- choose (0, 8) -- Size of mux header is 8
+            len <- if realLen == 8 then return 0
+                                   else arbitrary
             p <- arbitrary
 
             return $ ArbitraryInvalidSDU (InvalidSDU (RemoteClockModel ts) mid len realLen p)

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -345,7 +345,9 @@ makeFDBearer = MakeBearer $ \_ _ _ ->
       return MuxBearer {
           write   = \_ _ -> getMonotonicTime,
           read    = \_ -> forever (threadDelay 3600),
-          sduSize = SDUSize 1500
+          writeMany   = \_ _ -> getMonotonicTime,
+          sduSize = SDUSize 1500,
+          batchSize = 1500
         }
 
 -- | We only keep exceptions here which should not be handled by the test

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Testnet.hs
@@ -2411,7 +2411,7 @@ prop_diffusion_async_demotions ioSimTrace traceNumber =
 
           demotionOpportunitiesTooLong :: Signal (Set NtNAddr)
           demotionOpportunitiesTooLong =
-              Signal.keyedTimeout 1 id demotionOpportunities
+              Signal.keyedTimeout 10 id demotionOpportunities
 
       in signalProperty
             20 show Set.null


### PR DESCRIPTION
# Description

Reading a Mux segment used to require at least two syscalls.
One two read the header and one to read the rest of the data.
    
This change reads up to RecvBuffer bytes into a buffer in one go and
then serves data from it.


# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
