### PR TITLE
Moved NodeToNode and NodeToClient modules to cardano-diffusion

### DIFF
--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -28,7 +28,7 @@ library
     contra-tracer >=0.1 && <0.3,
     io-classes:si-timers ^>=1.8.0.1,
     network-mux ^>=0.9,
-    ouroboros-network ^>=0.22,
+    ouroboros-network:cardano-diffusion ^>=0.22,
     ouroboros-network-api ^>=0.15,
     ouroboros-network-framework ^>=0.19,
 

--- a/cardano-client/src/Cardano/Client/Subscription.hs
+++ b/cardano-client/src/Cardano/Client/Subscription.hs
@@ -41,17 +41,17 @@ import Data.Void (Void)
 
 import Network.Mux qualified as Mx
 
+import Cardano.Network.NodeToClient (Handshake, LocalAddress (..),
+           NetworkConnectTracers (..), NodeToClientProtocols,
+           NodeToClientVersion, NodeToClientVersionData (..), TraceSendRecv,
+           Versions)
+import Cardano.Network.NodeToClient qualified as NtC
+
+import Ouroboros.Network.ConnectionId (ConnectionId (..))
 import Ouroboros.Network.ControlMessage (ControlMessage (..))
 import Ouroboros.Network.Magic (NetworkMagic)
 import Ouroboros.Network.Mux (MiniProtocolCb (..),
            OuroborosApplicationWithMinimalCtx, RunMiniProtocol (..))
-
-import Ouroboros.Network.ConnectionId (ConnectionId (..))
-import Ouroboros.Network.NodeToClient (Handshake, LocalAddress (..),
-           NetworkConnectTracers (..), NodeToClientProtocols,
-           NodeToClientVersion, NodeToClientVersionData (..), TraceSendRecv,
-           Versions)
-import Ouroboros.Network.NodeToClient qualified as NtC
 import Ouroboros.Network.Snocket qualified as Snocket
 
 type MuxMode  = Mx.Mode

--- a/decentralized-message-queue/decentralized-message-queue.cabal
+++ b/decentralized-message-queue/decentralized-message-queue.cabal
@@ -88,7 +88,7 @@ library
     network-mux ^>=0.9,
     nothunks ^>=0.1.4 || ^>=0.2,
     optparse-applicative ^>=0.18,
-    ouroboros-network:{ouroboros-network, orphan-instances} ^>=0.22,
+    ouroboros-network:{ouroboros-network, cardano-diffusion, orphan-instances} ^>=0.22,
     ouroboros-network-api ^>=0.15,
     ouroboros-network-framework ^>=0.19,
     ouroboros-network-protocols ^>=0.15,

--- a/decentralized-message-queue/src/DMQ/Configuration.hs
+++ b/decentralized-message-queue/src/DMQ/Configuration.hs
@@ -30,7 +30,7 @@ import Ouroboros.Network.Diffusion.Topology (NetworkTopology (..),
            producerAddresses)
 import Ouroboros.Network.Diffusion.Types qualified as Diffusion
 import Ouroboros.Network.Magic (NetworkMagic (..))
-import Ouroboros.Network.NodeToNode (DiffusionMode (..))
+import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.OrphanInstances ()
 import Ouroboros.Network.PeerSelection.Governor.Types
            (PeerSelectionTargets (..), makePublicPeerSelectionStateVar)

--- a/decentralized-message-queue/src/DMQ/Diffusion/Applications.hs
+++ b/decentralized-message-queue/src/DMQ/Diffusion/Applications.hs
@@ -20,15 +20,16 @@ import Control.Monad.Class.MonadFork (MonadFork, MonadThread)
 import Control.Monad.Class.MonadST (MonadST)
 import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTimer.SI (MonadTimer)
+
 import Data.ByteString.Lazy qualified as BL
 import Data.Hashable (Hashable)
+
 import Ouroboros.Network.Diffusion.Types qualified as Diffusion
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import Ouroboros.Network.Mux (OuroborosApplication (..))
-import Ouroboros.Network.NodeToClient (combineVersions)
-import Ouroboros.Network.NodeToNode ()
 import Ouroboros.Network.PeerSelection.Governor.Types (PeerSelectionPolicy)
-import Ouroboros.Network.Protocol.Handshake.Version (simpleSingletonVersions)
+import Ouroboros.Network.Protocol.Handshake.Version (combineVersions,
+           simpleSingletonVersions)
 import Ouroboros.Network.RethrowPolicy (ioErrorRethrowPolicy,
            muxErrorRethrowPolicy)
 

--- a/decentralized-message-queue/src/DMQ/Diffusion/Arguments.hs
+++ b/decentralized-message-queue/src/DMQ/Diffusion/Arguments.hs
@@ -15,11 +15,10 @@ import Control.Tracer (Tracer)
 import Network.DNS (Resolver)
 import Network.Socket (Socket)
 
-import DMQ.NodeToClient
-import DMQ.NodeToNode
+import DMQ.NodeToClient as NtC
+import DMQ.NodeToNode as NtN
 import DMQ.NodeToNode qualified as DMQ
 import Ouroboros.Network.Diffusion.Types qualified as Diffusion
-import Ouroboros.Network.NodeToNode (HandshakeTr)
 import Ouroboros.Network.PeerSelection.Churn (peerChurnGovernor)
 import Ouroboros.Network.PeerSelection.Governor.Types
            (ExtraGuardedDecisions (..), PeerSelectionGovernorArgs (..))
@@ -37,8 +36,8 @@ diffusionArguments
      , MonadTimer m
      , Exception exception
      )
-  => Tracer m (HandshakeTr ntnAddr NodeToNodeVersion)
-  -> Tracer m (HandshakeTr ntcAddr NodeToClientVersion)
+  => Tracer m (NtN.HandshakeTr ntnAddr)
+  -> Tracer m (NtC.HandshakeTr ntcAddr)
   -> Diffusion.Arguments
        () () () () () () ()
        exception

--- a/decentralized-message-queue/src/DMQ/Diffusion/NodeKernel.hs
+++ b/decentralized-message-queue/src/DMQ/Diffusion/NodeKernel.hs
@@ -9,7 +9,7 @@ import Control.DeepSeq (NFData)
 import NoThunks.Class (NoThunks)
 import Ouroboros.Network.BlockFetch (FetchClientRegistry,
            newFetchClientRegistry)
-import Ouroboros.Network.NodeToNode (ConnectionId (..))
+import Ouroboros.Network.ConnectionId (ConnectionId (..))
 import Ouroboros.Network.PeerSelection.Governor.Types
            (makePublicPeerSelectionStateVar)
 import Ouroboros.Network.PeerSharing (PeerSharingAPI, PeerSharingRegistry,

--- a/decentralized-message-queue/src/DMQ/NodeToClient.hs
+++ b/decentralized-message-queue/src/DMQ/NodeToClient.hs
@@ -15,13 +15,16 @@ import GHC.Generics (Generic)
 
 import Control.Monad.Class.MonadST (MonadST)
 import Control.Tracer (Tracer, nullTracer)
+
+import Network.Mux qualified as Mx
+
 import Ouroboros.Network.CodecCBORTerm (CodecCBORTerm (..))
 import Ouroboros.Network.ConnectionId (ConnectionId)
+import Ouroboros.Network.Driver.Simple (TraceSendRecv)
 import Ouroboros.Network.Handshake.Acceptable (Acceptable (..))
 import Ouroboros.Network.Handshake.Queryable (Queryable (..))
 import Ouroboros.Network.Magic (NetworkMagic (..))
-import Ouroboros.Network.NodeToClient (HandshakeTr)
-import Ouroboros.Network.Protocol.Handshake (Accept (..),
+import Ouroboros.Network.Protocol.Handshake (Accept (..), Handshake,
            HandshakeArguments (..))
 import Ouroboros.Network.Protocol.Handshake.Codec (cborTermVersionDataCodec,
            codecHandshake, noTimeLimitsHandshake)
@@ -107,9 +110,11 @@ data Protocols =
   Protocols {
   }
 
+type HandshakeTr ntcAddr = Mx.WithBearer (ConnectionId ntcAddr) (TraceSendRecv (Handshake NodeToClientVersion CBOR.Term))
+
 ntcHandshakeArguments
   :: MonadST m
-  => Tracer m (HandshakeTr ntcAddr NodeToClientVersion)
+  => Tracer m (HandshakeTr ntcAddr)
   -> HandshakeArguments
       (ConnectionId ntcAddr)
       NodeToClientVersion

--- a/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Snocket.hs
@@ -9,10 +9,13 @@
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE StandaloneDeriving         #-}
+{-# LANGUAGE TypeSynonymInstances       #-}
 
 #if !defined(mingw32_HOST_OS)
 #define POSIX
 #endif
+
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Ouroboros.Network.Snocket
   ( -- * Snocket Interface
@@ -20,6 +23,8 @@ module Ouroboros.Network.Snocket
   , Accepted (..)
   , AddressFamily (..)
   , Snocket (..)
+  , RemoteAddress
+  , RemoteConnectionId
   , makeSocketBearer
   , makeSocketBearer'
   , makeLocalRawBearer
@@ -34,6 +39,7 @@ module Ouroboros.Network.Snocket
   , makeLocalBearer
   , LocalSocket (..)
   , LocalAddress (..)
+  , LocalConnectionId
   , localAddressFromPath
   , TestAddress (..)
   , FileDescriptor
@@ -68,8 +74,17 @@ import Network.Socket qualified as Socket
 
 import Network.Mux.Bearer
 
+import Ouroboros.Network.ConnectionId
 import Ouroboros.Network.IOManager
 import Ouroboros.Network.RawBearer
+import Ouroboros.Network.Util.ShowProxy (ShowProxy, showProxy)
+
+
+type RemoteAddress      = Socket.SockAddr
+type RemoteConnectionId = ConnectionId RemoteAddress
+
+instance ShowProxy RemoteAddress where
+  showProxy _ = "SockAddr"
 
 
 -- | Named pipes and Berkeley sockets have different API when accepting
@@ -197,6 +212,7 @@ newtype LocalAddress = LocalAddress { getFilePath :: FilePath }
   deriving (Eq, Ord, Generic)
   deriving Show via Quiet LocalAddress
 
+
 instance Hashable LocalAddress where
     hashWithSalt s (LocalAddress path) = hashWithSalt s path
 
@@ -206,6 +222,8 @@ newtype TestAddress addr = TestAddress { getTestAddress :: addr }
   deriving Show via Quiet (TestAddress addr)
 
 instance Hashable addr => Hashable (TestAddress addr)
+
+type LocalConnectionId = ConnectionId LocalAddress
 
 -- | We support either sockets or named pipes.
 --

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Breaking changes
 
+* `Ouroboros.Network.NodeTo{Client,Node}` modules moved to
+  `ouroboros-network:cardano-diffusion` (as `Cardano.Network.NodeTo{Node,Client}`)
+
 ### Non-breaking changes
 
 ## 0.22.0.0 -- 28.06.2025

--- a/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion.hs
+++ b/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion.hs
@@ -26,6 +26,10 @@ import Cardano.Network.Diffusion.Configuration qualified as Cardano
 import Cardano.Network.Diffusion.Handlers qualified as Cardano
 import Cardano.Network.Diffusion.Types
 import Cardano.Network.LedgerPeerConsensusInterface qualified as Cardano
+import Cardano.Network.NodeToClient qualified as NodeToClient
+import Cardano.Network.NodeToNode (NodeToNodeVersionData (..), RemoteAddress,
+           ntnDataFlow)
+import Cardano.Network.NodeToNode qualified as NodeToNode
 import Cardano.Network.PeerSelection.Churn qualified as Cardano.Churn
 import Cardano.Network.PeerSelection.ExtraRootPeers qualified as Cardano
 import Cardano.Network.PeerSelection.Governor.PeerSelectionActions qualified as Cardano
@@ -35,10 +39,6 @@ import Cardano.Network.PeerSelection.PeerSelectionActions qualified as Cardano
 
 import Ouroboros.Network.Diffusion qualified as Diffusion
 import Ouroboros.Network.IOManager
-import Ouroboros.Network.NodeToClient qualified as NodeToClient
-import Ouroboros.Network.NodeToNode (NodeToNodeVersionData (..), RemoteAddress,
-           ntnDataFlow)
-import Ouroboros.Network.NodeToNode qualified as NodeToNode
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type
            (LedgerPeersConsensusInterface (..))
 import Ouroboros.Network.Protocol.Handshake

--- a/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion/Configuration.hs
+++ b/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion/Configuration.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns    #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- | One stop shop for configuring diffusion layer for upstream clients
@@ -10,13 +11,21 @@ module Cardano.Network.Diffusion.Configuration
   , defaultSyncTargets
   , defaultNumberOfBigLedgerPeers
   , defaultChainSyncIdleTimeout
+  , defaultBlockFetchConfiguration
+  , defaultMiniProtocolParameters
   , srvPrefix
     -- * Re-exports
   , ChainSyncIdleTimeout (..)
+  , BlockFetchConfiguration (..)
+  , MiniProtocolParameters (..)
   ) where
 
+import Cardano.Network.NodeToNode (MiniProtocolParameters (..),
+           defaultMiniProtocolParameters)
 import Cardano.Network.Types (NumberOfBigLedgerPeers (..))
 
+import Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
+           GenesisBlockFetchConfiguration (..))
 import Ouroboros.Network.PeerSelection.Governor.Types
            (PeerSelectionTargets (..))
 import Ouroboros.Network.PeerSelection.RelayAccessPoint (SRVPrefix)
@@ -64,3 +73,18 @@ defaultChainSyncIdleTimeout = ChainSyncIdleTimeout 3373
 
 srvPrefix :: SRVPrefix
 srvPrefix = "_cardano._tcp"
+
+
+-- | Configuration for FetchDecisionPolicy.
+--
+defaultBlockFetchConfiguration :: Int -> BlockFetchConfiguration
+defaultBlockFetchConfiguration bfcSalt =
+  BlockFetchConfiguration {
+    bfcMaxConcurrencyBulkSync = 1,
+    bfcMaxConcurrencyDeadline = 1,
+    bfcMaxRequestsInflight    = fromIntegral $ blockFetchPipeliningMax defaultMiniProtocolParameters,
+    bfcDecisionLoopIntervalGenesis = 0.04,  -- 40ms
+    bfcDecisionLoopIntervalPraos = 0.01,  -- 10ms
+    bfcGenesisBFConfig        = GenesisBlockFetchConfiguration
+      { gbfcGracePeriod = 10 },  -- seconds
+    bfcSalt }

--- a/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion/Types.hs
+++ b/ouroboros-network/cardano-diffusion/Cardano/Network/Diffusion/Types.hs
@@ -28,6 +28,10 @@ import Control.Tracer (Tracer)
 import Network.Socket (SockAddr, Socket)
 
 import Cardano.Network.LedgerPeerConsensusInterface qualified as Cardano
+import Cardano.Network.NodeToClient (LocalAddress, LocalSocket,
+           NodeToClientVersion, NodeToClientVersionData)
+import Cardano.Network.NodeToNode (NodeToNodeVersion, NodeToNodeVersionData,
+           RemoteAddress)
 import Cardano.Network.PeerSelection.Bootstrap (UseBootstrapPeers)
 import Cardano.Network.PeerSelection.Churn qualified as Cardano.Churn
 import Cardano.Network.PeerSelection.ExtraRootPeers (ExtraPeers)
@@ -40,10 +44,6 @@ import Cardano.Network.Types (NumberOfBigLedgerPeers (..))
 
 import Ouroboros.Network.Diffusion qualified as Diffusion
 import Ouroboros.Network.Diffusion.Configuration (ConsensusMode)
-import Ouroboros.Network.NodeToClient (LocalAddress, LocalSocket,
-           NodeToClientVersion, NodeToClientVersionData)
-import Ouroboros.Network.NodeToNode (NodeToNodeVersion, NodeToNodeVersionData,
-           RemoteAddress)
 import Ouroboros.Network.PeerSelection.Governor.Types (DebugPeerSelection,
            PeerSelectionCounters, PeerSelectionTargets (..), TracePeerSelection)
 import Ouroboros.Network.PeerSelection.LedgerPeers.Type

--- a/ouroboros-network/cardano-diffusion/Cardano/Network/NodeToNode.hs
+++ b/ouroboros-network/cardano-diffusion/Cardano/Network/NodeToNode.hs
@@ -11,7 +11,7 @@
 -- | This is the starting point for a module that will bring together the
 -- overall node to node protocol, as a collection of mini-protocols.
 --
-module Ouroboros.Network.NodeToNode
+module Cardano.Network.NodeToNode
   ( nodeToNodeProtocols
   , NodeToNodeProtocols (..)
   , NodeToNodeProtocolsWithExpandedCtx
@@ -64,7 +64,6 @@ module Ouroboros.Network.NodeToNode
     -- ** Traces
   , AcceptConnectionsPolicyTrace (..)
   , TraceSendRecv (..)
-  , HandshakeTr
     -- * For Consensus ThreadNet Tests
   , chainSyncMiniProtocolNum
   , blockFetchMiniProtocolNum
@@ -75,9 +74,9 @@ module Ouroboros.Network.NodeToNode
 
 import Control.Exception (SomeException)
 
-import Codec.CBOR.Term qualified as CBOR
 import Data.ByteString.Lazy qualified as BL
 import Data.Word
+
 import Network.Mux qualified as Mx
 import Network.Socket (Socket, StructLinger (..))
 import Network.Socket qualified as Socket
@@ -101,13 +100,6 @@ import Ouroboros.Network.Protocol.TxSubmission2.Type (NumTxIdsToAck (..))
 import Ouroboros.Network.Server.RateLimiting
 import Ouroboros.Network.Snocket
 import Ouroboros.Network.Socket
-import Ouroboros.Network.Util.ShowProxy (ShowProxy, showProxy)
-
-
--- The Handshake tracer types are simply terrible.
-type HandshakeTr ntnAddr ntnVersion =
-    Mx.WithBearer (ConnectionId ntnAddr)
-                  (TraceSendRecv (Handshake ntnVersion CBOR.Term))
 
 
 data NodeToNodeProtocols appType initiatorCtx responderCtx bytes m a b = NodeToNodeProtocols {
@@ -431,10 +423,3 @@ ntnDataFlow NodeToNodeVersionData { diffusionMode } =
   case diffusionMode of
     InitiatorAndResponderDiffusionMode -> Duplex
     InitiatorOnlyDiffusionMode         -> Unidirectional
-
-type RemoteAddress      = Socket.SockAddr
-
-instance ShowProxy RemoteAddress where
-  showProxy _ = "SockAddr"
-
-type RemoteConnectionId = ConnectionId RemoteAddress

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -46,15 +46,15 @@ import Network.TypedProtocol.Codec
 
 import Network.Mux qualified as Mx
 
+import Cardano.Network.NodeToClient
+import Cardano.Network.NodeToNode
+
 import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.Block
 import Ouroboros.Network.ControlMessage (continueForever)
-import Ouroboros.Network.IOManager
 import Ouroboros.Network.Mock.Chain qualified as Chain
 import Ouroboros.Network.Mock.ConcreteBlock
 import Ouroboros.Network.Mux
-import Ouroboros.Network.NodeToClient (LocalConnectionId)
-import Ouroboros.Network.NodeToNode
 import Ouroboros.Network.Point (WithOrigin (..))
 import Ouroboros.Network.Snocket
 import Ouroboros.Network.Socket

--- a/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
+++ b/ouroboros-network/io-tests/Test/Ouroboros/Network/Socket.hs
@@ -31,13 +31,14 @@ import Ouroboros.Network.Mux
 import Ouroboros.Network.Snocket
 import Ouroboros.Network.Socket
 
+import Cardano.Network.NodeToNode
+
 import Ouroboros.Network.Block (Tip, decodeTip, encodeTip)
 import Ouroboros.Network.IOManager
 import Ouroboros.Network.Magic
 import Ouroboros.Network.Mock.Chain (Chain, ChainUpdate, Point)
 import Ouroboros.Network.Mock.Chain qualified as Chain
 import Ouroboros.Network.Mock.ProducerState qualified as CPS
-import Ouroboros.Network.NodeToNode
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
 import Ouroboros.Network.Protocol.ChainSync.Client qualified as ChainSync
 import Ouroboros.Network.Protocol.ChainSync.Codec qualified as ChainSync

--- a/ouroboros-network/orphan-instances/Cardano/Network/OrphanInstances.hs
+++ b/ouroboros-network/orphan-instances/Cardano/Network/OrphanInstances.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
+
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,11 +11,17 @@ import Data.Aeson
 import Data.Aeson qualified as Aeson
 import Data.Map qualified as Map
 
+import Cardano.Network.NodeToClient (NodeToClientVersion (..),
+           NodeToClientVersionData (..))
+import Cardano.Network.NodeToNode (NodeToNodeVersion (..),
+           NodeToNodeVersionData (..))
 import Cardano.Network.PeerSelection.Bootstrap
 import Cardano.Network.PeerSelection.PeerTrustable (PeerTrustable (..))
 import Cardano.Network.PeerSelection.PublicRootPeers (CardanoPublicRootPeers,
            getBootstrapPeers, getPublicConfigPeers)
 import Cardano.Network.Types
+
+import Ouroboros.Network.Magic (NetworkMagic (..))
 import Ouroboros.Network.PeerSelection.PublicRootPeers
 
 instance ToJSON LedgerStateJudgement where
@@ -52,3 +60,49 @@ instance ToJSON PeerTrustable where
   toJSON IsNotTrustable = Bool False
 
 instance ToJSONKey PeerTrustable where
+
+instance FromJSON NodeToNodeVersion where
+  parseJSON = \case
+    Number 14 -> pure NodeToNodeV_14
+    Number 15 -> pure NodeToNodeV_15
+    Number x  -> fail $ "FromJSON.NodeToNodeVersion: unsupported node-to-node protocol version " ++ show x
+    x         -> fail $ "FromJSON.NodeToNodeVersion: error parsing NodeToNodeVersion: " ++ show x
+
+instance ToJSON NodeToNodeVersion where
+  toJSON NodeToNodeV_14 = Number 14
+  toJSON NodeToNodeV_15 = Number 15
+
+instance FromJSON NodeToClientVersion where
+  parseJSON = \case
+    Number 16 -> pure NodeToClientV_16
+    Number 17 -> pure NodeToClientV_17
+    Number 18 -> pure NodeToClientV_18
+    Number 19 -> pure NodeToClientV_19
+    Number 20 -> pure NodeToClientV_20
+    Number 21 -> pure NodeToClientV_21
+    Number x  -> fail $ "FromJSON.NodeToClientVersion: unsupported node-to-client protocol version " ++ show x
+    x         -> fail $ "FromJSON.NodeToClientVersion: error parsing NodeToClientVersion: " ++ show x
+
+instance ToJSON NodeToClientVersion where
+  toJSON = \case
+    NodeToClientV_16 -> Number 16
+    NodeToClientV_17 -> Number 17
+    NodeToClientV_18 -> Number 18
+    NodeToClientV_19 -> Number 19
+    NodeToClientV_20 -> Number 20
+    NodeToClientV_21 -> Number 21
+
+instance ToJSON NodeToNodeVersionData where
+  toJSON (NodeToNodeVersionData (NetworkMagic m) dm ps q) = object
+    [ "networkMagic"  .= toJSON m
+    , "diffusionMode" .= show dm
+    , "peerSharing"   .= show ps
+    , "query"         .= toJSON q
+    ]
+
+instance ToJSON NodeToClientVersionData where
+  toJSON (NodeToClientVersionData (NetworkMagic m) q) = object
+    [ "networkMagic" .= toJSON m
+    , "query"        .= toJSON q
+    ]
+

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -73,8 +73,6 @@ library
     Ouroboros.Network.Diffusion.Utils
     Ouroboros.Network.ExitPolicy
     Ouroboros.Network.KeepAlive
-    Ouroboros.Network.NodeToClient
-    Ouroboros.Network.NodeToNode
     Ouroboros.Network.PeerSelection
     Ouroboros.Network.PeerSelection.Churn
     Ouroboros.Network.PeerSelection.Governor
@@ -111,8 +109,6 @@ library
     Ouroboros.Network.AnchoredFragment,
     Ouroboros.Network.AnchoredSeq,
     Ouroboros.Network.Magic,
-    Ouroboros.Network.NodeToClient.Version,
-    Ouroboros.Network.NodeToNode.Version,
 
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -141,7 +137,6 @@ library
     TypeInType
 
   build-depends:
-    async >=2.2 && <2.3,
     base >=4.14 && <4.22,
     bytestring >=0.10 && <0.13,
     cardano-prelude,
@@ -168,7 +163,7 @@ library
     random,
     strict-checked-vars ^>=0.2,
     transformers,
-    typed-protocols:{typed-protocols, stateful} ^>=1.0,
+    typed-protocols ^>=1.0,
 
   if !os(windows)
     build-depends:
@@ -243,6 +238,8 @@ library cardano-diffusion
     Cardano.Network.Diffusion.Topology
     Cardano.Network.Diffusion.Types
     Cardano.Network.LedgerPeerConsensusInterface
+    Cardano.Network.NodeToClient
+    Cardano.Network.NodeToNode
     Cardano.Network.PeerSelection.Churn
     Cardano.Network.PeerSelection.ExtraRootPeers
     Cardano.Network.PeerSelection.Governor.Monitor
@@ -282,17 +279,20 @@ library cardano-diffusion
 
   build-depends:
     base >=4.14 && <4.22,
+    bytestring,
     containers,
     contra-tracer,
     dns,
     io-classes:{io-classes, si-timers, strict-stm} ^>=1.8,
     monoidal-synchronisation,
     network ^>=3.2.7,
+    network-mux,
     ouroboros-network,
     ouroboros-network-api ^>=0.15,
     ouroboros-network-framework ^>=0.19,
     ouroboros-network-protocols ^>=0.15,
     random,
+    typed-protocols:{typed-protocols, stateful} ^>=1.0,
 
   if !os(windows)
     build-depends:
@@ -353,6 +353,10 @@ library testlib
   exposed-modules:
     Ouroboros.Network.BlockFetch.Examples
     Ouroboros.Network.MockNode
+    Test.Cardano.Network.NodeToClient.Version
+    Test.Cardano.Network.NodeToNode.Version
+    Test.Cardano.Network.OrphanInstances.Tests
+    Test.Cardano.Network.Version
     Test.Ouroboros.Network.BlockFetch
     Test.Ouroboros.Network.Diffusion.Node
     Test.Ouroboros.Network.Diffusion.Node.ChainDB
@@ -365,9 +369,6 @@ library testlib
     Test.Ouroboros.Network.LedgerPeers
     Test.Ouroboros.Network.MockNode
     Test.Ouroboros.Network.Mux
-    Test.Ouroboros.Network.NodeToClient.Version
-    Test.Ouroboros.Network.NodeToNode.Version
-    Test.Ouroboros.Network.OrphanInstances.Tests
     Test.Ouroboros.Network.Orphans
     Test.Ouroboros.Network.PeerSelection
     Test.Ouroboros.Network.PeerSelection.Cardano.Instances
@@ -383,7 +384,6 @@ library testlib
     Test.Ouroboros.Network.PeerSelection.RootPeersDNS
     Test.Ouroboros.Network.PeerSelection.Utils
     Test.Ouroboros.Network.TxSubmission
-    Test.Ouroboros.Network.Version
 
 -- Simulation tests, and IO tests which don't require native system calls.
 -- (i.e. they don't require system call API provided by `Win32-network` or
@@ -434,7 +434,7 @@ test-suite io-tests
     monoidal-synchronisation,
     network,
     network-mux,
-    ouroboros-network,
+    ouroboros-network:cardano-diffusion,
     ouroboros-network-api,
     ouroboros-network-framework,
     ouroboros-network-mock,
@@ -475,7 +475,7 @@ executable demo-chain-sync
     io-classes:{si-timers, strict-stm},
     network-mux,
     optparse-applicative,
-    ouroboros-network,
+    ouroboros-network:{ouroboros-network, cardano-diffusion},
     ouroboros-network-api,
     ouroboros-network-framework,
     ouroboros-network-mock,

--- a/ouroboros-network/sim-tests/Main.hs
+++ b/ouroboros-network/sim-tests/Main.hs
@@ -3,16 +3,19 @@ module Main (main) where
 import Main.Utf8 (withUtf8)
 import Test.Tasty
 
+import Test.Cardano.Network.NodeToClient.Version qualified (tests)
+import Test.Cardano.Network.NodeToNode.Version qualified (tests)
+import Test.Cardano.Network.OrphanInstances.Tests qualified (tests)
+import Test.Cardano.Network.Version qualified (tests)
+
 import Test.ChainProducerState qualified (tests)
+
 import Test.Ouroboros.Network.BlockFetch qualified (tests)
 import Test.Ouroboros.Network.Diffusion.Policies qualified (tests)
 import Test.Ouroboros.Network.Diffusion.Testnet.Cardano qualified (tests)
 import Test.Ouroboros.Network.KeepAlive qualified (tests)
 import Test.Ouroboros.Network.LedgerPeers qualified (tests)
 import Test.Ouroboros.Network.MockNode qualified (tests)
-import Test.Ouroboros.Network.NodeToClient.Version qualified (tests)
-import Test.Ouroboros.Network.NodeToNode.Version qualified (tests)
-import Test.Ouroboros.Network.OrphanInstances.Tests qualified (tests)
 import Test.Ouroboros.Network.PeerSelection qualified (tests)
 import Test.Ouroboros.Network.PeerSelection.Cardano.LocalRootPeers qualified
 import Test.Ouroboros.Network.PeerSelection.Cardano.MockEnvironment qualified
@@ -22,7 +25,6 @@ import Test.Ouroboros.Network.PeerSelection.LocalRootPeers qualified
 import Test.Ouroboros.Network.PeerSelection.PeerMetric qualified
 import Test.Ouroboros.Network.PeerSelection.RootPeersDNS qualified
 import Test.Ouroboros.Network.TxSubmission qualified (tests)
-import Test.Ouroboros.Network.Version qualified (tests)
 
 main :: IO ()
 main = withUtf8 $ defaultMain tests
@@ -33,21 +35,23 @@ tests =
     -- data structures
   [ Test.ChainProducerState.tests
 
+    -- cardano
+  , Test.Cardano.Network.NodeToClient.Version.tests
+  , Test.Cardano.Network.NodeToNode.Version.tests
+  , Test.Cardano.Network.OrphanInstances.Tests.tests
+  , Test.Cardano.Network.Version.tests
+
     -- network logic
   , Test.Ouroboros.Network.Diffusion.Policies.tests
   , Test.Ouroboros.Network.LedgerPeers.tests
   , Test.Ouroboros.Network.BlockFetch.tests
   , Test.Ouroboros.Network.KeepAlive.tests
   , Test.Ouroboros.Network.TxSubmission.tests
-  , Test.Ouroboros.Network.NodeToClient.Version.tests
-  , Test.Ouroboros.Network.NodeToNode.Version.tests
-  , Test.Ouroboros.Network.OrphanInstances.Tests.tests
   , Test.Ouroboros.Network.PeerSelection.KnownPeers.tests
   , Test.Ouroboros.Network.PeerSelection.LocalRootPeers.tests
   , Test.Ouroboros.Network.PeerSelection.PeerMetric.tests
   , Test.Ouroboros.Network.PeerSelection.RootPeersDNS.tests
   , Test.Ouroboros.Network.PeerSelection.tests
-  , Test.Ouroboros.Network.Version.tests
 
     -- cardano specific logic
   , Test.Ouroboros.Network.Diffusion.Testnet.Cardano.tests

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -69,7 +69,6 @@ import Ouroboros.Network.InboundGovernor.InformationChannel (InformationChannel,
 import Ouroboros.Network.IOManager
 import Ouroboros.Network.Mux hiding (MiniProtocol (..))
 import Ouroboros.Network.MuxMode
-import Ouroboros.Network.NodeToNode (RemoteAddress)
 import Ouroboros.Network.PeerSelection as PeerSelection
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor
 import Ouroboros.Network.PeerSelection.RootPeersDNS (PeerActionsDNS (..))
@@ -79,7 +78,7 @@ import Ouroboros.Network.PeerSharing (PeerSharingRegistry (..))
 import Ouroboros.Network.Protocol.Handshake
 import Ouroboros.Network.RethrowPolicy
 import Ouroboros.Network.Server qualified as Server
-import Ouroboros.Network.Snocket (LocalAddress, LocalSocket (..),
+import Ouroboros.Network.Snocket (LocalAddress, LocalSocket (..), RemoteAddress,
            localSocketFileDescriptor, makeLocalBearer, makeSocketBearer')
 import Ouroboros.Network.Snocket qualified as Snocket
 import Ouroboros.Network.Socket (configureSocket, configureSystemdSocket)

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Configuration.hs
@@ -6,21 +6,17 @@
 module Ouroboros.Network.Diffusion.Configuration
   ( defaultAcceptedConnectionsLimit
   , defaultPeerSharing
-  , defaultBlockFetchConfiguration
   , defaultDeadlineTargets
   , defaultDeadlineChurnInterval
   , defaultBulkChurnInterval
     -- re-exports
   , AcceptedConnectionsLimit (..)
-  , BlockFetchConfiguration (..)
   , DiffusionMode (..)
-  , MiniProtocolParameters (..)
   , PeerSelectionTargets (..)
   , PeerSharing (..)
   , ConsensusMode (..)
   , defaultConsensusMode
   , defaultEgressPollInterval
-  , defaultMiniProtocolParameters
   , deactivateTimeout
   , closeConnectionTimeout
   , peerMetricsConfiguration
@@ -37,14 +33,11 @@ module Ouroboros.Network.Diffusion.Configuration
 import Control.Monad.Class.MonadTime.SI
 
 import Cardano.Network.ConsensusMode
-import Ouroboros.Network.BlockFetch (BlockFetchConfiguration (..),
-           GenesisBlockFetchConfiguration (..))
 import Ouroboros.Network.ConnectionManager.Core (defaultProtocolIdleTimeout,
            defaultResetTimeout, defaultTimeWaitTimeout)
 import Ouroboros.Network.Diffusion.Policies (closeConnectionTimeout,
            deactivateTimeout, peerMetricsConfiguration)
-import Ouroboros.Network.NodeToNode (DiffusionMode (..),
-           MiniProtocolParameters (..), defaultMiniProtocolParameters)
+import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection.Governor.Types
            (PeerSelectionTargets (..))
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing (..))
@@ -83,20 +76,6 @@ defaultAcceptedConnectionsLimit =
 --
 defaultPeerSharing :: PeerSharing
 defaultPeerSharing = PeerSharingEnabled
-
--- | Configuration for FetchDecisionPolicy.
---
-defaultBlockFetchConfiguration :: Int -> BlockFetchConfiguration
-defaultBlockFetchConfiguration bfcSalt =
-  BlockFetchConfiguration {
-    bfcMaxConcurrencyBulkSync = 1,
-    bfcMaxConcurrencyDeadline = 1,
-    bfcMaxRequestsInflight    = fromIntegral $ blockFetchPipeliningMax defaultMiniProtocolParameters,
-    bfcDecisionLoopIntervalGenesis = 0.04,  -- 40ms
-    bfcDecisionLoopIntervalPraos = 0.01,  -- 10ms
-    bfcGenesisBFConfig        = GenesisBlockFetchConfiguration
-      { gbfcGracePeriod = 10 },  -- seconds
-    bfcSalt }
 
 defaultDeadlineChurnInterval :: DiffTime
 defaultDeadlineChurnInterval = 3300

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerMetric.hs
@@ -6,8 +6,6 @@
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving  #-}
-
 
 module Ouroboros.Network.PeerSelection.PeerMetric
   ( -- * Peer metrics
@@ -53,8 +51,8 @@ import NoThunks.Class
 import NoThunks.Class.Orphans ()
 
 import Cardano.Slotting.Slot (SlotNo (..))
+import Ouroboros.Network.ConnectionId (ConnectionId (..))
 import Ouroboros.Network.DeltaQ (SizeInBytes)
-import Ouroboros.Network.NodeToNode (ConnectionId (..))
 import Ouroboros.Network.PeerSelection.PeerMetric.Type
 
 

--- a/ouroboros-network/testlib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/testlib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -39,6 +39,8 @@ import Ouroboros.Network.Block
 
 import Network.TypedProtocol.Peer.Client
 
+import Cardano.Network.NodeToNode (NodeToNodeVersion (..))
+
 import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.Client
@@ -47,7 +49,6 @@ import Ouroboros.Network.Channel
 import Ouroboros.Network.ControlMessage
 import Ouroboros.Network.DeltaQ
 import Ouroboros.Network.Driver
-import Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
 import Ouroboros.Network.Protocol.BlockFetch.Codec
 import Ouroboros.Network.Protocol.BlockFetch.Server
 import Ouroboros.Network.Protocol.BlockFetch.Type

--- a/ouroboros-network/testlib/Test/Cardano/Network/NodeToClient/Version.hs
+++ b/ouroboros-network/testlib/Test/Cardano/Network/NodeToClient/Version.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Network.NodeToClient.Version (tests) where
+module Test.Cardano.Network.NodeToClient.Version (tests) where
 
 import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Magic
@@ -13,7 +13,7 @@ import Test.Tasty.QuickCheck (testProperty)
 
 
 tests :: TestTree
-tests = testGroup "Ouroboros.Network.NodeToClient.Version"
+tests = testGroup "Cardano.Network.NodeToClient.Version"
     [ testProperty "nodeToClientCodecCBORTerm" prop_nodeToClientCodec
     ]
 

--- a/ouroboros-network/testlib/Test/Cardano/Network/NodeToNode/Version.hs
+++ b/ouroboros-network/testlib/Test/Cardano/Network/NodeToNode/Version.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Test.Ouroboros.Network.NodeToNode.Version (tests) where
+module Test.Cardano.Network.NodeToNode.Version (tests) where
 
 import Ouroboros.Network.CodecCBORTerm
 import Ouroboros.Network.Magic
@@ -14,7 +14,7 @@ import Test.Tasty.QuickCheck (testProperty)
 
 
 tests :: TestTree
-tests = testGroup "Ouroboros.Network.NodeToNode.Version"
+tests = testGroup "Cardano.Network.NodeToNode.Version"
     [ testProperty "nodeToNodeCodecCBORTerm" prop_nodeToNodeCodec
     ]
 

--- a/ouroboros-network/testlib/Test/Cardano/Network/OrphanInstances/Tests.hs
+++ b/ouroboros-network/testlib/Test/Cardano/Network/OrphanInstances/Tests.hs
@@ -1,7 +1,8 @@
-module Test.Ouroboros.Network.OrphanInstances.Tests (tests) where
+module Test.Cardano.Network.OrphanInstances.Tests (tests) where
 
 import Data.Aeson
 
+import Cardano.Network.OrphanInstances ()
 import Ouroboros.Network.OrphanInstances ()
 import Ouroboros.Network.Protocol.Handshake.Test hiding (tests)
 
@@ -11,7 +12,7 @@ import Test.Tasty.QuickCheck
 
 
 tests :: TestTree
-tests = testGroup "Ouroboros.Network.OrphanInstances"
+tests = testGroup "Cardano.Network.OrphanInstances"
         [ testProperty "NodeToNodeVersion" prop_json_NodeToNodeVersion
         , testProperty "NodeToClientVersion" prop_json_NodeToClientVersion
         ]

--- a/ouroboros-network/testlib/Test/Cardano/Network/Version.hs
+++ b/ouroboros-network/testlib/Test/Cardano/Network/Version.hs
@@ -2,13 +2,13 @@
 
 -- | Test `NodeToNodeVersion` and `NodeToClientVersion` codecs.
 --
-module Test.Ouroboros.Network.Version (tests) where
+module Test.Cardano.Network.Version (tests) where
 
-import Ouroboros.Network.CodecCBORTerm
-import Ouroboros.Network.NodeToClient (NodeToClientVersion (..),
+import Cardano.Network.NodeToClient (NodeToClientVersion (..),
            nodeToClientVersionCodec)
-import Ouroboros.Network.NodeToNode (NodeToNodeVersion (..),
+import Cardano.Network.NodeToNode (NodeToNodeVersion (..),
            nodeToNodeVersionCodec)
+import Ouroboros.Network.CodecCBORTerm
 
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit
@@ -16,7 +16,7 @@ import Test.Tasty.HUnit
 
 tests :: TestTree
 tests =
-  testGroup "Ouroboros.Network.Protocol.Handshake.Version"
+  testGroup "Cardano.Network.Protocol.Handshake.Version"
     [ testGroup "NodeToClientVersion"
       [ testCase "NodeToClientVersion round-trip codec property"
                  (roundTripPropAll nodeToClientVersionCodec)

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/Kernel.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/Kernel.hs
@@ -57,6 +57,8 @@ import System.Random qualified as Random
 
 import Network.Socket (PortNumber)
 
+import Cardano.Network.NodeToNode ()
+
 import Ouroboros.Network.AnchoredFragment (Anchor (..))
 import Ouroboros.Network.Block (HasFullHeader, SlotNo)
 import Ouroboros.Network.Block qualified as Block
@@ -67,7 +69,6 @@ import Ouroboros.Network.Mock.Chain qualified as Chain
 import Ouroboros.Network.Mock.ConcreteBlock (Block)
 import Ouroboros.Network.Mock.ConcreteBlock qualified as ConcreteBlock
 import Ouroboros.Network.Mock.ProducerState
-import Ouroboros.Network.NodeToNode ()
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection (PeerSharing, RelayAccessPoint (..))
 import Ouroboros.Network.PeerSelection.Governor (PublicPeerSelectionState,

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node/MiniProtocols.hs
@@ -51,6 +51,10 @@ import Network.TypedProtocol.PingPong.Examples
 import Network.TypedProtocol.PingPong.Server
 import Network.TypedProtocol.PingPong.Type
 
+import Cardano.Network.NodeToNode (blockFetchMiniProtocolNum,
+           chainSyncMiniProtocolNum, keepAliveMiniProtocolNum,
+           peerSharingMiniProtocolNum)
+
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.Client
 import Ouroboros.Network.Protocol.BlockFetch.Codec
@@ -83,9 +87,6 @@ import Ouroboros.Network.Mock.Chain qualified as Chain
 import Ouroboros.Network.Mock.ConcreteBlock
 import Ouroboros.Network.Mock.ProducerState
 import Ouroboros.Network.Mux
-import Ouroboros.Network.NodeToNode (blockFetchMiniProtocolNum,
-           chainSyncMiniProtocolNum, keepAliveMiniProtocolNum,
-           peerSharingMiniProtocolNum)
 import Ouroboros.Network.NodeToNode.Version (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection.PeerMetric (PeerMetrics)
 import Ouroboros.Network.PeerSelection.PeerSharing qualified as PSTypes

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Testnet/Cardano.hs
@@ -47,6 +47,7 @@ import Network.DNS.Types qualified as DNS
 import Network.Mux.Trace qualified as Mx
 
 import Cardano.Network.ConsensusMode
+import Cardano.Network.NodeToNode (DiffusionMode (..))
 import Cardano.Network.PeerSelection.Bootstrap (UseBootstrapPeers (..),
            requiresBootstrapPeers)
 import Cardano.Network.PeerSelection.PeerTrustable (PeerTrustable (..))
@@ -69,7 +70,6 @@ import Ouroboros.Network.Diffusion.Policies qualified as Diffusion
 import Ouroboros.Network.ExitPolicy (RepromoteDelay (..))
 import Ouroboros.Network.InboundGovernor qualified as IG
 import Ouroboros.Network.Mock.ConcreteBlock (BlockHeader)
-import Ouroboros.Network.NodeToNode (DiffusionMode (..))
 import Ouroboros.Network.PeerSelection
 import Ouroboros.Network.PeerSelection.Governor hiding (PeerSelectionState (..))
 import Ouroboros.Network.PeerSelection.Governor qualified as Governor

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/TxSubmission.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/TxSubmission.hs
@@ -44,10 +44,11 @@ import GHC.Generics (Generic)
 
 import Network.TypedProtocol.Codec
 
+import Cardano.Network.NodeToNode (NodeToNodeVersion (..))
+
 import Ouroboros.Network.Channel
 import Ouroboros.Network.ControlMessage (ControlMessage (..), ControlMessageSTM)
 import Ouroboros.Network.Driver
-import Ouroboros.Network.NodeToNode (NodeToNodeVersion (..))
 import Ouroboros.Network.Protocol.TxSubmission2.Client
 import Ouroboros.Network.Protocol.TxSubmission2.Codec
 import Ouroboros.Network.Protocol.TxSubmission2.Server


### PR DESCRIPTION
# Description

* Moved `NodeToNode` and `NodeToClient` modules to `ouroboros-network:cardano-diffusion` 
  sublibrary.
* Moved some orphan instances from `Ouroboros.Network.OrphanInstances` to `Cardano.Network.OrphanInstances`
* Moved some tests around.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
