### PR TITLE
Improved network-mux haddocks

### DIFF
--- a/network-mux/CHANGELOG.md
+++ b/network-mux/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Non-breaking changes
 
+* Exposed `MakeBearerCb` to expose its haddocks.
+
 ## 0.9.0.0 -- 2025-06-28
 
 ### Breaking changes

--- a/network-mux/src/Network/Mux/Bearer/Socket.hs
+++ b/network-mux/src/Network/Mux/Bearer/Socket.hs
@@ -55,7 +55,7 @@ socketAsBearer
   -> DiffTime -- ^ egress poll interval
   -> Socket.Socket
   -> Bearer IO
-socketAsBearer sduSize batchSize readBuffer_m sduTimeout pollInterval sd =
+socketAsBearer sduSize batchSize readBuffer_m sduTimeout egressInterval sd =
       Mx.Bearer {
         Mx.read           = readSocket,
         Mx.write          = writeSocket,
@@ -63,7 +63,7 @@ socketAsBearer sduSize batchSize readBuffer_m sduTimeout pollInterval sd =
         Mx.sduSize        = sduSize,
         Mx.batchSize      = batchSize,
         Mx.name           = "socket-bearer",
-        Mx.egressInterval = pollInterval
+        Mx.egressInterval
       }
     where
       readSocket :: Tracer IO BearerTrace -> Mx.TimeoutFn IO -> IO (Mx.SDU, Time)


### PR DESCRIPTION
To expose haddocks attached to arguments of `MakeBearer` callback,
a type alias is exposed.

# Description

_reasonably detailed description of the pull request_

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
