### PR TITLE
Fix default genesis sync targets

### DIFF
--- a/ouroboros-network/src/Ouroboros/Cardano/Network/Diffusion/Configuration.hs
+++ b/ouroboros-network/src/Ouroboros/Cardano/Network/Diffusion/Configuration.hs
@@ -11,7 +11,6 @@ module Ouroboros.Cardano.Network.Diffusion.Configuration
   ) where
 
 import Cardano.Network.Types (NumberOfBigLedgerPeers (..))
-import Ouroboros.Network.Diffusion.Configuration (defaultDeadlineTargets)
 import Ouroboros.Network.PeerSelection.Governor.Types
            (PeerSelectionTargets (..))
 
@@ -27,9 +26,9 @@ defaultNumBootstrapPeers = DefaultNumBootstrapPeers 30
 -- | These targets are established when Genesis mode is enabled
 -- in node configuration and when the node is syncing up
 --
-defaultSyncTargets :: PeerSelectionTargets
-defaultSyncTargets =
-  defaultDeadlineTargets {
+defaultSyncTargets :: PeerSelectionTargets -> PeerSelectionTargets
+defaultSyncTargets deadlineTargets =
+  deadlineTargets {
     targetNumberOfActivePeers               = 0,
     targetNumberOfKnownBigLedgerPeers       = 100,
     targetNumberOfEstablishedBigLedgerPeers = 40,


### PR DESCRIPTION
defaultSyncTargets should be an adaption of the configured deadline targets. Not the default deadline targets.

# Description

_reasonably detailed description of the pull request_

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
