### PR TITLE
mux socket bearer test

### DIFF
--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-breaking changes
 
+* Added socket bearer in demux sdu properties
+
 ## 0.7.0.0 -- 2025-02-25
 
 ### Breaking changes
@@ -28,7 +30,7 @@
 ### Breaking changes
 
 * Removed `Network.Mux.Compat` module with legacy API.
-* `Ouroboros.Network.Mux.toApplication` was removed. 
+* `Ouroboros.Network.Mux.toApplication` was removed.
 * `Ouroboros.Network.Mux.mkMiniProtocolBundle` was renamed to
   `mkMiniProtocolInfos`, its type changed.
 * Removed `MiniProtocolBundle` newtype wrapper.

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -28,6 +28,11 @@ flag tracetcpinfo
   manual: True
   default: False
 
+flag bypass-sdu-encode
+  description: For running socket bearer tests such that arbitrary data can be sent by the client
+  manual: True
+  default: False
+
 common demo-deps
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -72,6 +77,9 @@ library
 
   if flag(tracetcpinfo)
     cpp-options: -DMUX_TRACE_TCPINFO
+
+  if flag(bypass-sdu-encode)
+    cpp-options: -DBYPASS_SDU_ENCODE
   hs-source-dirs: src
   exposed-modules:
     Control.Concurrent.JobPool

--- a/network-mux/src/Network/Mux/Codec.hs
+++ b/network-mux/src/Network/Mux/Codec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP            #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Network.Mux.Codec where
@@ -25,6 +26,10 @@ import Network.Mux.Types
 --
 -- All fields are in big endian byte order.
 --
+#if defined(BYPASS_SDU_ENCODE)
+encodeSDU :: SDU -> BL.ByteString
+encodeSDU = msBlob
+#else
 encodeSDU :: SDU -> BL.ByteString
 encodeSDU sdu =
   let hdr = Bin.runPut enc in
@@ -38,6 +43,7 @@ encodeSDU sdu =
     putNumAndMode :: MiniProtocolNum -> MiniProtocolDir -> Word16
     putNumAndMode (MiniProtocolNum n) InitiatorDir = n
     putNumAndMode (MiniProtocolNum n) ResponderDir = n .|. 0x8000
+#endif
 
 
 -- | Decode a 'MuSDU' header.  A left inverse of 'encodeSDU'.

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -1193,7 +1193,7 @@ prop_demux_sdu_sim badSdu =
                                                  readQueue  = server_r
                                                }
                 server <- async $ plainServer miniInfoV serverInfoV payload serverTracer serverBearer
-                clientBearer <- getBearer makeQueueChannelBearer
+                clientBearer <- getBearer (makeQueueChannelBearer' True)
                                   (-1)
                                   clientTracer
                                   QueueChannel { writeQueue = server_r,
@@ -1236,7 +1236,7 @@ prop_demux_sdu_io badSdu = ioProperty do
   clientSd <- Socket.socket Socket.AF_INET Socket.Stream Socket.defaultProtocol
   Socket.connect clientSd addr
   let clientTracer = contramap (Mx.WithBearer "client") activeTracer
-  clientBearer <- getBearer makeSocketBearer 0 clientTracer clientSd
+  clientBearer <- getBearer (makeSocketBearer' True) 0 clientTracer clientSd
   resultFn <- prop_demux_sdu badSdu clientBearer miniInfoV
   (mux, resultPromise) <- atomically $ takeTMVar serverInfoV
   result <- atomically resultPromise


### PR DESCRIPTION
# Description

Even though socket bearers are used in tests in o-network and o-n-framework, such a test is missing in this package where these mechanisms are defined. This PR enhances sdu demux property tests to include socket bearers.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
