### PR TITLE
Propagate disconnection reason out of connection manager

### DIFF
--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes
 
+* `HandleError` renamed as `HandlerError`, also `HandlerErrorType` and `classifyHandlerError`.
+
 ### Non-breaking changes
 
 ## 0.19.0.0 -- 28.06.2025

--- a/ouroboros-network-framework/CHANGELOG.md
+++ b/ouroboros-network-framework/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### Non-breaking changes
 
+* propagate diconnection reason out of connection manager when including an
+  inbound connection or acquiring an outbound connection.
+
 ## 0.19.0.0 -- 28.06.2025
 
 ### Breaking changes

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -567,7 +567,6 @@ bidirectionalExperiment
                               Mux.InitiatorResponderMode peerAddr
                               UnversionedProtocolData ByteString IO () ())
                             (HandleError
-                              Mux.InitiatorResponderMode
                               UnversionedProtocol))
     connect n cm | n <= 1 =
       acquireOutboundConnection cm InitiatorAndResponderDiffusionMode remoteAddr

--- a/ouroboros-network-framework/demo/connection-manager.hs
+++ b/ouroboros-network-framework/demo/connection-manager.hs
@@ -280,7 +280,7 @@ withBidirectionalConnectionManager snocket makeBearer socket
                     },
                   updateVersionData = \a _ -> a,
                   connStateIdSupply,
-                  classifyHandleError = (\_ -> HandshakeFailure)
+                  classifyHandlerError = (\_ -> HandshakeFailure)
                 }
               (InResponderMode inbgovInfoChannel)
               connectionHandler
@@ -566,7 +566,7 @@ bidirectionalExperiment
                             (HandleWithExpandedCtx
                               Mux.InitiatorResponderMode peerAddr
                               UnversionedProtocolData ByteString IO () ())
-                            (HandleError
+                            (HandlerError
                               UnversionedProtocol))
     connect n cm | n <= 1 =
       acquireOutboundConnection cm InitiatorAndResponderDiffusionMode remoteAddr

--- a/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
+++ b/ouroboros-network-framework/sim-tests/Test/Ouroboros/Network/ConnectionManager.hs
@@ -784,7 +784,7 @@ prop_valid_transitions (Fixed rnd) (SkewedBool bindToLocalAddress) scheduleMap =
             outboundIdleTimeout = testOutboundIdleTimeout,
             updateVersionData = \a _ -> a,
             connStateIdSupply,
-            classifyHandleError = \_ -> HandshakeFailure }
+            classifyHandlerError = \_ -> HandshakeFailure }
           (InResponderMode inbgovInfoChannel)
           connectionHandler
           $ \(connectionManager

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionHandler.hs
@@ -31,8 +31,8 @@ module Ouroboros.Network.ConnectionHandler
   ( Handle (..)
   , HandleWithExpandedCtx
   , HandleWithMinimalCtx
-  , HandleError (..)
-  , classifyHandleError
+  , HandlerError (..)
+  , classifyHandlerError
   , MkMuxConnectionHandler (..)
   , MuxConnectionHandler
   , makeConnectionHandler
@@ -110,7 +110,7 @@ sduHandshakeTimeout = 10
 -- * 'HandleHandshakeServerError'
 --                - the connection handler thread was running server side of the
 --                handshake protocol, which fail with 'HandshakeException'
--- * 'HandleError'
+-- * 'HandlerError'
 --                - the multiplexer thrown 'MuxError'.
 --
 data Handle (muxMode :: Mx.Mode) initiatorCtx responderCtx versionData bytes m a b =
@@ -155,48 +155,46 @@ type HandleWithMinimalCtx muxMode peerAddr versionData bytes m a b =
                           (ResponderContext peerAddr)
                           versionData bytes m a b
 
-data HandleError versionNumber where
-    HandleHandshakeClientError
-      :: !(HandshakeException versionNumber)
-      -> HandleError versionNumber
+-- | A connection handler error.
+--
+-- It is returned either when creating the `Handle` or raised by the connection
+-- handler.
+--
+data HandlerError versionNumber =
+    -- | A handshake exception when creating `Handle`.
+    HandleHandshakeClientError !(HandshakeException versionNumber)
 
-    HandleHandshakeServerError
-      :: !(HandshakeException versionNumber)
-      -> HandleError versionNumber
+    -- | A handshake exception when creating `Handle`.
+  | HandleHandshakeServerError !(HandshakeException versionNumber)
 
-    HandleError
-     :: !SomeException
-     -> HandleError versionNumber
-
-instance Show versionNumber
-      => Show (HandleError versionNumber) where
-    show (HandleHandshakeServerError err) = "HandleHandshakeServerError " ++ show err
-    show (HandleHandshakeClientError err) = "HandleHandshakeClientError " ++ show err
-    show (HandleError err)                = "HandleError " ++ show err
+    -- | A connection handler exception (e.g. might be a mini-protocol error, io
+    -- exception, etc).
+  | HandlerError !SomeException
+  deriving Show
 
 instance ( Typeable versionNumber
          , Show versionNumber
          )
-      => Exception (HandleError versionNumber) where
-    displayException (HandleHandshakeClientError err) = "handshake client error: " ++ displayException err
-    displayException (HandleHandshakeServerError err) = "handshake server error: " ++ displayException err
-    displayException (HandleError err)                = show err
+      => Exception (HandlerError versionNumber) where
+    displayException (HandleHandshakeClientError err) = "handshake client error: " ++ show err
+    displayException (HandleHandshakeServerError err) = "handshake server error: " ++ show err
+    displayException (HandlerError err)                = "connection handler error: " ++ show err
 
 
-classifyHandleError :: HandleError versionNumber
-                    -> HandleErrorType
-classifyHandleError (HandleHandshakeClientError (HandshakeProtocolLimit _)) =
+classifyHandlerError :: HandlerError versionNumber
+                     -> HandlerErrorType
+classifyHandlerError (HandleHandshakeClientError (HandshakeProtocolLimit _)) =
     HandshakeProtocolViolation
 -- TODO: 'HandshakeProtocolError' is not a protocol error! It is just
 -- a negotiation failure.  It should be renamed.
-classifyHandleError (HandleHandshakeClientError (HandshakeProtocolError _)) =
+classifyHandlerError (HandleHandshakeClientError (HandshakeProtocolError _)) =
     HandshakeFailure
-classifyHandleError (HandleHandshakeServerError (HandshakeProtocolLimit _)) =
+classifyHandlerError (HandleHandshakeServerError (HandshakeProtocolLimit _)) =
     HandshakeProtocolViolation
-classifyHandleError (HandleHandshakeServerError (HandshakeProtocolError _)) =
+classifyHandlerError (HandleHandshakeServerError (HandshakeProtocolError _)) =
     HandshakeFailure
 -- any other exception, e.g. MuxError \/ IOError, codec errors, etc.
-classifyHandleError (HandleError _) =
+classifyHandlerError (HandlerError _) =
     HandshakeProtocolViolation
 
 
@@ -208,7 +206,7 @@ type MuxConnectionHandler muxMode socket initiatorCtx responderCtx peerAddr vers
                       socket
                       peerAddr
                       (Handle muxMode initiatorCtx responderCtx versionData bytes m a b)
-                      (HandleError versionNumber)
+                      (HandlerError versionNumber)
                       versionNumber
                       versionData
                       m
@@ -218,7 +216,7 @@ type MuxConnectionHandler muxMode socket initiatorCtx responderCtx peerAddr vers
 type MuxConnectionManager muxMode socket initiatorCtx responderCtx peerAddr versionData versionNumber bytes m a b =
     ConnectionManager muxMode socket peerAddr
                       (Handle muxMode initiatorCtx responderCtx versionData bytes m a b)
-                      (HandleError versionNumber)
+                      (HandlerError versionNumber)
                       m
 
 -- | Type alias for 'ConnectionManager' which is using expanded context.
@@ -226,7 +224,7 @@ type MuxConnectionManager muxMode socket initiatorCtx responderCtx peerAddr vers
 type ConnectionManagerWithExpandedCtx muxMode socket peerAddr versionData versionNumber bytes m a b =
     ConnectionManager muxMode socket peerAddr
                       (HandleWithExpandedCtx muxMode peerAddr versionData bytes m a b)
-                      (HandleError versionNumber)
+                      (HandlerError versionNumber)
                       m
 
 -- | To be used as `makeConnectionHandler` field of 'ConnectionManagerArguments'.
@@ -311,7 +309,7 @@ makeConnectionHandler muxTracers forkPolicy
                              socket
                              peerAddr
                              (Handle muxMode initiatorCtx responderCtx versionData ByteString m a b)
-                             (HandleError versionNumber)
+                             (HandlerError versionNumber)
                              versionNumber
                              versionData
                              m
@@ -344,7 +342,7 @@ makeConnectionHandler muxTracers forkPolicy
               -- handshake negotiation failures, but not with 'IOException's or
               -- 'MuxError's.
               `catch` \(err :: SomeException) -> do
-                atomically $ writePromise (Left (HandleError err))
+                atomically $ writePromise (Left (HandlerError err))
                 throwIO err
             case hsResult of
               Left !err -> do
@@ -393,7 +391,7 @@ makeConnectionHandler muxTracers forkPolicy
                              socket
                              peerAddr
                              (Handle muxMode initiatorCtx responderCtx versionData ByteString m a b)
-                             (HandleError versionNumber)
+                             (HandlerError versionNumber)
                              versionNumber
                              versionData
                              m
@@ -426,7 +424,7 @@ makeConnectionHandler muxTracers forkPolicy
               -- handshake negotiation failures, but not with 'IOException's or
               -- 'MuxError's.
               `catch` \(err :: SomeException) -> do
-                atomically $ writePromise (Left (HandleError err))
+                atomically $ writePromise (Left (HandlerError err))
                 throwIO err
 
             case hsResult of

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -155,7 +155,7 @@ data Arguments handlerTrace socket peerAddr handle handleError versionNumber ver
         --
         connStateIdSupply   :: ConnStateIdSupply m,
 
-        classifyHandleError :: handleError -> HandleErrorType
+        classifyHandlerError :: handleError -> HandlerErrorType
       }
 
 
@@ -404,7 +404,7 @@ with args@Arguments {
          connectionsLimits,
          updateVersionData,
          connStateIdSupply,
-         classifyHandleError
+         classifyHandlerError
        }
      inboundGovernorInfoChannel
      ConnectionHandler {
@@ -1079,7 +1079,7 @@ with args@Arguments {
           connState <- readTVar connVar
 
           let connState' =
-                case classifyHandleError <$> connectionError of
+                case classifyHandlerError <$> connectionError of
                   ConnectionHandlerError HandshakeFailure ->
                     TerminatingState connId connThread
                                      (case connectionError of
@@ -1815,7 +1815,7 @@ with args@Arguments {
           connState <- readTVar connVar
 
           let connState' =
-                case classifyHandleError <$> connectionError of
+                case classifyHandlerError <$> connectionError of
                   ConnectionHandlerError HandshakeFailure ->
                     TerminatingState connId connThread
                                      (case connectionError of

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -947,28 +947,32 @@ with args@Arguments {
                                             , toState   = Known connState
                                             })
             return ( State.insert connId connVar state
-                   , Just (connVar, connThread, reader)
+                   , Right (connVar, connThread, reader)
                    )
           else
             return ( state
-                   , Nothing
+                   , Left ReachedInboundConnectionHardLimit
                    )
 
         case r of
-          Nothing ->
-            return (Disconnected connId Nothing)
+          Left reason ->
+            -- we were unable to include the connection due to hard inbound
+            -- connection limit
+            return (Disconnected connId reason)
 
-          Just (mutableConnState@MutableConnState { connVar, connStateId }
-               , connThread, reader) -> do
+          Right ( mutableConnState@MutableConnState { connVar, connStateId }
+                , connThread, reader) -> do
             traceCounters stateVar
 
             res <- atomically $ readPromise reader
             case res of
               Left handleError -> do
-                terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState $ Just handleError
+                terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState
+                                                 (ConnectionHandlerError handleError)
 
               Right HandshakeConnectionQuery -> do
-                terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState Nothing
+                terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState
+                                                 ConnectionDisconnectedByHandshakeQuery
 
               Right (HandshakeConnectionResult handle (_version, versionData)) -> do
                 let dataFlow = connectionDataFlow versionData
@@ -1025,10 +1029,10 @@ with args@Arguments {
                       throwSTM (withCallStack (ImpossibleState (remoteAddress connId)))
 
                     TerminatingState _ _ err ->
-                      return (Left err, Nothing, Inbound)
+                      return (Left (mkDisconnectionException ConnectionInTerminatingState err), Nothing, Inbound)
 
                     TerminatedState err ->
-                      return (Left err, Nothing, Inbound)
+                      return (Left (mkDisconnectionException ConnectionInTerminatedState err), Nothing, Inbound)
 
                 traverse_ (traceWith trTracer . TransitionTrace connStateId) mbTransition
                 traceCounters stateVar
@@ -1068,23 +1072,26 @@ with args@Arguments {
       -> StrictTMVar
            m (ConnectionManagerState peerAddr handle handleError version m)
       -> MutableConnState peerAddr handle handleError version m
-      -> Maybe handleError
+      -> DisconnectionException handleError
       -> m (Connected peerAddr handle handleError)
-    terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState handleErrorM = do
+    terminateInboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState connectionError = do
         transitions <- atomically $ do
           connState <- readTVar connVar
 
           let connState' =
-                case classifyHandleError <$> handleErrorM of
-                  Just HandshakeFailure ->
+                case classifyHandleError <$> connectionError of
+                  ConnectionHandlerError HandshakeFailure ->
                     TerminatingState connId connThread
-                                     handleErrorM
-                  Just HandshakeProtocolViolation ->
-                    TerminatedState handleErrorM
+                                     (case connectionError of
+                                        ConnectionHandlerError err -> Just err
+                                        _                          -> Nothing)
+                  ConnectionHandlerError HandshakeProtocolViolation ->
+                    TerminatedState (case connectionError of
+                                       ConnectionHandlerError err -> Just err
+                                       _                          -> Nothing)
                   -- On inbound query, connection is terminating.
-                  Nothing ->
-                    TerminatingState connId connThread
-                                     handleErrorM
+                  _ ->
+                    TerminatingState connId connThread Nothing
               transition = mkTransition connState connState'
               absConnState = State.abstractState (Known connState)
               shouldTrace = absConnState /= TerminatedSt
@@ -1148,7 +1155,7 @@ with args@Arguments {
         traverse_ (traceWith trTracer . TransitionTrace connStateId) transitions
         traceCounters stateVar
 
-        return (Disconnected connId handleErrorM)
+        return (Disconnected connId connectionError)
 
     -- We need 'mask' in order to guarantee that the traces are logged if an
     -- async exception lands between the successful STM action and the logging
@@ -1619,10 +1626,12 @@ with args@Arguments {
             res <- atomically (readPromise reader)
             case res of
               Left handleError -> do
-                terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState $ Just handleError
+                terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState
+                                                  (ConnectionHandlerError handleError)
 
               Right HandshakeConnectionQuery -> do
-                terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState Nothing
+                terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState
+                                                  ConnectionDisconnectedByHandshakeQuery
 
               Right (HandshakeConnectionResult handle (_version, versionData)) -> do
                 let dataFlow = connectionDataFlow versionData
@@ -1685,7 +1694,7 @@ with args@Arguments {
                       return (Right $ mkTransition connState connState')
 
                     TerminatedState err ->
-                      return $ Left err
+                      return $ Left $ mkDisconnectionException ConnectionInTerminatedState err
                     _ ->
                       let st = State.abstractState (Known connState) in
                       throwSTM (withCallStack (ForbiddenOperation peerAddr st))
@@ -1773,12 +1782,12 @@ with args@Arguments {
 
                 TerminatingState _connId _connThread handleError ->
                   return ( Right (TrTerminatingConnection provenance connId)
-                         , Disconnected connId handleError
+                         , Disconnected connId (mkDisconnectionException ConnectionInTerminatingState handleError)
                          )
                 TerminatedState handleError ->
                   return ( Right (TrTerminatedConnection provenance
                                                          (remoteAddress connId))
-                         , Disconnected connId handleError
+                         , Disconnected connId (mkDisconnectionException ConnectionInTerminatedState handleError)
                          )
 
             case etr of
@@ -1799,27 +1808,31 @@ with args@Arguments {
         -> Async m ()
         -> StrictTMVar m (ConnectionManagerState peerAddr handle handleError version m)
         -> MutableConnState peerAddr handle handleError version m
-        -> Maybe handleError
+        -> DisconnectionException handleError
         -> m (Connected peerAddr handle handleError)
-    terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState handleErrorM = do
+    terminateOutboundWithErrorOrQuery connId connStateId connVar connThread stateVar mutableConnState connectionError = do
         transitions <- atomically $ do
           connState <- readTVar connVar
 
           let connState' =
-                case classifyHandleError <$> handleErrorM of
-                  Just HandshakeFailure ->
+                case classifyHandleError <$> connectionError of
+                  ConnectionHandlerError HandshakeFailure ->
                     TerminatingState connId connThread
-                                     handleErrorM
-                  Just HandshakeProtocolViolation ->
-                    TerminatedState handleErrorM
+                                     (case connectionError of
+                                       ConnectionHandlerError err -> Just err
+                                       _                          -> Nothing)
+                  ConnectionHandlerError HandshakeProtocolViolation ->
+                    TerminatedState (case connectionError of
+                                      ConnectionHandlerError err -> Just err
+                                      _                          -> Nothing)
                   -- On outbound query, connection is terminated.
-                  Nothing ->
-                    TerminatedState handleErrorM
+                  _ ->
+                    TerminatedState Nothing
               transition = mkTransition connState connState'
               absConnState = State.abstractState (Known connState)
               shouldTransition = absConnState /= TerminatedSt
 
-          -- 'handleError' might be either a handshake negotiation
+          -- 'connectionError' might be either a handshake negotiation
           -- a protocol failure (an IO exception, a timeout or
           -- codec failure).  In the first case we should not reset
           -- the connection as this is not a protocol error.
@@ -1870,7 +1883,7 @@ with args@Arguments {
         traverse_ (traceWith trTracer . TransitionTrace connStateId) transitions
         traceCounters stateVar
 
-        return (Disconnected connId handleErrorM)
+        return (Disconnected connId connectionError)
 
 
     releaseOutboundConnectionImpl

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Core.hs
@@ -991,22 +991,22 @@ with args@Arguments {
                       let connState' = InboundIdleState
                                          connId connThread handle dataFlow
                       writeTVar connVar connState'
-                      return ( True
+                      return ( Right ()
                              , Just $ mkTransition connState connState'
                              , Inbound
                              )
 
                     -- Self connection: the inbound side lost the race to update
                     -- the state after negotiating the connection.
-                    OutboundUniState {} -> return (True, Nothing, Outbound)
-                    OutboundDupState {} -> return (True, Nothing, Outbound)
+                    OutboundUniState {} -> return (Right (), Nothing, Outbound)
+                    OutboundDupState {} -> return (Right (), Nothing, Outbound)
 
                     OutboundIdleState _ _ _ dataFlow' -> do
                       let connState' = InboundIdleState
                                          connId connThread handle
                                          dataFlow'
                       writeTVar connVar connState'
-                      return ( True
+                      return ( Right ()
                              , Just $ mkTransition connState connState'
                              , Outbound
                              )
@@ -1024,9 +1024,11 @@ with args@Arguments {
                     DuplexState {} ->
                       throwSTM (withCallStack (ImpossibleState (remoteAddress connId)))
 
-                    TerminatingState {} -> return (False, Nothing, Inbound)
+                    TerminatingState _ _ err ->
+                      return (Left err, Nothing, Inbound)
 
-                    TerminatedState {} -> return (False, Nothing, Inbound)
+                    TerminatedState err ->
+                      return (Left err, Nothing, Inbound)
 
                 traverse_ (traceWith trTracer . TransitionTrace connStateId) mbTransition
                 traceCounters stateVar
@@ -1043,8 +1045,8 @@ with args@Arguments {
                 -- idle, it will call 'releaseInboundConnection' which will
                 -- perform the aforementioned @Commit@ transition.
 
-                if connected
-                  then do
+                case connected of
+                  Right _ -> do
                     case inboundGovernorInfoChannel of
                       InResponderMode infoChannel ->
                         atomically $ InfoChannel.writeMessage
@@ -1055,8 +1057,8 @@ with args@Arguments {
 
                   -- the connection is in `TerminatingState` or
                   -- `TerminatedState`.
-                  else
-                    return $ Disconnected connId Nothing
+                  Left err ->
+                    return $ Disconnected connId err
 
     terminateInboundWithErrorOrQuery
       :: ConnectionId peerAddr

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -100,7 +100,7 @@ module Ouroboros.Network.ConnectionManager.Types
   , ConnectionHandler (..)
   , Inactive (..)
   , ExceptionInHandler (..)
-  , HandleErrorType (..)
+  , HandlerErrorType (..)
   , HandshakeConnectionResult (..)
     -- ** Prune Policy
   , PrunePolicy
@@ -413,7 +413,7 @@ instance Exception ExceptionInHandler
 
 -- | Data type used to classify 'handleErrors'.
 --
-data HandleErrorType =
+data HandlerErrorType =
     -- | Handshake negotiation failed.  This is not a protocol error.
     HandshakeFailure
 

--- a/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/ConnectionManager/Types.hs
@@ -130,6 +130,8 @@ module Ouroboros.Network.ConnectionManager.Types
   , InboundConnectionManager (..)
     -- * Exceptions
   , ConnectionManagerError (..)
+  , DisconnectionException (..)
+  , mkDisconnectionException
   , SomeConnectionManagerError (..)
   , AbstractState (..)
     -- * Counters
@@ -493,7 +495,7 @@ data Connected peerAddr handle handleError =
     -- update from the handshake instead, but this would introduce a race
     -- between inbound \/ outbound threads.
     --
-  | Disconnected !(ConnectionId peerAddr) !(Maybe handleError)
+  | Disconnected !(ConnectionId peerAddr) !(DisconnectionException handleError)
 
 
 type AcquireOutboundConnection peerAddr handle handleError m
@@ -743,7 +745,7 @@ data ConnectionManagerError peerAddr
     -- was expected.
     --
     | UnknownPeer           !peerAddr                !CallStack
-    deriving (Show)
+    deriving Show
 
 
 instance ( Show peerAddr
@@ -832,6 +834,48 @@ connectionManagerErrorFromException :: (Typeable addr, Show addr)
 connectionManagerErrorFromException x = do
     SomeConnectionManagerError a <- fromException x
     cast a
+
+
+-- | Disconnection contextual information returned by `Disconnected`.
+--
+data DisconnectionException handlerError =
+      -- | We tried to accept or acquire a connection but the connection
+      -- manager moved it to `TerminatingState`.
+      ConnectionInTerminatingState
+
+      -- | We tried to accept or acquire a connection but the connection
+      -- manager moved it to `TerminatedState`.
+    | ConnectionInTerminatedState
+
+      -- | The connection was refused because we reached inbound connection hard
+      -- limit.
+    | ReachedInboundConnectionHardLimit
+
+      -- | `ConnectionDisconnectedByHandshakeQuery` is returned when the remote
+      -- side is doing a handshake query. It's not an exception when handshake is
+      -- terminated after a query, it should be handled in a special way.
+    | ConnectionDisconnectedByHandshakeQuery
+
+      -- | Connection handler raised an exception.
+    | ConnectionHandlerError handlerError
+    deriving (Show, Functor)
+
+
+instance Exception handleError
+      => Exception (DisconnectionException handleError) where
+  displayException ConnectionInTerminatingState           = "disconnected: connection in terminating state"
+  displayException ConnectionInTerminatedState            = "disconnected: connection in terminated state"
+  displayException ReachedInboundConnectionHardLimit      = "disconnected: inbound connection hard limit reached"
+  displayException ConnectionDisconnectedByHandshakeQuery = "disconnected: handshake query"
+  displayException (ConnectionHandlerError handlerError)  = "disconnected: " ++ displayException handlerError
+
+mkDisconnectionException
+  :: DisconnectionException handlerError
+  -> Maybe handlerError
+  -> DisconnectionException handlerError
+mkDisconnectionException _ (Just handlerError) = ConnectionHandlerError handlerError
+mkDisconnectionException err Nothing           = err
+
 
 --
 -- Tracing

--- a/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
+++ b/ouroboros-network-framework/src/Ouroboros/Network/Protocol/Handshake.hs
@@ -33,6 +33,7 @@ import Codec.CBOR.Read qualified as CBOR
 import Codec.CBOR.Term qualified as CBOR
 import Control.Tracer (Tracer, contramap)
 import Data.ByteString.Lazy qualified as BL
+import Data.Typeable (Typeable)
 
 import Network.Mux.Trace qualified as Mx
 import Network.Mux.Types qualified as Mx
@@ -61,6 +62,13 @@ data HandshakeException vNumber =
     HandshakeProtocolLimit ProtocolLimitFailure
   | HandshakeProtocolError (HandshakeProtocolError vNumber)
   deriving Show
+
+instance ( Typeable versionNumber
+         , Show versionNumber
+         )
+      => Exception (HandshakeException versionNumber) where
+  displayException (HandshakeProtocolLimit failure) = "handshake protocol limits: " ++ show failure
+  displayException (HandshakeProtocolError err)     = "handshake protocol error: " ++ show err
 
 
 -- | Try to complete either initiator or responder side of the Handshake protocol

--- a/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
+++ b/ouroboros-network-framework/testlib/Test/Ouroboros/Network/ConnectionManager/Experiments.hs
@@ -326,7 +326,7 @@ withInitiatorOnlyConnectionManager name timeouts trTracer tracer stdGen snocket 
     connectionsLimits = acceptedConnLimit,
     updateVersionData = \a _ -> a,
     connStateIdSupply,
-    classifyHandleError = \_ -> HandshakeFailure
+    classifyHandlerError = \_ -> HandshakeFailure
     }
     NotInResponderMode
     mkConnectionHandler
@@ -527,7 +527,7 @@ withBidirectionalConnectionManager name timeouts
                                                     InitiatorAndResponderDiffusionMode -> Duplex
                                               },
             connStateIdSupply,
-            classifyHandleError = (\_ -> HandshakeFailure)
+            classifyHandlerError = (\_ -> HandshakeFailure)
             }
             (InResponderMode inbgovInfoChannel)
             connectionHandler

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -345,10 +345,10 @@ runM Interfaces
               :: InformationChannel
                    (IG.Event 'ResponderMode handle initiatorCtx ntcAddr versionData m c b) m
               -> ConnectionHandler 'ResponderMode (ConnectionHandlerTrace ntcVersion ntcVersionData)
-                                   ntcFd ntcAddr handle (HandleError versionNumber) version
+                                   ntcFd ntcAddr handle (HandlerError versionNumber) version
                                    versionData m
               -> (   ConnectionManager 'ResponderMode ntcFd ntcAddr handle
-                                       (HandleError versionNumber) m
+                                       (HandlerError versionNumber) m
                   -> m x)
               -> m x
             localWithConnectionManager responderInfoChannel connectionHandler k =
@@ -370,7 +370,7 @@ runM Interfaces
                   CM.connectionsLimits   = localConnectionLimits,
                   CM.updateVersionData   = \a _ -> a,
                   CM.connStateIdSupply   = diConnStateIdSupply,
-                  CM.classifyHandleError
+                  CM.classifyHandlerError
               }
               (InResponderMode responderInfoChannel)
               connectionHandler
@@ -472,7 +472,7 @@ runM Interfaces
             -> StdGen
             -> CM.Arguments
                  (ConnectionHandlerTrace ntnVersion ntnVersionData)
-                 ntnFd ntnAddr handle (HandleError ntnVersion) ntnVersion ntnVersionData m a b
+                 ntnFd ntnAddr handle (HandlerError ntnVersion) ntnVersion ntnVersionData m a b
           connectionManagerArguments' prunePolicy stdGen =
             CM.Arguments {
               CM.tracer              = dtConnectionManagerTracer,
@@ -494,7 +494,7 @@ runM Interfaces
               CM.outboundIdleTimeout = dcProtocolIdleTimeout,
               CM.updateVersionData   = daUpdateVersionData,
               CM.connStateIdSupply   = diConnStateIdSupply,
-              CM.classifyHandleError
+              CM.classifyHandlerError
             }
 
       let makeConnectionHandler'

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion.hs
@@ -345,10 +345,10 @@ runM Interfaces
               :: InformationChannel
                    (IG.Event 'ResponderMode handle initiatorCtx ntcAddr versionData m c b) m
               -> ConnectionHandler 'ResponderMode (ConnectionHandlerTrace ntcVersion ntcVersionData)
-                                   ntcFd ntcAddr handle (HandleError muxMode versionNumber) version
+                                   ntcFd ntcAddr handle (HandleError versionNumber) version
                                    versionData m
               -> (   ConnectionManager 'ResponderMode ntcFd ntcAddr handle
-                                       (HandleError muxMode versionNumber) m
+                                       (HandleError versionNumber) m
                   -> m x)
               -> m x
             localWithConnectionManager responderInfoChannel connectionHandler k =
@@ -467,12 +467,12 @@ runM Interfaces
       --
 
       let connectionManagerArguments'
-            :: forall muxMode handle b.
+            :: forall handle b.
                PrunePolicy ntnAddr
             -> StdGen
             -> CM.Arguments
                  (ConnectionHandlerTrace ntnVersion ntnVersionData)
-                 ntnFd ntnAddr handle (HandleError muxMode ntnVersion) ntnVersion ntnVersionData m a b
+                 ntnFd ntnAddr handle (HandleError ntnVersion) ntnVersion ntnVersionData m a b
           connectionManagerArguments' prunePolicy stdGen =
             CM.Arguments {
               CM.tracer              = dtConnectionManagerTracer,

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
@@ -21,6 +21,7 @@ module Ouroboros.Network.Diffusion.Types
     -- * NodeToClient type aliases
   , NodeToClientHandle
   , NodeToClientHandleError
+  , NodeToClientHandlerError
   , MkNodeToClientConnectionHandler
     -- * NodeToNode type aliases
   , NodeToNodeHandle
@@ -610,7 +611,11 @@ type NodeToClientHandle ntcAddr versionData m =
     HandleWithMinimalCtx Mx.ResponderMode ntcAddr versionData ByteString m Void ()
 
 type NodeToClientHandleError ntcVersion =
-    HandleError ntcVersion
+    HandlerError ntcVersion
+{-# DEPRECATED NodeToClientHandleError "Use NodeToClientHandlerError" #-}
+
+type NodeToClientHandlerError ntcVersion =
+    HandlerError ntcVersion
 
 type MkNodeToClientConnectionHandler
       ntcFd ntcAddr ntcVersion ntcVersionData m =
@@ -622,7 +627,7 @@ type MkNodeToClientConnectionHandler
          ntcFd
          ntcAddr
          (NodeToClientHandle ntcAddr ntcVersionData m)
-         (NodeToClientHandleError ntcVersion)
+         (NodeToClientHandlerError ntcVersion)
          ntcVersion
          ntcVersionData
          m
@@ -646,7 +651,7 @@ type NodeToNodeConnectionManager
       ntnFd
       ntnAddr
       (NodeToNodeHandle mode ntnAddr ntnVersionData m a b)
-      (HandleError ntnVersion)
+      (HandlerError ntnVersion)
       m
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
+++ b/ouroboros-network/src/Ouroboros/Network/Diffusion/Types.hs
@@ -610,7 +610,7 @@ type NodeToClientHandle ntcAddr versionData m =
     HandleWithMinimalCtx Mx.ResponderMode ntcAddr versionData ByteString m Void ()
 
 type NodeToClientHandleError ntcVersion =
-    HandleError Mx.ResponderMode ntcVersion
+    HandleError ntcVersion
 
 type MkNodeToClientConnectionHandler
       ntcFd ntcAddr ntcVersion ntcVersionData m =
@@ -646,7 +646,7 @@ type NodeToNodeConnectionManager
       ntnFd
       ntnAddr
       (NodeToNodeHandle mode ntnAddr ntnVersionData m a b)
-      (HandleError mode ntnVersion)
+      (HandleError ntnVersion)
       m
 
 --

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -66,7 +66,7 @@ import Ouroboros.Network.PeerSelection.Governor.Types (PeerStateActions (..))
 import Ouroboros.Network.Protocol.Handshake (HandshakeException)
 import Ouroboros.Network.RethrowPolicy
 
-import Ouroboros.Network.ConnectionHandler (Handle (..), HandleError (..),
+import Ouroboros.Network.ConnectionHandler (Handle (..), HandlerError (..),
            MuxConnectionManager)
 import Ouroboros.Network.ConnectionManager.Types
 import Ouroboros.Network.PeerSelection.PeerSharing (PeerSharing)
@@ -852,7 +852,7 @@ withPeerStateActions PeerStateActionsArguments {
                                             (HandshakeServerFailure err))
                       throwIO (ServerException err)
 
-                    HandleError err -> do
+                    HandlerError err -> do
                       traceWith spsTracer (PeerStatusChangeFailure
                                             (ColdToWarm Nothing remotePeerAddr )
                                             (HandleFailure err))

--- a/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/src/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -836,29 +836,29 @@ withPeerStateActions PeerStateActionsArguments {
                                    ("peerMonitoringLoop " ++ show remoteAddress))
               pure connHandle
 
-            Right (Disconnected _ Nothing) ->
-              -- Disconnected in 'TerminatingState' or 'TerminatedState' without
-              -- an exception.
-              throwIO $ userError "establishPeerConnection: Disconnected"
-            Right (Disconnected _ (Just reason)) ->
-              case reason of
-                HandleHandshakeClientError err -> do
-                  traceWith spsTracer (PeerStatusChangeFailure
-                                        (ColdToWarm Nothing remotePeerAddr)
-                                        (HandshakeClientFailure err))
-                  throwIO (ClientException err)
+            Right (Disconnected _ disconnectionError) ->
+              case disconnectionError of
+                ConnectionHandlerError handlerError ->
+                  case handlerError of
+                    HandleHandshakeClientError err -> do
+                      traceWith spsTracer (PeerStatusChangeFailure
+                                            (ColdToWarm Nothing remotePeerAddr)
+                                            (HandshakeClientFailure err))
+                      throwIO (ClientException err)
 
-                HandleHandshakeServerError err -> do
-                  traceWith spsTracer (PeerStatusChangeFailure
-                                        (ColdToWarm Nothing remotePeerAddr)
-                                        (HandshakeServerFailure err))
-                  throwIO (ServerException err)
+                    HandleHandshakeServerError err -> do
+                      traceWith spsTracer (PeerStatusChangeFailure
+                                            (ColdToWarm Nothing remotePeerAddr)
+                                            (HandshakeServerFailure err))
+                      throwIO (ServerException err)
 
-                HandleError err -> do
-                  traceWith spsTracer (PeerStatusChangeFailure
-                                        (ColdToWarm Nothing remotePeerAddr )
-                                        (HandleFailure err))
-                  throwIO err
+                    HandleError err -> do
+                      traceWith spsTracer (PeerStatusChangeFailure
+                                            (ColdToWarm Nothing remotePeerAddr )
+                                            (HandleFailure err))
+                      throwIO err
+
+                _ -> throwIO disconnectionError
       where
         mkAwaitVars :: OuroborosBundle muxMode (ExpandedInitiatorContext peerAddr m)
                                                responderCtx ByteString m a b


### PR DESCRIPTION
# Description

- **connection manager: propagate disconnection reason to peer selection**
- **connection manager: propagate disconnection reason to inbound governor**
- **connection-manager: propagate disconnection exceptions**
- **connection handler: renamed HandleError as HandlerError**


# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [x] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
