### PR TITLE
Remove all derived Typeable instances

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -16,7 +16,6 @@ import Control.Monad ((>=>))
 import Data.Bits (clearBit, setBit, testBit)
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Typeable (Typeable)
 import GHC.Generics
 import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Handshake.Acceptable (Accept (..), Acceptable (..))
@@ -53,7 +52,7 @@ data NodeToClientVersion
     -- ^ added @GetLedgerPeerSnapshot@
     | NodeToClientV_20
     -- ^ added @QueryStakePoolDefaultVote@
-  deriving (Eq, Ord, Enum, Bounded, Show, Typeable, Generic, NFData)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and
 -- `NodeToClientVersion`.  This way connecting wrong protocol suite will fail
@@ -106,7 +105,7 @@ data NodeToClientVersionData = NodeToClientVersionData
   { networkMagic :: !NetworkMagic
   , query        :: !Bool
   }
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Show)
 
 instance Acceptable NodeToClientVersionData where
     acceptableVersion local remote

--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToNode/Version.hs
@@ -14,7 +14,6 @@ module Ouroboros.Network.NodeToNode.Version
 
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Typeable (Typeable)
 
 import Codec.CBOR.Term qualified as CBOR
 
@@ -69,7 +68,7 @@ data NodeToNodeVersion =
     --   peer sharing server side and can not reply to requests.
     | NodeToNodeV_14
     -- ^ Chang+1 HF
-  deriving (Eq, Ord, Enum, Bounded, Show, Typeable, Generic, NFData)
+  deriving (Eq, Ord, Enum, Bounded, Show, Generic, NFData)
 
 nodeToNodeVersionCodec :: CodecCBORTerm (Text, Maybe Int) NodeToNodeVersion
 nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
@@ -105,7 +104,7 @@ nodeToNodeVersionCodec = CodecCBORTerm { encodeTerm, decodeTerm }
 data DiffusionMode
     = InitiatorOnlyDiffusionMode
     | InitiatorAndResponderDiffusionMode
-  deriving (Typeable, Eq, Ord, Show)
+  deriving (Eq, Ord, Show)
 
 
 -- | Version data for NodeToNode protocol
@@ -116,7 +115,7 @@ data NodeToNodeVersionData = NodeToNodeVersionData
   , peerSharing   :: !PeerSharing
   , query         :: !Bool
   }
-  deriving (Show, Typeable, Eq)
+  deriving (Show, Eq)
   -- 'Eq' instance is not provided, it is not what we need in version
   -- negotiation (see 'Acceptable' instance below).
 

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server/Sim.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/Server/Sim.hs
@@ -605,7 +605,6 @@ data ExperimentError =
     | SimulationTimeout
 
 deriving instance Show ExperimentError
-deriving instance Typeable ExperimentError
 instance Exception ExperimentError where
 
 -- | Run a central server that talks to any number of clients and other nodes.

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -275,7 +275,7 @@ data PromiseWriter m a = PromiseWriter {
   }
 
 data PromiseWriterException = PromiseWriterBlocked
-  deriving (Show, Typeable)
+  deriving (Show)
 
 instance Exception PromiseWriterException
 
@@ -399,7 +399,6 @@ data ExceptionInHandler where
                        => !peerAddr
                        -> !SomeException
                        -> ExceptionInHandler
-  deriving Typeable
 
 instance Show ExceptionInHandler where
     show (ExceptionInHandler peerAddr e) = "ExceptionInHandler "
@@ -684,7 +683,7 @@ data AbstractState =
     | WaitRemoteIdleSt
     | TerminatingSt
     | TerminatedSt
-    deriving (Eq, Ord, Show, Typeable)
+    deriving (Eq, Ord, Show)
 
 
 -- | Counters for tracing and analysis purposes
@@ -742,7 +741,7 @@ data ConnectionManagerError peerAddr
     -- was expected.
     --
     | UnknownPeer           !peerAddr                !CallStack
-    deriving (Show, Typeable)
+    deriving (Show)
 
 
 instance ( Show peerAddr

--- a/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Server/RateLimiting.hs
@@ -15,7 +15,6 @@ import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
 import Control.Tracer (Tracer, traceWith)
 
-import Data.Typeable (Typeable)
 import Data.Word
 import Text.Printf
 
@@ -144,7 +143,7 @@ data AcceptConnectionsPolicyTrace
       = ServerTraceAcceptConnectionRateLimiting DiffTime Int
       | ServerTraceAcceptConnectionHardLimit Word32
       | ServerTraceAcceptConnectionResume Int
-  deriving (Eq, Ord, Typeable)
+  deriving (Eq, Ord)
 
 instance Show AcceptConnectionsPolicyTrace where
     show (ServerTraceAcceptConnectionRateLimiting delay numberOfConnections) =

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -49,7 +49,6 @@ import Control.Exception
 import Data.Bifoldable (Bifoldable (..))
 import Data.Bifunctor (Bifunctor (..))
 import Data.Hashable
-import Data.Typeable (Typeable)
 import Data.Word
 import GHC.Generics (Generic)
 import Quiet (Quiet (..))
@@ -202,7 +201,7 @@ instance Hashable LocalAddress where
     hashWithSalt s (LocalAddress path) = hashWithSalt s path
 
 newtype TestAddress addr = TestAddress { getTestAddress :: addr }
-  deriving (Eq, Ord, Typeable, Generic, NFData)
+  deriving (Eq, Ord, Generic, NFData)
   deriving NoThunks via InspectHeap (TestAddress addr)
   deriving Show via Quiet (TestAddress addr)
 

--- a/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Simulation/Network/Snocket.hs
@@ -387,7 +387,6 @@ data ResourceException
                                         (Maybe SomeException)
 
 deriving instance Show ResourceException
-deriving instance Typeable ResourceException
 instance Exception ResourceException where
 
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/Kernel.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/Diffusion/Node/Kernel.hs
@@ -49,7 +49,6 @@ import Data.IP qualified as IP
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Monoid.Synchronisation
-import Data.Typeable (Typeable)
 import Data.Void (Void)
 import GHC.Generics (Generic)
 import Numeric.Natural (Natural)
@@ -359,7 +358,7 @@ withSlotTime slotDuration k = do
 -- | Node kernel erros.
 --
 data NodeKernelError = UnexpectedSlot !SlotNo !SlotNo
-  deriving (Typeable, Show)
+  deriving Show
 
 instance Exception NodeKernelError where
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Cardano/MockEnvironment.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/Cardano/MockEnvironment.hs
@@ -420,7 +420,7 @@ mockPeerSelectionActions tracer
 data TransitionError
   = ActivationError
   | DeactivationError
-  deriving (Show, Typeable)
+  deriving Show
 
 instance Exception TransitionError where
 

--- a/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
+++ b/ouroboros-network/sim-tests-lib/Test/Ouroboros/Network/PeerSelection/RootPeersDNS.hs
@@ -472,7 +472,7 @@ mockResolveLedgerPeers tracer (MockRoots _ _ publicRootPeers dnsMapScript)
 data TestTraceEvent = RootPeerDNSLocal  (TraceLocalRootPeers () SockAddr Failure)
                     | LocalRootPeersResults [(HotValency, WarmValency, Map SockAddr (LocalRootConfig ()))]
                     | RootPeerDNSPublic TracePublicRootPeers
-  deriving (Show, Typeable)
+  deriving Show
 
 tracerTraceLocalRoots :: Tracer (IOSim s) (TraceLocalRootPeers () SockAddr Failure)
 tracerTraceLocalRoots = contramap RootPeerDNSLocal tracerTestTraceEvent

--- a/ouroboros-network/src/Ouroboros/Cardano/Network/PublicRootPeers.hs
+++ b/ouroboros-network/src/Ouroboros/Cardano/Network/PublicRootPeers.hs
@@ -6,7 +6,6 @@ import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
-import Data.Typeable (Typeable)
 import Ouroboros.Network.PeerSelection.PeerAdvertise (PeerAdvertise (..))
 import Ouroboros.Network.PeerSelection.Types
 
@@ -15,7 +14,7 @@ data ExtraPeers peeraddr =
     { getPublicConfigPeers :: !(Map peeraddr PeerAdvertise)
     , getBootstrapPeers    :: !(Set peeraddr)
     }
-  deriving (Eq, Show, Typeable)
+  deriving (Eq, Show)
 
 instance Ord peeraddr => Semigroup (ExtraPeers peeraddr) where
   (ExtraPeers a b) <> (ExtraPeers a' b') =

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -275,7 +275,7 @@ data MiniProtocolException = MiniProtocolException {
   deriving Show
 
 newtype MiniProtocolExceptions = MiniProtocolExceptions [MiniProtocolException]
-  deriving (Show, Typeable)
+  deriving Show
 
 instance Exception MiniProtocolExceptions
 


### PR DESCRIPTION
# Description

GHC has added this typeclass by default for a long time and ghc-9.12 now warns about this being redundant.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
