### PR TITLE
tx-sub: added mempoolLastTicket to MempoolSnapshot

### DIFF
--- a/ouroboros-network/CHANGELOG.md
+++ b/ouroboros-network/CHANGELOG.md
@@ -14,6 +14,7 @@
 * `Ouroboros.Network.TxSubmission.Inbound.V1.txSubmissionInbound` takes extra argument: `TxSubmissionInitDelay` (previously configurable through `cabal` flags).
 * Removed the `txsubmission-delay` cabal flag.
 * `ProtocolErrorRequestedTooManyTxids` includes number of unacked txids.
+* Added `mempoolLastTicket` to `MempoolSnapshot`
 
 ### Non-breaking changes
 

--- a/ouroboros-network/src/Ouroboros/Network/TxSubmission/Mempool/Reader.hs
+++ b/ouroboros-network/src/Ouroboros/Network/TxSubmission/Mempool/Reader.hs
@@ -54,7 +54,8 @@ data MempoolSnapshot txid tx idx =
      MempoolSnapshot {
        mempoolTxIdsAfter :: idx -> [(txid, idx, SizeInBytes)],
        mempoolLookupTx   :: idx -> Maybe tx,
-       mempoolHasTx      :: txid -> Bool
+       mempoolHasTx      :: txid -> Bool,
+       mempoolLastTicket :: !(Maybe idx)
      }
 
 mapMempoolSnapshot ::

--- a/ouroboros-network/testlib/Test/Ouroboros/Network/TxSubmission/Types.hs
+++ b/ouroboros-network/testlib/Test/Ouroboros/Network/TxSubmission/Types.hs
@@ -131,7 +131,8 @@ getMempoolReader (Mempool mempool) =
             \idx -> zipWith f [idx + 1 ..] (toList $ Seq.drop idx seq),
           -- why do I need to use `pred`?
           mempoolLookupTx   = flip Seq.lookup seq . pred,
-          mempoolHasTx      = \txid -> isJust $ find (\tx -> getTxId tx == txid) seq
+          mempoolHasTx      = \txid -> isJust $ find (\tx -> getTxId tx == txid) seq,
+          mempoolLastTicket = Just $ Seq.length seq
        }
 
     f :: Int -> Tx txid -> (txid, Int, SizeInBytes)


### PR DESCRIPTION
# Description

This is just to expose what consensus already tracks so we don't have to traverse the list of transactions to find the last tx index/ticket. This will also come in handy in dmq node to client code.

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
