### PR TITLE
Use strict pairs in network-mux IngressQueue

### DIFF
--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* `IngressQueue` is parameterized by a strict `Pair` type
+
 ### Non-breaking changes
 
 ## 0.9.0.0 -- 2025-06-28

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -60,6 +60,7 @@ library
     process ^>=1.6,
     quiet,
     statistics-linreg >=0.3 && <0.4,
+    strict,
     time >=1.9.1 && <1.14,
     vector >=0.12 && <0.14,
 
@@ -204,6 +205,7 @@ benchmark socket-read-write-benchmarks
     io-classes:{io-classes, si-timers, strict-stm},
     network,
     network-mux,
+    strict,
     tasty-bench,
 
   default-extensions: ImportQualifiedPost

--- a/network-mux/src/Network/Mux/Types.hs
+++ b/network-mux/src/Network/Mux/Types.hs
@@ -54,6 +54,7 @@ import Data.ByteString.Lazy qualified as BL
 import Data.Functor (void)
 import Data.Int
 import Data.Ix (Ix (..))
+import Data.Strict.Tuple as Strict (Pair)
 import Data.Word
 import Foreign.Ptr (Ptr)
 import Quiet
@@ -180,7 +181,7 @@ data Status
 -- Mux internal types
 --
 
-type IngressQueue m = StrictTVar m (Int64, Builder)
+type IngressQueue m = StrictTVar m (Strict.Pair Int64 Builder)
 
 -- | The index of a protocol in a MuxApplication, used for array indices
 newtype MiniProtocolIx = MiniProtocolIx Int


### PR DESCRIPTION
# Description

Use strict pairs in mux's ingress queue

resolves #5101 

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
