### PR TITLE
PeerStateActions: peerMonitoringLoop termination

### DIFF
--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/Governor/Types.hs
@@ -315,11 +315,10 @@ sanePeerSelectionTargets PeerSelectionTargets{..} =
  && targetNumberOfKnownBigLedgerPeers       <= 10000
 
 
--- | The asynchronous demotion action will wait
--- this long for peer status to change to 'PeerCold'
--- before removing a peer from the OG state. If this times out,
--- there is a logic error somewhere as this should happen after
--- CM drops that peer from its state.
+-- | The asynchronous demotion action will wait this long for peer status to
+-- change to 'PeerCold' before removing a peer from the OG state. If this times
+-- out, there is a logic error somewhere as this should happen after CM drops
+-- that peer from its state.
 --
 c_PEER_DEMOTION_TIMEOUT :: DiffTime
 c_PEER_DEMOTION_TIMEOUT = 10*60

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -714,13 +714,21 @@ withPeerStateActions PeerStateActionsArguments {
           -- supposed to terminate (unless the remote peer did something
           -- wrong).
           Just (WithSomeProtocolTemperature (WithWarm MiniProtocolSuccess {})) -> do
-            isCooling <- closePeerConnection pch
-            when isCooling
-              $ peerMonitoringLoop pch
+            _peerStatus <- closePeerConnection pch
+            -- if peerStatus is `PeerCold`, in the next loop we'll log
+            -- `CoolingToCold`; it's likely it is `PeerCooling` in which case
+            -- we'll block until whole connection is demoted.
+            peerMonitoringLoop pch
           Just (WithSomeProtocolTemperature (WithEstablished MiniProtocolSuccess {})) -> do
-            isCooling <- closePeerConnection pch
-            when isCooling
-              $ peerMonitoringLoop pch
+            _peerStatus <- closePeerConnection pch
+            -- if peerStatus is `PeerCold`, in the next loop we'll log
+            -- `CoolingToCold`; it's likely it is `PeerCooling` in which case
+            -- we'll block until whole connection is demoted.
+            peerMonitoringLoop pch
+
+          --
+          -- peerMonitingLoop exit
+          --
 
           Nothing ->
             traceWith spsTracer (PeerStatusChanged (CoolingToCold pchConnectionId))
@@ -1007,7 +1015,7 @@ withPeerStateActions PeerStateActionsArguments {
 
 
     closePeerConnection :: PeerConnectionHandle muxMode responderCtx peerAddr versionData ByteString m a b
-                        -> m Bool
+                        -> m PeerStatus
     closePeerConnection
         PeerConnectionHandle {
             pchConnectionId,
@@ -1040,7 +1048,7 @@ withPeerStateActions PeerStateActionsArguments {
             traceWith spsTracer (PeerStatusChangeFailure
                                   (WarmToCooling pchConnectionId)
                                   TimeoutError)
-          (<= PeerCooling) <$> readTVarIO pchPeerStatus
+          readTVarIO pchPeerStatus
 
         Just (SomeErrored errs) -> do
           -- some mini-protocol errored
@@ -1065,7 +1073,7 @@ withPeerStateActions PeerStateActionsArguments {
           when wasWarm $ do
             _ <- releaseOutboundConnection spsConnectionManager pchConnectionId
             traceWith spsTracer (PeerStatusChanged (WarmToCooling pchConnectionId))
-          (<= PeerCooling) <$> readTVarIO pchPeerStatus
+          readTVarIO pchPeerStatus
 
 --
 -- Utilities

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Cardano/MockEnvironment.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/PeerSelection/Cardano/MockEnvironment.hs
@@ -216,9 +216,12 @@ validGovernorMockEnvironment GovernorMockEnvironment {
            , counterexample "public root peers not a subset of  all peers" $
              property (PublicRootPeers.toSet Cardano.ExtraPeers.toSet publicRootPeers `Set.isSubsetOf` allPeersSet)
            , counterexample "failed peer selection targets sanity check" $
-             property (foldl (\ !p ((t, t'), _) -> p && all sanePeerSelectionTargets [t, t'])
-                        True
-                        targets)
+             foldl (\ !p ((t1, t2), _) ->  p
+                                     .&&. counterexample ("deadline targets: " ++ show t1) (sanePeerSelectionTargets t1)
+                                     .&&. counterexample ("sync targets: " ++ show t2) (sanePeerSelectionTargets t2)
+                   )
+                   (property True)
+                   targets
            , counterexample "big ledger peers not a subset of public roots"
                 (PublicRootPeers.invariant Cardano.ExtraPeers.invariant Cardano.ExtraPeers.toSet publicRootPeers)
            ]
@@ -1050,7 +1053,7 @@ instance Arbitrary GovernorMockEnvironment where
                                   targetNumberOfEstablishedPeers = genesisEst,
                                   targetNumberOfActivePeers = genesisAct,
                                   targetNumberOfKnownBigLedgerPeers = genesisBigKnown,
-                                  targetNumberOfEstablishedBigLedgerPeers = genesisBigKnown,
+                                  targetNumberOfEstablishedBigLedgerPeers = genesisBigEst,
                                   targetNumberOfActiveBigLedgerPeers = genesisBigAct }
                           let lsjWithDelay = (,) lsj <$> elements [ShortDelay, NoDelay]
                               -- synchronize target basis with ledger state judgement


### PR DESCRIPTION
The `peerMonitoringLoop` was prematurelly terminating, not logging
`CoolingToCold`.
