### PR TITLE
Bump dependency upper bounds as needed

### DIFF
--- a/acts-generic/acts-generic.cabal
+++ b/acts-generic/acts-generic.cabal
@@ -33,7 +33,7 @@ library
   -- other-extensions:
   build-depends:
     acts,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
 
   hs-source-dirs: src
   default-language: Haskell2010

--- a/cabal.project
+++ b/cabal.project
@@ -15,10 +15,10 @@ repository cardano-haskell-packages
 -- repeat the index-state for hackage to work around haskell.nix parsing limitation
 index-state:
   -- Bump this if you need newer packages from Hackage
-  , hackage.haskell.org 2025-08-05T15:28:56Z
+  , hackage.haskell.org 2025-10-03T00:57:11Z
 
   -- Bump this if you need newer packages from CHaP
-  , cardano-haskell-packages 2025-03-18T17:41:11Z
+  , cardano-haskell-packages 2025-10-01T14:54:47Z
 
 packages: ./cardano-ping
           ./monoidal-synchronisation

--- a/cardano-client/cardano-client.cabal
+++ b/cardano-client/cardano-client.cabal
@@ -21,7 +21,7 @@ library
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring >=0.10 && <0.13,
     cborg >=0.2.8 && <0.3,
     containers >=0.5 && <0.9,

--- a/cardano-ping/cardano-ping.cabal
+++ b/cardano-ping/cardano-ping.cabal
@@ -27,7 +27,7 @@ library
   exposed-modules: Cardano.Network.Ping
   build-depends:
     aeson >=2.1.1.0 && <3,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring >=0.10 && <0.13,
     cborg >=0.2.8 && <0.3,
     contra-tracer >=0.1 && <0.3,
@@ -37,7 +37,7 @@ library
     network-mux ^>=0.9,
     tdigest ^>=0.3,
     text >=1.2.4 && <2.2,
-    time >=1.9.1 && <1.14,
+    time >=1.9.1 && <1.16,
     transformers >=0.5 && <0.7,
 
   if flag(asserts)

--- a/dmq-node/dmq-node.cabal
+++ b/dmq-node/dmq-node.cabal
@@ -103,7 +103,7 @@ library
     random ^>=1.2,
     singletons,
     text >=1.2.4 && <2.2,
-    time >= 1.12 && < 1.16,
+    time >= 1.12 && <1.16,
     typed-protocols:{typed-protocols, cborg} ^>=1.1,
 
   hs-source-dirs: src

--- a/dmq-node/dmq-node.cabal
+++ b/dmq-node/dmq-node.cabal
@@ -77,12 +77,12 @@ library
     acts-generic,
     aeson >=2.1.1.0 && <3,
     aeson-pretty,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring >=0.10 && <0.13,
     cardano-binary,
     cardano-crypto-class,
     cborg >=0.2.1 && <0.3,
-    containers >=0.5 && <0.8,
+    containers >=0.5 && <0.9,
     contra-tracer >=0.1 && <0.3,
     deepseq >=1.0 && <1.6,
     directory,
@@ -95,7 +95,7 @@ library
     kes-agent-crypto ^>=0.1,
     network ^>=3.2.7,
     network-mux ^>=0.9.1,
-    optparse-applicative ^>=0.18,
+    optparse-applicative ^>=0.19,
     ouroboros-network:{ouroboros-network, orphan-instances} ^>=0.23,
     ouroboros-network-api ^>=0.17,
     ouroboros-network-framework ^>=0.20,
@@ -103,7 +103,7 @@ library
     random ^>=1.2,
     singletons,
     text >=1.2.4 && <2.2,
-    time ^>=1.12,
+    time >= 1.12 && < 1.16,
     typed-protocols:{typed-protocols, cborg} ^>=1.1,
 
   hs-source-dirs: src
@@ -152,7 +152,7 @@ test-suite dmq-test
   main-is: Main.hs
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cardano-crypto-class,
     cardano-crypto-tests,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1757088431,
-        "narHash": "sha256-yUv1JB7WOjoVWhEfk8cKap1P9QDn4hLd4ZHdkNoqvuY=",
+        "lastModified": 1759339316,
+        "narHash": "sha256-SW/K9yfhNLNCDAl2ZC8ol0w8X+AwyLin0XOvnn50468=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "8e043cb654d69e62bfb59b80afb2ddda8481f6f7",
+        "rev": "aa50d6dffede91c8fdfcef94c71641a00214522a",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1757118285,
-        "narHash": "sha256-raOJMmWvdovIsWKD0qPTfEmidzhKWYPb5iJRaITEGwU=",
+        "lastModified": 1759455519,
+        "narHash": "sha256-26uX6iK4F0TnBB8Sy1xFezdJTdnvCXbSgilMIHIhIGw=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "a94851a2dcf6a8d4fd6e88e6481fd8fe620f320b",
+        "rev": "0d8a374f043f503a627d41df2fbe5a7b00b98f07",
         "type": "github"
       },
       "original": {

--- a/monoidal-synchronisation/monoidal-synchronisation.cabal
+++ b/monoidal-synchronisation/monoidal-synchronisation.cabal
@@ -16,7 +16,7 @@ extra-doc-files: CHANGELOG.md
 
 library
   exposed-modules: Data.Monoid.Synchronisation
-  build-depends: base >=4.14 && <4.22
+  build-depends: base >=4.14 && <4.23
   hs-source-dirs: src
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -37,7 +37,7 @@ test-suite test
   other-modules: Test.Data.Monoid.Synchronisation
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     io-classes,
     io-sim,
     monoidal-synchronisation,

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -49,10 +49,10 @@ library
     -- functions, see
     -- https://github.com/haskell/network/issues/484
     array >=0.5 && <0.6,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     binary >=0.8 && <0.11,
     bytestring >=0.10 && <0.13,
-    containers >=0.5 && <0.8,
+    containers >=0.5 && <0.9,
     contra-tracer >=0.1 && <0.2,
     io-classes:{io-classes, si-timers, strict-stm} ^>=1.8.0.1,
     monoidal-synchronisation >=0.1 && <0.2,
@@ -61,7 +61,7 @@ library
     quiet,
     statistics-linreg >=0.3 && <0.4,
     strict,
-    time >=1.9.1 && <1.14,
+    time >=1.9.1 && <1.16,
     vector >=0.12 && <0.14,
 
   if os(windows)
@@ -127,7 +127,7 @@ test-suite test
   build-depends:
     QuickCheck,
     Win32-network,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     binary,
     bytestring,
     cborg,
@@ -174,7 +174,7 @@ executable mux-demo
   main-is: mux-demo.hs
   other-modules: Test.Mux.ReqResp
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     contra-tracer,
@@ -199,7 +199,7 @@ benchmark socket-read-write-benchmarks
   main-is: Main.hs
   other-modules:
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     contra-tracer,
     io-classes:{io-classes, si-timers, strict-stm},

--- a/ntp-client/ntp-client.cabal
+++ b/ntp-client/ntp-client.cabal
@@ -30,13 +30,13 @@ library
   build-depends:
     Win32-network >=0.1 && <0.3,
     async >=2.2 && <2.3,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     binary >=0.8 && <0.11,
     bytestring >=0.10 && <0.13,
     contra-tracer >=0.1 && <0.2,
     network ^>=3.2.7,
     stm >=2.4 && <2.6,
-    time >=1.9.1 && <1.14,
+    time >=1.9.1 && <1.16,
 
   hs-source-dirs: src
   default-language: Haskell2010
@@ -63,11 +63,11 @@ test-suite test
   type: exitcode-stdio-1.0
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     binary >=0.8 && <0.11,
     tasty,
     tasty-quickcheck,
-    time >=1.9.1 && <1.14,
+    time >=1.9.1 && <1.16,
 
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -89,7 +89,7 @@ executable demo-ntp-client
   build-depends:
     Win32-network >=0.1 && <0.3,
     async >=2.2 && <2.3,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     contra-tracer >=0.1 && <0.2,
     ntp-client,
 

--- a/ouroboros-network-api/ouroboros-network-api.cabal
+++ b/ouroboros-network-api/ouroboros-network-api.cabal
@@ -56,7 +56,7 @@ library
   default-extensions: ImportQualifiedPost
   build-depends:
     aeson,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     base16-bytestring,
     bytestring >=0.10 && <0.13,
     cardano-binary,
@@ -105,7 +105,7 @@ test-suite test
   build-depends:
     QuickCheck,
     aeson,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cardano-binary,
     cborg,
@@ -137,7 +137,7 @@ benchmark bench-anchored-fragment
     BenchBlock
 
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cryptohash-sha256,
     nothunks,

--- a/ouroboros-network-framework/ouroboros-network-framework.cabal
+++ b/ouroboros-network-framework/ouroboros-network-framework.cabal
@@ -65,11 +65,11 @@ library
   build-depends:
     -- ^ only to derive nothunk instances
     Win32-network ^>=0.2,
-    base >=4.12 && <4.22,
+    base >=4.12 && <4.23,
     bytestring >=0.10 && <0.13,
     cardano-strict-containers,
     cborg >=0.2.1 && <0.3,
-    containers >=0.5 && <0.8,
+    containers >=0.5 && <0.9,
     contra-tracer,
     deepseq,
     hashable,
@@ -117,7 +117,7 @@ library testlib
   other-modules:
   build-depends:
     QuickCheck >=2.16,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     containers,
@@ -159,7 +159,7 @@ test-suite sim-tests
 
   build-depends:
     QuickCheck >=2.16,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     containers,
@@ -214,7 +214,7 @@ test-suite io-tests
 
   build-depends:
     QuickCheck >=2.16,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     contra-tracer,
     directory,
@@ -255,7 +255,7 @@ executable demo-ping-pong
   main-is: ping-pong.hs
   build-depends:
     async,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     contra-tracer,
     directory,
@@ -282,7 +282,7 @@ executable demo-connection-manager
   hs-source-dirs: demo
   main-is: connection-manager.hs
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     contra-tracer,
     hashable,

--- a/ouroboros-network-mock/ouroboros-network-mock.cabal
+++ b/ouroboros-network-mock/ouroboros-network-mock.cabal
@@ -34,7 +34,7 @@ library
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     containers,

--- a/ouroboros-network-protocols/ouroboros-network-protocols.cabal
+++ b/ouroboros-network-protocols/ouroboros-network-protocols.cabal
@@ -98,7 +98,7 @@ library
     TypeInType
 
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring >=0.10 && <0.13,
     cborg >=0.2.1 && <0.3,
     constraints,
@@ -177,7 +177,7 @@ library testlib
 
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cardano-slotting:testlib ^>=0.2.0,
     cardano-strict-containers,
@@ -220,7 +220,7 @@ test-suite test
   default-extensions: ImportQualifiedPost
   build-depends:
     QuickCheck ^>=2.16,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     ouroboros-network-api,
     ouroboros-network-mock,
     ouroboros-network-protocols:testlib,
@@ -248,7 +248,7 @@ test-suite cddl
   default-extensions: ImportQualifiedPost
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     containers,
@@ -287,7 +287,7 @@ test-suite bench
   main-is: Main.hs
   default-language: Haskell2010
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cborg,
     containers,

--- a/ouroboros-network-testing/ouroboros-network-testing.cabal
+++ b/ouroboros-network-testing/ouroboros-network-testing.cabal
@@ -64,7 +64,7 @@ library
 
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     cborg >=0.2.1 && <0.3,
     containers,
     contra-tracer,
@@ -99,7 +99,7 @@ test-suite test
   other-modules: Test.Ouroboros.Network.Data.AbsBearerInfo.Test
   build-depends:
     QuickCheck,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     ouroboros-network-testing,
     tasty,
     tasty-quickcheck,

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -139,7 +139,7 @@ library
     TypeInType
 
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring >=0.10 && <0.13,
     cardano-prelude,
     cardano-slotting,
@@ -212,7 +212,7 @@ library orphan-instances
 
   build-depends:
     aeson,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     containers,
     io-classes:si-timers,
     iproute,
@@ -280,7 +280,7 @@ library cardano-diffusion
     TypeInType
 
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     containers,
     contra-tracer,
@@ -314,7 +314,7 @@ library testlib
     QuickCheck >=2.16,
     aeson,
     array,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     cardano-slotting,
     cardano-strict-containers,
@@ -349,7 +349,7 @@ library testlib
     tasty-hunit,
     tasty-quickcheck,
     text,
-    time >=1.9.1 && <1.14,
+    time >=1.9.1 && <1.16,
     typed-protocols:{typed-protocols, examples},
 
   exposed-modules:
@@ -402,7 +402,7 @@ test-suite sim-tests
   hs-source-dirs: sim-tests
   main-is: Main.hs
   build-depends:
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     ouroboros-network:testlib,
     ouroboros-network-protocols:testlib,
     tasty,
@@ -433,7 +433,7 @@ test-suite io-tests
   default-extensions: ImportQualifiedPost
   build-depends:
     QuickCheck >=2.16,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     contra-tracer,
     io-classes:{io-classes, si-timers, strict-stm},
@@ -472,7 +472,7 @@ executable demo-chain-sync
   main-is: chain-sync.hs
   build-depends:
     async,
-    base >=4.14 && <4.22,
+    base >=4.14 && <4.23,
     bytestring,
     containers,
     contra-tracer,


### PR DESCRIPTION
# Description

Upper bounds that could be bumped (found with `cabal outdated`) were. Still builds with `ghc-9.12.2`.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
