### PR TITLE
Remove usage of ledger annotator and release o-n-api 0.14.0.0

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -28,7 +28,7 @@ library
     contra-tracer,
     network-mux >=0.6 && <0.8,
     ouroboros-network >=0.19 && <0.21,
-    ouroboros-network-api >=0.12 && <0.14,
+    ouroboros-network-api >=0.12 && <0.15,
     ouroboros-network-framework >=0.15 && <0.18,
     si-timers,
 

--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ouroboros-network-api
 
+## 0.14.0.0 -- 2025-04-04
+
+### Breaking changes
+
+- Changed type of `unwrapCBORinCBOR`.
+
 ## 0.13.0.0 -- 2025-02-25
 
 ### Breaking changes

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: ouroboros-network-api
-version: 0.13.0.0
+version: 0.14.0.0
 synopsis: A networking api shared with ouroboros-consensus
 description: A networking api shared with ouroboros-consensus.
 license: Apache-2.0

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -92,7 +92,7 @@ library
     network-mux ^>=0.7,
     nothunks,
     nothunks ^>=0.1.4 || ^>=0.2,
-    ouroboros-network-api ^>=0.13,
+    ouroboros-network-api >=0.13 && <0.15,
     ouroboros-network-testing,
     psqueues,
     quiet,

--- a/ouroboros-network-protocols/CHANGELOG.md
+++ b/ouroboros-network-protocols/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Revision history for ouroboros-network-protocols
 
+## 0.14.0.1 -- 2025-04-04
+
+### Patch changes
+
+- Use `ouroboros-network-api-0.14.0.0`.
+
 ## 0.14.0.0 -- 2025-02-25
 
 ### Breaking changes

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: ouroboros-network-protocols
-version: 0.14.0.0
+version: 0.14.0.1
 synopsis: Ouroboros Network Protocols
 description: Ouroboros Network Protocols.
 license: Apache-2.0
@@ -104,7 +104,7 @@ library
     deepseq,
     io-classes ^>=1.5.0,
     nothunks,
-    ouroboros-network-api ^>=0.13,
+    ouroboros-network-api ^>=0.14,
     quiet,
     serialise,
     si-timers,

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/BlockFetch/Test.hs
@@ -335,7 +335,7 @@ codecWrapped :: MonadST m
                       m ByteString
 codecWrapped =
     codecBlockFetch
-      (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const <$> S.decode))
+      (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const S.decode))
       S.encode                  S.decode
 
 codecSerialised :: MonadST m

--- a/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
+++ b/ouroboros-network-protocols/testlib/Ouroboros/Network/Protocol/ChainSync/Test.hs
@@ -479,7 +479,7 @@ codecWrapped :: ( MonadST m
                       S.DeserialiseFailure
                       m ByteString
 codecWrapped =
-    codecChainSync (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const <$> S.decode))
+    codecChainSync (wrapCBORinCBOR S.encode) (unwrapCBORinCBOR (const S.decode))
                    S.encode                  S.decode
                    (encodeTip S.encode)      (decodeTip S.decode)
 

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -178,7 +178,7 @@ library
     network ^>=3.2.7,
     network-mux,
     nothunks,
-    ouroboros-network-api ^>=0.13,
+    ouroboros-network-api >=0.13 && <0.15,
     ouroboros-network-framework ^>=0.17,
     ouroboros-network-protocols ^>=0.14,
     psqueues >=0.2.3 && <0.3,


### PR DESCRIPTION
# Description

In the same spirit of https://github.com/IntersectMBO/ouroboros-consensus/pull/1445, `unwrapCBORinCBOR` needs to change its type.

This also prepares a release and revisions of packages.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] ~New tests are added and existing tests are updated.~
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [ ] ~The documentation has been properly updated, see [ref][contrib#documentation].~

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
