### PR TITLE
Refine the CDDL spec of the `LocalStateQuery` mini-protocol

### DIFF
--- a/ouroboros-network-protocols/bench-cddl/Main.hs
+++ b/ouroboros-network-protocols/bench-cddl/Main.hs
@@ -334,10 +334,10 @@ localStateQueryMessages =
   , AnyMessageWithResult
       (Stateful.AnyMessage
         StateAcquired
-        (MsgQuery (Query largeCBORBS)))
+        (MsgQuery (Query . BlockQuery $ largeCBORBS)))
   , AnyMessageWithResult
       (Stateful.AnyMessage
-        (StateQuerying (Query largeCBORBS))
+        (StateQuerying (Query . BlockQuery $ largeCBORBS))
         (MsgResult (Result (Any CBOR.TNull))))
   , AnyMessageWithResult
       (Stateful.AnyMessage

--- a/ouroboros-network-protocols/cddl/specs/local-state-query.cddl
+++ b/ouroboros-network-protocols/cddl/specs/local-state-query.cddl
@@ -2,11 +2,13 @@
 ; LocalStateQuery mini-protocol.
 ;
 
-localStateQueryMessage
+localStateQueryMessage = localStateQueryMessageImpl<query>
+
+localStateQueryMessageImpl<q>
   = msgAcquire
   / msgAcquired
   / msgFailure
-  / msgQuery
+  / msgQuery<q>
   / msgResult
   / msgRelease
   / msgReAcquire
@@ -35,7 +37,7 @@ msgAcquire   = [0, point]
              / [10]
 msgAcquired  = [1]
 msgFailure   = [2, failure]
-msgQuery     = [3, query]
+msgQuery<q>  = [3, q]
 msgResult    = [4, result]
 msgRelease   = [5]
 msgReAcquire = [6, point]

--- a/ouroboros-network-protocols/cddl/specs/local-state-query.cddl
+++ b/ouroboros-network-protocols/cddl/specs/local-state-query.cddl
@@ -18,7 +18,16 @@ acquireFailurePointNotOnChain = 1
 failure      = acquireFailurePointTooOld
              / acquireFailurePointNotOnChain
 
-query        = any
+blockQuery      = [0, point]
+getSystemStart  = [1]
+getChainBlockNo = [2]
+getChainPoint   = [3]
+
+query        = blockQuery
+             / getSystemStart
+             / getChainBlockNo
+             / getChainPoint
+
 result       = any
 
 msgAcquire   = [0, point]


### PR DESCRIPTION
# Description

This is a draft PR that may address https://github.com/IntersectMBO/ouroboros-consensus/issues/1370. See the issue for further discussion, as it is not clear is `ouroboros-network` is the right place for this change.

This PR:
- Refines the CDDL spec of the `LocalStateQuery` mini-protocol by specifying the possible queries
- Adapts the testing helpers in [Ouroboros.Network.Protocol.LocalStateQuery.Codec.CDDL](https://github.com/IntersectMBO/ouroboros-network/blob/geo2a%2Fconsensus-issue-1370-refine-local-state-query/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalStateQuery/Codec/CDDL.hs#L47) to make them aware of the query types

The query type is modeled after the one defined in [Ouroboros.Consensus.Ledger.Query](https://github.com/IntersectMBO/ouroboros-consensus/blob/main/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Ledger/Query.hs#L71), which is used to instantiate the `LocalStateQuery` in the Consensus code.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
