### PR TITLE
Require `NodeToClientV_20` minimum for `LocalTxMonitor`'s `MsgGetMeasures`

### DIFF
--- a/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/NodeToClient/Version.hs
@@ -52,7 +52,8 @@ data NodeToClientVersion
     | NodeToClientV_19
     -- ^ added @GetLedgerPeerSnapshot@
     | NodeToClientV_20
-    -- ^ added @QueryStakePoolDefaultVote@
+    -- ^ added @QueryStakePoolDefaultVote@,
+    -- added @MsgGetMeasures@ / @MsgReplyGetMeasures@ to @LocalTxMonitor@
   deriving (Eq, Ord, Enum, Bounded, Show, Typeable, Generic, NFData)
 
 -- | We set 16ths bit to distinguish `NodeToNodeVersion` and

--- a/ouroboros-network-protocols/bench-cddl/Main.hs
+++ b/ouroboros-network-protocols/bench-cddl/Main.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE NamedFieldPuns        #-}
+{-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE PolyKinds             #-}
 {-# LANGUAGE QuantifiedConstraints #-}
 
@@ -301,6 +302,8 @@ localTxMonitorMessages =
   , AnyMessage (MsgReplyHasTx maxBound)
   , AnyMessage MsgGetSizes
   , AnyMessage (MsgReplyGetSizes (MempoolSizeAndCapacity maxBound maxBound maxBound))
+  , AnyMessage MsgGetMeasures
+  , AnyMessage (MsgReplyGetMeasures (MempoolMeasures maxBound (Map.singleton (MeasureName "example_measure") (SizeAndCapacity 0 0))))
   , AnyMessage LocalTxMonitor.MsgRelease
   , AnyMessage LocalTxMonitor.MsgDone
   ]

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Codec/CDDL.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Codec/CDDL.hs
@@ -13,6 +13,7 @@ localTxMonitorCodec :: Codec (LocalTxMonitor TxId Tx SlotNo)
                             CBOR.DeserialiseFailure IO BL.ByteString
 localTxMonitorCodec =
     codecLocalTxMonitor
+      maxBound
       Serialise.encode Serialise.decode
       Serialise.encode Serialise.decode
       Serialise.encode Serialise.decode

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/LocalTxMonitor/Test.hs
@@ -72,6 +72,7 @@ codec ::
      )
   => Codec (LocalTxMonitor TxId Tx SlotNo) S.DeserialiseFailure m ByteString
 codec = codecLocalTxMonitor
+  maxBound
   S.encode S.decode
   S.encode S.decode
   S.encode S.decode


### PR DESCRIPTION
# Description

Cherry-picked commits from #5080:

- **note use of NodeToClientV_20 for Msg{Reply}GetMeasures**
- **ensure `NodeToClient` version >= V20 for `GetMeasures` / `ReplyGetMeasures` in `LocalTxMonitor`**
- **add MsgGetMeasures to bench-cddl**

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
