### PR TITLE
Make egress poll interval configurable

### DIFF
--- a/decentralized-message-queue/src/DMQ/Configuration.hs
+++ b/decentralized-message-queue/src/DMQ/Configuration.hs
@@ -214,6 +214,7 @@ mkDiffusionConfiguration
       , Diffusion.dcBulkChurnInterval        = dmqcChurnInterval
       , Diffusion.dcMuxForkPolicy            = Diffusion.noBindForkPolicy -- TODO: Make option flag for responderForkPolicy
       , Diffusion.dcLocalMuxForkPolicy       = Diffusion.noBindForkPolicy -- TODO: Make option flag for responderForkPolicy
+      , Diffusion.dcEgressPollInterval       = 0                          -- TODO: Make option flag for egress poll interval
       }
   where
     hints = defaultHints {

--- a/network-mux/src/Network/Mux/Bearer.hs
+++ b/network-mux/src/Network/Mux/Bearer.hs
@@ -10,6 +10,7 @@ module Network.Mux.Bearer
   ( Bearer (..)
   , MakeBearer (..)
   , makeSocketBearer
+  , makeSocketBearer'
   , makePipeChannelBearer
   , makeQueueChannelBearer
 #if defined(mingw32_HOST_OS)
@@ -61,8 +62,11 @@ pureBearer f = \sduTimeout rb tr fd -> pure (f sduTimeout rb tr fd)
 
 
 makeSocketBearer :: MakeBearer IO Socket
-makeSocketBearer = MakeBearer $ (\sduTimeout tr fd rb -> do
-    return $ socketAsBearer size batch rb sduTimeout tr fd)
+makeSocketBearer = makeSocketBearer' 0
+
+makeSocketBearer' :: DiffTime -> MakeBearer IO Socket
+makeSocketBearer' pt = MakeBearer $ (\sduTimeout tr fd rb -> do
+    return $ socketAsBearer size batch rb sduTimeout pt tr fd)
   where
     size = SDUSize 12_288
     batch = 131_072
@@ -89,13 +93,13 @@ makeQueueChannelBearer :: ( MonadSTM   m
                           , MonadThrow m
                           )
                        => MakeBearer m (QueueChannel m)
-makeQueueChannelBearer = MakeBearer $ pureBearer (\_ tr q _-> queueChannelAsBearer size tr q)
+makeQueueChannelBearer = MakeBearer $ pureBearer (\_ tr q _ -> queueChannelAsBearer size tr q)
   where
     size = SDUSize 1_280
 
 #if defined(mingw32_HOST_OS)
 makeNamedPipeBearer :: MakeBearer IO HANDLE
-makeNamedPipeBearer = MakeBearer $ pureBearer (\_ tr fd _-> namedPipeAsBearer size tr fd)
+makeNamedPipeBearer = MakeBearer $ pureBearer (\_ tr fd _ -> namedPipeAsBearer size tr fd)
   where
     size = SDUSize 24_576
 #endif

--- a/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
+++ b/network-mux/src/Network/Mux/Bearer/AttenuatedChannel.hs
@@ -273,12 +273,13 @@ attenuationChannelAsBearer :: forall m.
                            -> Bearer m
 attenuationChannelAsBearer sduSize sduTimeout muxTracer chan =
     Bearer {
-      read      = readMux,
-      write     = writeMux,
-      writeMany = writeMuxMany,
+      read           = readMux,
+      write          = writeMux,
+      writeMany      = writeMuxMany,
       sduSize,
-      batchSize = fromIntegral $ getSDUSize sduSize,
-      name      = "attenuation-channel"
+      batchSize      = fromIntegral $ getSDUSize sduSize,
+      name           = "attenuation-channel",
+      egressInterval = 0
     }
   where
     readMux :: TimeoutFn m -> m (SDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/NamedPipe.hs
@@ -33,12 +33,13 @@ namedPipeAsBearer :: Mx.SDUSize
                   -> Mx.Bearer IO
 namedPipeAsBearer sduSize tracer h =
     Mx.Bearer {
-        Mx.read      = readNamedPipe,
-        Mx.write     = writeNamedPipe,
-        Mx.writeMany = writeNamedPipeMany,
-        Mx.sduSize   = sduSize,
-        Mx.batchSize = fromIntegral $ Mx.getSDUSize sduSize,
-        Mx.name      = "named-pipe"
+        Mx.read           = readNamedPipe,
+        Mx.write          = writeNamedPipe,
+        Mx.writeMany      = writeNamedPipeMany,
+        Mx.sduSize        = sduSize,
+        Mx.batchSize      = fromIntegral $ Mx.getSDUSize sduSize,
+        Mx.name           = "named-pipe",
+        Mx.egressInterval = 0
       }
   where
     readNamedPipe :: Mx.TimeoutFn IO -> IO (Mx.SDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Pipe.hs
+++ b/network-mux/src/Network/Mux/Bearer/Pipe.hs
@@ -75,12 +75,13 @@ pipeAsBearer
   -> Bearer IO
 pipeAsBearer sduSize tracer channel =
       Mx.Bearer {
-          Mx.read      = readPipe,
-          Mx.write     = writePipe,
-          Mx.writeMany = writePipeMany,
-          Mx.sduSize   = sduSize,
-          Mx.name      = "pipe",
-          Mx.batchSize = fromIntegral $ Mx.getSDUSize sduSize
+          Mx.read           = readPipe,
+          Mx.write          = writePipe,
+          Mx.writeMany      = writePipeMany,
+          Mx.sduSize        = sduSize,
+          Mx.name           = "pipe",
+          Mx.batchSize      = fromIntegral $ Mx.getSDUSize sduSize,
+          Mx.egressInterval = 0
         }
     where
       readPipe :: Mx.TimeoutFn IO -> IO (Mx.SDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Queues.hs
+++ b/network-mux/src/Network/Mux/Bearer/Queues.hs
@@ -40,12 +40,13 @@ queueChannelAsBearer
   -> Bearer m
 queueChannelAsBearer sduSize tracer QueueChannel { writeQueue, readQueue } = do
       Mx.Bearer {
-        Mx.read      = readMux,
-        Mx.write     = writeMux,
-        Mx.writeMany = writeMuxMany,
-        Mx.sduSize   = sduSize,
-        Mx.batchSize = 2 * (fromIntegral $ Mx.getSDUSize sduSize),
-        Mx.name      = "queue-channel"
+        Mx.read           = readMux,
+        Mx.write          = writeMux,
+        Mx.writeMany      = writeMuxMany,
+        Mx.sduSize        = sduSize,
+        Mx.batchSize      = 2 * (fromIntegral $ Mx.getSDUSize sduSize),
+        Mx.name           = "queue-channel",
+        Mx.egressInterval = 0
       }
     where
       readMux :: Mx.TimeoutFn m -> m (Mx.SDU, Time)

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -52,17 +52,19 @@ socketAsBearer
   -> Int
   -> Maybe (Mx.ReadBuffer IO)
   -> DiffTime
+  -> DiffTime
   -> Tracer IO Mx.Trace
   -> Socket.Socket
   -> Bearer IO
-socketAsBearer sduSize batchSize readBuffer_m sduTimeout tracer sd =
+socketAsBearer sduSize batchSize readBuffer_m sduTimeout pollInterval tracer sd =
       Mx.Bearer {
-        Mx.read      = readSocket,
-        Mx.write     = writeSocket,
-        Mx.writeMany = writeSocketMany,
-        Mx.sduSize   = sduSize,
-        Mx.batchSize = batchSize,
-        Mx.name      = "socket-bearer"
+        Mx.read           = readSocket,
+        Mx.write          = writeSocket,
+        Mx.writeMany      = writeSocketMany,
+        Mx.sduSize        = sduSize,
+        Mx.batchSize      = batchSize,
+        Mx.name           = "socket-bearer",
+        Mx.egressInterval = pollInterval
       }
     where
       readSocket :: Mx.TimeoutFn IO -> IO (Mx.SDU, Time)

--- a/network-mux/src/Network/Mux/Egress.hs
+++ b/network-mux/src/Network/Mux/Egress.hs
@@ -144,7 +144,7 @@ muxer
     => EgressQueue m
     -> Bearer m
     -> m void
-muxer egressQueue Bearer { writeMany, sduSize, batchSize } =
+muxer egressQueue Bearer { writeMany, sduSize, batchSize, egressInterval } =
     withTimeoutSerial $ \timeout ->
     forever $ do
       start <- getMonotonicTime
@@ -156,12 +156,9 @@ muxer egressQueue Bearer { writeMany, sduSize, batchSize } =
       empty <- atomically $ isEmptyTBQueue egressQueue
       when (empty) $ do
         let delta = diffTime end start
-        threadDelay (loopInterval - delta)
+        threadDelay (egressInterval - delta)
 
   where
-    loopInterval :: DiffTime
-    loopInterval = 0.001
-
     maxSDUsPerBatch :: Int
     maxSDUsPerBatch = 100
 

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -244,17 +244,19 @@ msHeaderLength = 8
 --
 data Bearer m = Bearer {
     -- | Timestamp and send SDU.
-      write     :: TimeoutFn m -> SDU -> m Time
+      write          :: TimeoutFn m -> SDU -> m Time
     -- | Timestamp and send many SDUs.
-    , writeMany :: TimeoutFn m -> [SDU] -> m Time
+    , writeMany      :: TimeoutFn m -> [SDU] -> m Time
     -- | Read a SDU
-    , read      :: TimeoutFn m -> m (SDU, Time)
+    , read           :: TimeoutFn m -> m (SDU, Time)
     -- | Return a suitable SDU payload size.
-    , sduSize   :: SDUSize
+    , sduSize        :: SDUSize
     -- | Return a suitable batch size
-    , batchSize :: Int
+    , batchSize      :: Int
     -- | Name of the bearer
-    , name      :: String
+    , name           :: String
+    -- | Egress poll interval
+    , egressInterval :: DiffTime
     }
 
 newtype SDUSize = SDUSize { getSDUSize :: Word16 }

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -919,7 +919,7 @@ runWithSocket cap clientBuf_m serverBuf_m initApps respApps = withIOManager (\io
       )
    )
   where
-    mkBearer buf_m sock tr = getBearer makeSocketBearer (-1) tr sock buf_m
+    mkBearer buf_m sock tr = getBearer (makeSocketBearer' 0.001) (-1) tr sock buf_m
     clientTracer = contramap (Mx.WithBearer "client") activeTracer
     serverTracer = contramap (Mx.WithBearer "server") activeTracer
 

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -347,12 +347,13 @@ makeFDBearer :: MonadDelay m
              => MakeBearer m (FD m)
 makeFDBearer = MakeBearer $ \_ _ _ _ ->
       return Mx.Bearer {
-          Mx.write     = \_ _ -> getMonotonicTime,
-          Mx.writeMany = \_ _ -> getMonotonicTime,
-          Mx.read      = \_ -> forever (threadDelay 3600),
-          Mx.sduSize   = Mx.SDUSize 1500,
-          Mx.batchSize = 1500,
-          Mx.name      = "FD"
+          Mx.write          = \_ _ -> getMonotonicTime,
+          Mx.writeMany      = \_ _ -> getMonotonicTime,
+          Mx.read           = \_ -> forever (threadDelay 3600),
+          Mx.sduSize        = Mx.SDUSize 1500,
+          Mx.batchSize      = 1500,
+          Mx.name           = "FD",
+          Mx.egressInterval = 0
         }
 
 -- | We only keep exceptions here which should not be handled by the test

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -21,6 +21,7 @@ module Ouroboros.Network.Snocket
   , AddressFamily (..)
   , Snocket (..)
   , makeSocketBearer
+  , makeSocketBearer'
   , makeLocalRawBearer
     -- ** Socket based Snockets
   , SocketSnocket

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -37,6 +37,7 @@
 - Renamed `Arguments` to `DiffusionConfiguration`
 - Renamed `Applications` to `DiffusionApplications`
 - `runM` function now receives `ExtraParameters` as an argument
+- Configurable Mux Egress Poll Interval
 
 ## 0.20.1.0 -- 2025-03-13
 

--- a/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion.hs
+++ b/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion.hs
@@ -136,7 +136,7 @@ run lpci tracerChurnMode localConfig metrics tracers args apps = do
                (\e -> traceWith tracer (Diffusion.DiffusionErrored e)
                    >> throwIO (Diffusion.DiffusionError e))
          $ withIOManager $ \iocp -> do
-             interfaces <- Diffusion.mkInterfaces iocp tracer
+             interfaces <- Diffusion.mkInterfaces iocp tracer (Diffusion.dcEgressPollInterval args)
              Diffusion.runM
                interfaces
                tracers

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
@@ -467,6 +467,9 @@ data Configuration extraFlags m ntnFd ntnAddr ntcFd ntcAddr = Configuration {
     --
     , dcLocalMuxForkPolicy :: Mx.ForkPolicy ntcAddr
 
+    -- | Mux egress queue's poll interval
+    , dcEgressPollInterval :: DiffTime
+
   }
 
 

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -475,6 +475,7 @@ run blockGeneratorArgs limits ni na
       , Diffusion.dcReadLedgerPeerSnapshot = pure Nothing -- ^ tested independently
       , Diffusion.dcMuxForkPolicy          = noBindForkPolicy
       , Diffusion.dcLocalMuxForkPolicy     = noBindForkPolicy
+      , Diffusion.dcEgressPollInterval     = 0.001
       }
 
     appArgs :: PeerMetrics m NtNAddr


### PR DESCRIPTION
# Description
Make the egress queue's poll interval configurable. 
Polling the egress queue is a trade between requests latency on one side and CPU and Network efficiency on the other.
By making it configurable node operators can tailor to their preference.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
