### PR TITLE
Support weighted chain comparisons

### DIFF
--- a/ouroboros-network-api/CHANGELOG.md
+++ b/ouroboros-network-api/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Simplify type of `headerForgeUTCTime` in `BlockFetchConsensusInterface`, and
   remove the supporting type `FromConsensus`.
+* Changed `BlockFetchConsensusInterface` to support dynamic (weighted) chain
+  comparisons.
 
 ### Non-breaking changes
 

--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -1,15 +1,22 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveFunctor  #-}
-{-# LANGUAGE DeriveGeneric  #-}
-{-# LANGUAGE LambdaCase     #-}
-{-# LANGUAGE RankNTypes     #-}
+{-# LANGUAGE DeriveAnyClass             #-}
+{-# LANGUAGE DeriveFunctor              #-}
+{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingStrategies         #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase                 #-}
+{-# LANGUAGE RankNTypes                 #-}
 
 module Ouroboros.Network.BlockFetch.ConsensusInterface
   ( PraosFetchMode (..)
   , FetchMode (..)
   , BlockFetchConsensusInterface (..)
   , ChainSelStarvation (..)
+  , ChainComparison (..)
   , mkReadFetchMode
+    -- * Utilities
+  , WithFingerprint (..)
+  , Fingerprint (..)
+  , initialWithFingerprint
   ) where
 
 import Control.Monad.Class.MonadSTM
@@ -18,6 +25,7 @@ import Control.Monad.Class.MonadTime.SI (Time)
 import Data.Functor ((<&>))
 
 import Data.Map.Strict (Map)
+import Data.Word (Word64)
 import GHC.Generics (Generic)
 import GHC.Stack (HasCallStack)
 import NoThunks.Class (NoThunks)
@@ -129,24 +137,9 @@ data BlockFetchConsensusInterface peer header block m =
        -- have been downloaded anyway.
        readFetchedMaxSlotNo    :: STM m MaxSlotNo,
 
-       -- | Given the current chain, is the given chain plausible as a
-       -- candidate chain. Classically for Ouroboros this would simply
-       -- check if the candidate is strictly longer, but for Ouroboros
-       -- with operational key certificates there are also cases where
-       -- we would consider a chain of equal length to the current chain.
-       --
-       plausibleCandidateChain :: HasCallStack
-                               => AnchoredFragment header
-                               -> AnchoredFragment header -> Bool,
-
-       -- | Compare two candidate chains and return a preference ordering.
-       -- This is used as part of selecting which chains to prioritise for
-       -- downloading block bodies.
-       --
-       compareCandidateChains  :: HasCallStack
-                               => AnchoredFragment header
-                               -> AnchoredFragment header
-                               -> Ordering,
+       -- | Compare chain fragments. This might involve further state, such as
+       -- Peras certificates (which give certain blocks additional weight).
+       readChainComparison     :: STM m (WithFingerprint (ChainComparison header)),
 
        -- | Much of the logic for deciding which blocks to download from which
        -- peer depends on making estimates based on recent performance metrics.
@@ -184,3 +177,57 @@ data ChainSelStarvation
   = ChainSelStarvationOngoing
   | ChainSelStarvationEndedAt Time
   deriving (Eq, Show, NoThunks, Generic)
+
+
+data ChainComparison header =
+     ChainComparison {
+       -- | Given the current chain, is the given chain plausible as a candidate
+       -- chain. Classically for Ouroboros this would simply check if the
+       -- candidate is strictly longer, but it can also involve further
+       -- criteria:
+       --
+       --  * Tiebreakers (e.g. based on the opcert numbers and VRFs) for chains
+       --    of equal length.
+       --
+       --  * Weight in the context of Ouroboros Peras, due to a boost from a
+       --    Peras certificate.
+       --
+       plausibleCandidateChain :: HasCallStack
+                               => AnchoredFragment header
+                               -> AnchoredFragment header
+                               -> Bool,
+
+       -- | Compare two candidate chains and return a preference ordering.
+       -- This is used as part of selecting which chains to prioritise for
+       -- downloading block bodies.
+       --
+       compareCandidateChains  :: HasCallStack
+                               => AnchoredFragment header
+                               -> AnchoredFragment header
+                               -> Ordering
+     }
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+-- | Simple type that can be used to indicate some value (without/only with an
+-- expensive 'Eq' instance) changed.
+newtype Fingerprint = Fingerprint Word64
+  deriving stock (Show, Eq, Generic)
+  deriving newtype (Enum)
+  deriving anyclass (NoThunks)
+
+-- | Store a value together with its 'Fingerprint'.
+data WithFingerprint a = WithFingerprint
+  { forgetFingerprint :: !a
+  , getFingerprint    :: !Fingerprint
+  }
+  deriving stock (Show, Functor, Generic)
+  deriving anyclass (NoThunks)
+
+-- | Attach @'Fingerprint' 0@ to the given value. When the underlying @a@ is
+-- changed, the 'Fingerprint' must be updated to a new unique value (e.g. via
+-- 'succ').
+initialWithFingerprint :: a -> WithFingerprint a
+initialWithFingerprint a = WithFingerprint a (Fingerprint 0)

--- a/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
+++ b/ouroboros-network-api/src/Ouroboros/Network/BlockFetch/ConsensusInterface.hs
@@ -201,6 +201,8 @@ data ChainComparison header =
        -- This is used as part of selecting which chains to prioritise for
        -- downloading block bodies.
        --
+       -- PRECONDITION: The two fragments must intersect.
+       --
        compareCandidateChains  :: HasCallStack
                                => AnchoredFragment header
                                -> AnchoredFragment header

--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Adapt to simplified type of `headerForgeUTCTime` in `BlockFetchConsensusInterface`.
 * Type of `defaultSyncTargets` changed.
 * Type of `defaultPeerSharing` changed.
+* Adapted to changes of `BlockFetchConsensusInterface`.
 
 ### Non-breaking changes
 

--- a/ouroboros-network/demo/chain-sync.hs
+++ b/ouroboros-network/demo/chain-sync.hs
@@ -75,7 +75,8 @@ import Ouroboros.Network.Protocol.BlockFetch.Type qualified as BlockFetch
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.Client
 import Ouroboros.Network.BlockFetch.ClientRegistry (FetchClientRegistry (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
+           initialWithFingerprint)
 import Ouroboros.Network.DeltaQ (defaultGSV)
 
 import Ouroboros.Network.Server.Simple qualified as Server.Simple
@@ -433,8 +434,10 @@ clientBlockFetch sockAddrs maxSlotNo = withIOManager $ \iocp -> do
                   pure $ \p b ->
                     addTestFetchedBlock blockHeap (castPoint p) (blockHeader b),
 
-              plausibleCandidateChain,
-              compareCandidateChains,
+              readChainComparison    = pure $ initialWithFingerprint ChainComparison {
+                    plausibleCandidateChain,
+                    compareCandidateChains
+                  },
 
               blockFetchSize         = \_ -> 1000,
               blockMatchesHeader     = \_ _ -> True,

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch.hs
@@ -99,6 +99,7 @@ module Ouroboros.Network.BlockFetch
     -- * Re-export types used by 'BlockFetchConsensusInterface'
   , PraosFetchMode (..)
   , FetchMode (..)
+  , ChainComparison (..)
   , SizeInBytes
   ) where
 
@@ -121,7 +122,7 @@ import Ouroboros.Network.BlockFetch.ClientRegistry (FetchClientPolicy (..),
            readFetchClientsStateVars, readFetchClientsStatus, readPeerGSVs,
            setFetchClientContext)
 import Ouroboros.Network.BlockFetch.ConsensusInterface
-           (BlockFetchConsensusInterface (..))
+           (BlockFetchConsensusInterface (..), ChainComparison (..))
 import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import Ouroboros.Network.BlockFetch.State
 
@@ -221,8 +222,6 @@ blockFetchLogic decisionTracer clientStateTracer
         peerSalt                    = bfcSalt,
         bulkSyncGracePeriod         = gbfcGracePeriod bfcGenesisBFConfig,
 
-        plausibleCandidateChain,
-        compareCandidateChains,
         blockFetchSize
       }
 
@@ -231,7 +230,8 @@ blockFetchLogic decisionTracer clientStateTracer
       FetchTriggerVariables {
         readStateCurrentChain    = readCurrentChain,
         readStateCandidateChains = readCandidateChains,
-        readStatePeerStatus      = readFetchClientsStatus registry
+        readStatePeerStatus      = readFetchClientsStatus registry,
+        readStateChainComparison = readChainComparison
       }
 
     fetchNonTriggerVariables :: FetchNonTriggerVariables addr header block m

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -35,7 +35,6 @@ import Data.Hashable
 import Data.List as List (foldl', groupBy, sortBy, transpose)
 import Data.Maybe (mapMaybe)
 import Data.Set (Set)
-import GHC.Stack (HasCallStack)
 
 import Control.Exception (assert)
 import Control.Monad (guard)
@@ -48,8 +47,8 @@ import Ouroboros.Network.Point (withOriginToMaybe)
 
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeerFetchStatus (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (FetchMode (..),
-           PraosFetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainComparison (..),
+           FetchMode (..), PraosFetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (PeerFetchInFlightLimits (..),
            PeerGSV (..), SizeInBytes, calculatePeerFetchInFlightLimits,
            comparePeerGSV, comparePeerGSV', estimateExpectedResponseDuration,
@@ -57,25 +56,16 @@ import Ouroboros.Network.BlockFetch.DeltaQ (PeerFetchInFlightLimits (..),
 
 
 data FetchDecisionPolicy header = FetchDecisionPolicy {
-       maxInFlightReqsPerPeer  :: Word,  -- A protocol constant.
+       maxInFlightReqsPerPeer      :: Word,  -- A protocol constant.
 
-       maxConcurrencyBulkSync  :: Word,
-       maxConcurrencyDeadline  :: Word,
+       maxConcurrencyBulkSync      :: Word,
+       maxConcurrencyDeadline      :: Word,
        decisionLoopIntervalGenesis :: DiffTime,
-       decisionLoopIntervalPraos :: DiffTime,
-       peerSalt                :: Int,
-       bulkSyncGracePeriod     :: DiffTime,
+       decisionLoopIntervalPraos   :: DiffTime,
+       peerSalt                    :: Int,
+       bulkSyncGracePeriod         :: DiffTime,
 
-       plausibleCandidateChain :: HasCallStack
-                               => AnchoredFragment header
-                               -> AnchoredFragment header -> Bool,
-
-       compareCandidateChains  :: HasCallStack
-                               => AnchoredFragment header
-                               -> AnchoredFragment header
-                               -> Ordering,
-
-       blockFetchSize          :: header -> SizeInBytes
+       blockFetchSize              :: header -> SizeInBytes
      }
 
 
@@ -264,6 +254,7 @@ fetchDecisions
       HasHeader header,
       HeaderHash header ~ HeaderHash block)
   => FetchDecisionPolicy header
+  -> ChainComparison header
   -> PraosFetchMode
   -> AnchoredFragment header
   -> (Point block -> Bool)
@@ -271,10 +262,12 @@ fetchDecisions
   -> [(AnchoredFragment header, PeerInfo header peer extra)]
   -> [(FetchDecision (FetchRequest header), PeerInfo header peer extra)]
 fetchDecisions fetchDecisionPolicy@FetchDecisionPolicy {
-                 plausibleCandidateChain,
-                 compareCandidateChains,
                  blockFetchSize,
                  peerSalt
+               }
+               ChainComparison {
+                 plausibleCandidateChain,
+                 compareCandidateChains
                }
                fetchMode
                currentChain

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision.hs
@@ -33,7 +33,7 @@ import Data.Set qualified as Set
 import Data.Function (on)
 import Data.Hashable
 import Data.List as List (foldl', groupBy, sortBy, transpose)
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set (Set)
 
 import Control.Exception (assert)
@@ -473,8 +473,19 @@ empty fetch range, but this is ok since we never request empty ranges.
 --
 -- A 'ChainSuffix' must be non-empty, as an empty suffix, i.e. the candidate
 -- chain is equal to the current chain, would not be a plausible candidate.
-newtype ChainSuffix header =
-    ChainSuffix { getChainSuffix :: AnchoredFragment header }
+--
+-- Additionally, we store the full candidate (with the same anchor as our
+-- current chain), as this is needed for comparing different candidates via
+-- 'compareCandidateChains'.
+data ChainSuffix header = ChainSuffix {
+   -- | The suffix of the candidate after the intersection with the current
+   -- chain.
+   getChainSuffix   :: !(AnchoredFragment header),
+   -- | The full candidate, characterized by having the same tip as
+   -- 'getChainSuffix' and the same anchor as our current chain. In particular,
+   -- 'getChainSuffix' is a suffix of 'getFullCandidate'.
+   getFullCandidate :: !(AnchoredFragment header)
+ }
 
 {-
 We define the /chain suffix/ as the suffix of the candidate chain up until (but
@@ -511,25 +522,31 @@ interested in this candidate at all.
 -- current chain.
 --
 chainForkSuffix
-  :: (HasHeader header, HasHeader block,
-      HeaderHash header ~ HeaderHash block)
-  => AnchoredFragment block  -- ^ Current chain.
-  -> AnchoredFragment header -- ^ Candidate chain
+  :: HasHeader header
+  => AnchoredFragment header
+  -> AnchoredFragment header
   -> Maybe (ChainSuffix header)
 chainForkSuffix current candidate =
     case AF.intersect current candidate of
       Nothing                         -> Nothing
-      Just (_, _, _, candidateSuffix) ->
+      Just (currentChainPrefix, _, _, candidateSuffix) ->
         -- If the suffix is empty, it means the candidate chain was equal to
         -- the current chain and didn't fork off. Such a candidate chain is
         -- not a plausible candidate, so it must have been filtered out.
         assert (not (AF.null candidateSuffix)) $
-        Just (ChainSuffix candidateSuffix)
+        Just ChainSuffix {
+            getChainSuffix   = candidateSuffix,
+            getFullCandidate = fullCandidate
+          }
+        where
+          fullCandidate =
+            fromMaybe (error "invariant violation of AF.intersect") $
+              AF.join currentChainPrefix candidateSuffix
+
 
 selectForkSuffixes
-  :: (HasHeader header, HasHeader block,
-      HeaderHash header ~ HeaderHash block)
-  => AnchoredFragment block
+  :: HasHeader header
+  => AnchoredFragment header
   -> [(FetchDecision (AnchoredFragment header), peerinfo)]
   -> [(FetchDecision (ChainSuffix      header), peerinfo)]
 selectForkSuffixes current chains =
@@ -743,7 +760,11 @@ prioritisePeerChains FetchModeDeadline salt compareCandidateChains blockFetchSiz
                 (equatingPair
                    -- compare on probability band first, then preferred chain
                    (==)
-                   (equateCandidateChains `on` getChainSuffix)
+                   -- Precondition of 'compareCandidateChains' (used by
+                   -- 'equateCandidateChains') is fulfilled as all
+                   -- 'getFullCandidate's intersect pairwise (due to having the
+                   -- same anchor as our current chain).
+                   (equateCandidateChains `on` getFullCandidate)
                  `on`
                    (\(band, chain, _fragments) -> (band, chain)))))
   . sortBy  (descendingOrder
@@ -752,7 +773,10 @@ prioritisePeerChains FetchModeDeadline salt compareCandidateChains blockFetchSiz
                   (comparingPair
                      -- compare on probability band first, then preferred chain
                      compare
-                     (compareCandidateChains `on` getChainSuffix)
+                     -- Precondition of 'compareCandidateChains' is fulfilled as
+                     -- all 'getFullCandidate's intersect pairwise (due to
+                     -- having the same anchor as our current chain).
+                     (compareCandidateChains `on` getFullCandidate)
                    `on`
                       (\(band, chain, _fragments) -> (band, chain))))))
   . map annotateProbabilityBand
@@ -776,7 +800,7 @@ prioritisePeerChains FetchModeDeadline salt compareCandidateChains blockFetchSiz
       | EQ <- compareCandidateChains chain1 chain2 = True
       | otherwise                                  = False
 
-    chainHeadPoint (_,ChainSuffix c,_) = AF.headPoint c
+    chainHeadPoint (_,ChainSuffix {getChainSuffix = c},_) = AF.headPoint c
 
 prioritisePeerChains FetchModeBulkSync salt compareCandidateChains blockFetchSize =
     map (\(decision, peer) ->
@@ -785,7 +809,11 @@ prioritisePeerChains FetchModeBulkSync salt compareCandidateChains blockFetchSiz
              (comparingRight
                (comparingPair
                   -- compare on preferred chain first, then duration
-                  (compareCandidateChains `on` getChainSuffix)
+                  --
+                  -- Precondition of 'compareCandidateChains' is fulfilled as
+                  -- all 'getFullCandidate's intersect pairwise (due to having
+                  -- the same anchor as our current chain).
+                  (compareCandidateChains `on` getFullCandidate)
                   compare
                 `on`
                   (\(duration, chain, _fragments) -> (chain, duration)))))

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
@@ -146,8 +146,8 @@ import Ouroboros.Network.AnchoredFragment qualified as AF
 import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch.ClientState (FetchRequest (..),
            PeerFetchInFlight (..), PeersOrder (..))
-import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainSelStarvation (..),
-           FetchMode (..))
+import Ouroboros.Network.BlockFetch.ConsensusInterface (ChainComparison(..),
+           ChainSelStarvation (..), FetchMode (..))
 import Ouroboros.Network.BlockFetch.DeltaQ (calculatePeerFetchInFlightLimits)
 
 import Cardano.Slotting.Slot (WithOrigin)
@@ -167,6 +167,7 @@ fetchDecisionsGenesisM
       HeaderHash header ~ HeaderHash block, MonadMonotonicTime m)
   => Tracer m (TraceDecisionEvent peer header)
   -> FetchDecisionPolicy header
+  -> ChainComparison header
   -> AnchoredFragment header
   -> (Point block -> Bool)
      -- ^ Whether the block has been fetched (only if recent, i.e. within @k@).
@@ -181,6 +182,7 @@ fetchDecisionsGenesisM
 fetchDecisionsGenesisM
   tracer
   fetchDecisionPolicy@FetchDecisionPolicy {bulkSyncGracePeriod}
+  chainComparison
   currentChain
   fetchedBlocks
   fetchedMaxSlotNo
@@ -203,6 +205,7 @@ fetchDecisionsGenesisM
     let (theDecision, declines) =
           fetchDecisionsGenesis
             fetchDecisionPolicy
+            chainComparison
             currentChain
             fetchedBlocks
             fetchedMaxSlotNo
@@ -316,6 +319,7 @@ fetchDecisionsGenesis
      , HeaderHash header ~ HeaderHash block
      )
   => FetchDecisionPolicy header
+  -> ChainComparison header
   -> AnchoredFragment header
      -- ^ The current chain, anchored at the immutable tip.
   -> (Point block -> Bool)
@@ -334,6 +338,7 @@ fetchDecisionsGenesis
      -- one @'FetchRequest' header@.
 fetchDecisionsGenesis
   fetchDecisionPolicy
+  chainComparison
   currentChain
   fetchedBlocks
   fetchedMaxSlotNo
@@ -346,7 +351,7 @@ fetchDecisionsGenesis
       ) <-
       MaybeT $
         selectTheCandidate
-          fetchDecisionPolicy
+          chainComparison
           currentChain
           candidatesAndPeers
 
@@ -423,7 +428,7 @@ dropAlreadyFetched alreadyDownloaded fetchedMaxSlotNo candidate =
 selectTheCandidate
   :: forall header peerInfo.
      HasHeader header
-  => FetchDecisionPolicy header
+  => ChainComparison header
   -> AnchoredFragment header
      -- ^ The current chain.
   -> [(AnchoredFragment header, peerInfo)]
@@ -436,7 +441,7 @@ selectTheCandidate
      -- selected candidate that we choose to sync from and a list of peers that
      -- are still in the race to serve that candidate.
 selectTheCandidate
-  FetchDecisionPolicy {compareCandidateChains, plausibleCandidateChain}
+  ChainComparison {compareCandidateChains, plausibleCandidateChain}
   currentChain =
         separateDeclinedAndStillInRace
         -- Select the suffix up to the intersection with the current chain. This can

--- a/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
+++ b/ouroboros-network/src/Ouroboros/Network/BlockFetch/Decision/Genesis.hs
@@ -462,13 +462,16 @@ selectTheCandidate
         case inRace of
           [] -> pure Nothing
           _ : _ -> do
+            -- Precondition of 'compareCandidateChains' is fulfilled as all
+            -- 'getFullCandidate's intersect pairwise (due to having the same
+            -- anchor as our current chain).
             let maxChainOn f c0 c1 = case compareCandidateChains (f c0) (f c1) of
                   LT -> c1
                   _  -> c0
                 -- maximumBy yields the last element in case of a tie while we
                 -- prefer the first one
                 chainSfx = fst $
-                  List.foldl1' (maxChainOn (getChainSuffix . fst)) inRace
+                  List.foldl1' (maxChainOn (getFullCandidate . fst)) inRace
             pure $ Just (chainSfx, inRace)
 
 -- | Given _the_ candidate fragment to sync from, and a list of peers (with

--- a/ouroboros-network/testlib/Ouroboros/Network/BlockFetch/Examples.hs
+++ b/ouroboros-network/testlib/Ouroboros/Network/BlockFetch/Examples.hs
@@ -54,6 +54,7 @@ import Ouroboros.Network.Protocol.BlockFetch.Server
 import Ouroboros.Network.Protocol.BlockFetch.Type
 import Ouroboros.Network.Util.ShowProxy
 
+import Ouroboros.Network.BlockFetch.ConsensusInterface (initialWithFingerprint)
 import Ouroboros.Network.BlockFetch.Decision.Trace (TraceDecisionEvent)
 import Ouroboros.Network.Mock.ConcreteBlock
 
@@ -295,8 +296,10 @@ sampleBlockFetchPolicy1 fetchMode headerFieldsForgeUTCTime blockHeap currentChai
                                getTestFetchedBlocks blockHeap,
       mkAddFetchedBlock      = pure $ addTestFetchedBlock blockHeap,
 
-      plausibleCandidateChain,
-      compareCandidateChains,
+      readChainComparison    = pure $ initialWithFingerprint ChainComparison {
+            plausibleCandidateChain,
+            compareCandidateChains
+          },
 
       blockFetchSize         = \_ -> 2000,
       blockMatchesHeader     = \_ _ -> True,

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/Diffusion/Node.hs
@@ -79,7 +79,8 @@ import Ouroboros.Network.Block (MaxSlotNo (..), maxSlotNoFromWithOrigin,
            pointSlot)
 import Ouroboros.Network.BlockFetch
 import Ouroboros.Network.BlockFetch.ConsensusInterface
-           (ChainSelStarvation (ChainSelStarvationEndedAt))
+           (ChainSelStarvation (ChainSelStarvationEndedAt),
+           initialWithFingerprint)
 import Ouroboros.Network.ConnectionManager.State (ConnStateIdSupply)
 import Ouroboros.Network.ConnectionManager.Types (DataFlow (..))
 import Ouroboros.Network.Diffusion qualified as Diffusion
@@ -390,8 +391,10 @@ run blockGeneratorArgs limits ni na
               pure $ \_p b ->
                 atomically (addBlock b (nkChainDB nodeKernel)),
 
-          plausibleCandidateChain,
-          compareCandidateChains,
+          readChainComparison = pure $ initialWithFingerprint ChainComparison {
+                plausibleCandidateChain,
+                compareCandidateChains
+              },
 
           blockFetchSize         = \_ -> 1000,
           blockMatchesHeader     = \_ _ -> True,


### PR DESCRIPTION
With Ouroboros Peras, comparing chains now also depends on *certificates* which can give extra weight to certain blocks. Concretely, a particular candidate chain might first not be preferred to the current selection, but this can change when a particular Peras certificate arrives.

This PR adds support for this while keeping the exposure of Peras to the Network layer as minimal as possible in this area (in particular, Peras/certificates/weights are only mentioned in comments).

This PR is needed for https://github.com/tweag/cardano-peras/issues/62

### Dynamic chain comparisons

The first commit allows chain comparisons to be *dynamic*, ie change over time, modelling the arrival of new Peras certificates.

Previously, chain comparisons were modeled by the following two functions in the `BlockFetchConsensusInterface`:
```haskell
data BlockFetchConsensusInterface peer header block m = BlockFetchConsensusInterface {
    ...
    plausibleCandidateChain :: AnchoredFragment header -> AnchoredFragment header -> Bool,
    compareCandidateChains  :: AnchoredFragment header -> AnchoredFragment header -> Ordering
    ...
  }
```
This PR replaces this with
```haskell
  readChainComparison :: STM m (WithFingerprint (ChainComparison header))
```
where
```haskell
data ChainComparison header = ChainComparison {
    plausibleCandidateChain :: AnchoredFragment header -> AnchoredFragment header -> Bool,
    compareCandidateChains  :: AnchoredFragment header -> AnchoredFragment header -> Ordering
  }
```
Here, `WithFingerprint` is a [micro-abstraction copied from Consensus](https://ouroboros-consensus.cardano.intersectmbo.org/haddocks/ouroboros-consensus/Ouroboros-Consensus-Util-STM.html#t:WithFingerprint) used to indicate when new Peras certificates arrive (and therefore the results of the chain comparison functions might change), allowing the BlockFetch decision logic to be run again.

### Ensuring that arguments to `compareCandidateChains` intersect

With unweighted chain comparisons, `compareCandidateChains` [required](https://github.com/IntersectMBO/ouroboros-consensus/blob/252f4f0b7380ec666d0428e1275d40e474611cbf/ouroboros-consensus/src/ouroboros-consensus/Ouroboros/Consensus/Util/AnchoredFragment.hs#L79) that one of the following two criteria is true for its two fragment arguments:

 1. The fragments intersect.
 2. Both fragments are non-empty.

This latter criterion sufficed as we only need to get the block number and potentially further tiebreaker information (such as the VRF) from the tip header; the rest of the fragment is not relevant. However, this is no longer true for *weighted* chain comparisons: Here, we need the suffixes of both fragments after their common intersection.

The second commit ensures that this stronger precondition is met by enriching the `ChainSuffix` type by also storing the "full" candidate, each with the same anchor as the current chain, which directly yields that they must intersect pairwise.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
