### PR TITLE
network-spec: relax requirement after `MsgIntersectFound`

### DIFF
--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -876,9 +876,9 @@ The protocol uses the following messages:
       The consumer can decide whether to send more points.
       The message also tells the consumer about the $tip$ of the producer.
       Whenever the server replies with \MsgIntersectFound{}, the client can
-      expect the next update (i.e. a replay to \MsgRequestNext{}) to be
       \MsgRollBackward{} to the specified $point_{intersect}$ (which makes
       handling state updates on the client side easier).
+      expect the next update (i.e. a reply to \MsgRequestNext{}) to be
 \item [\MsgIntersectNotFound{} {\boldmath $(tip)$}]
       Reply to the consumer that no intersection was found: none of the
       points the consumer supplied are on the producer chain.

--- a/docs/network-spec/miniprotocols.tex
+++ b/docs/network-spec/miniprotocols.tex
@@ -876,9 +876,10 @@ The protocol uses the following messages:
       The consumer can decide whether to send more points.
       The message also tells the consumer about the $tip$ of the producer.
       Whenever the server replies with \MsgIntersectFound{}, the client can
-      \MsgRollBackward{} to the specified $point_{intersect}$ (which makes
-      handling state updates on the client side easier).
       expect the next update (i.e. a reply to \MsgRequestNext{}) to be
+      \MsgRollBackward{}, either to the specified $point_{intersect}$ or an earlier
+      point if the producer switched to a different fork in the meantime.
+      This makes handling state updates on the client side easier.
 \item [\MsgIntersectNotFound{} {\boldmath $(tip)$}]
       Reply to the consumer that no intersection was found: none of the
       points the consumer supplied are on the producer chain.


### PR DESCRIPTION
# Description

Closes #4917 by relaxing the specification. Now, after an intersection for a point `pt` was negotiated, the server still must send `MsgRollBackward`, but it can either send a rollback to `pt` *or to an earlier point*.

The motivation for sending `MsgRollBackward` after `MsgIntersectFound` (simpler state management on the client side) is preserved by this change, and it simplifies the server implementation, ensuring that the current production ChainSync server implementation actually adheres to the spec.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [ ] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
