### PR TITLE
cardano-diffusion: label ledger peer usage

### DIFF
--- a/cardano-diffusion/changelog.d/20260527_4683_dancewithheart_ledger_peer_usage_label.md
+++ b/cardano-diffusion/changelog.d/20260527_4683_dancewithheart_ledger_peer_usage_label.md
@@ -1,0 +1,3 @@
+### Non-Breaking
+
+- Add a diffusion test label showing the distribution of ledger peer usage.

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -2096,15 +2096,16 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
       (ledgerPeerResultLabels, ledgerPeerActionLabels) = ledgerPeerLabelsFromTrace events
 
       -- Generic peer-selection actions, such as 'TracePromoteWarmPeers',
-      -- only carry the selected peers.  They do not say whether those peers
+      -- only carry the selected peers. They do not say whether those peers
       -- are ledger peers.
       --
       -- This is a trace-derived classification: generic peer-action events are
       -- classified using the ledger-peer set from the most recent debug-state
-      -- snapshot in the same ordered trace stream.
+      -- snapshot in the same ordered trace stream. Before the first debug
+      -- snapshot, generic actions are left unclassified.
       --
-      -- The first result - ledger-peer result sizes.
-      -- The second result - how many ledger peers were selected by actions.
+      -- The first result list reports ledger-peer result sizes. The second
+      -- result list reports how many ledger peers were selected by actions.
       ledgerPeerLabelsFromTrace
         :: [TracePeerSelection Cardano.ExtraState
                                PeerTrustable
@@ -2112,11 +2113,11 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
                                NtNAddr]
         -> ([String], [String])
       ledgerPeerLabelsFromTrace =
-        go Set.empty
+        go Nothing
         where
           go
-            :: Set NtNAddr
-            -- ^ Ledger peers from the most recent 'TraceDebugState'.
+            :: Maybe (Set NtNAddr)
+            -- ^ Ledger peers from the most recent 'TraceDebugState', if any.
             -> [TracePeerSelection Cardano.ExtraState
                                    PeerTrustable
                                    (ExtraPeers NtNAddr)
@@ -2125,15 +2126,15 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
           go _ [] = ([], [])
           go _ (TraceDebugState _ st : evs) =
             let currentLedgerPeers = PublicRootPeers.getLedgerPeers (dpssPublicRootPeers st)
-             in go currentLedgerPeers evs
-          go ledgerPeers (event : evs) =
-            let (resultLabels, actionLabels) = go ledgerPeers evs
+            in go (Just currentLedgerPeers) evs
+          go mbLedgerPeers (event : evs) =
+            let (resultLabels, actionLabels) = go mbLedgerPeers evs
                 resultLabels' =
                   case ledgerPeerResultLabel event of
                     Nothing -> resultLabels
                     Just rl -> rl : resultLabels
                 actionLabels' =
-                  case ledgerPeerActionLabel ledgerPeers event of
+                  case ledgerPeerActionLabel mbLedgerPeers event of
                     Nothing -> actionLabels
                     Just al -> al : actionLabels
              in (resultLabels', actionLabels')
@@ -2150,37 +2151,36 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
         _ -> Nothing
 
       ledgerPeerActionLabel
-        :: Ord peeraddr
-        => Set peeraddr
-        -> TracePeerSelection extraDebugState extraFlags extraPeers peeraddr
+        :: Maybe (Set NtNAddr)
+        -> TracePeerSelection Cardano.ExtraState PeerTrustable (ExtraPeers NtNAddr) NtNAddr
         -> Maybe String
-      ledgerPeerActionLabel ledgerPeers = \case
+      ledgerPeerActionLabel mbLedgerPeers = \case
         TraceForgetBigLedgerPeers _ _ peers -> Just $ "TraceForgetBigLedgerPeers " ++ show (Set.size peers)
         TracePromoteColdBigLedgerPeers _ _ peers -> Just $ "TracePromoteColdBigLedgerPeers " ++ show (Set.size peers)
         TracePromoteWarmBigLedgerPeers _ _ peers -> Just $ "TracePromoteWarmBigLedgerPeers " ++ show (Set.size peers)
         TraceDemoteWarmBigLedgerPeers _ _ peers -> Just $ "TraceDemoteWarmBigLedgerPeers " ++ show (Set.size peers)
         TraceDemoteHotBigLedgerPeers _ _ peers -> Just $ "TraceDemoteHotBigLedgerPeers " ++ show (Set.size peers)
         TracePromoteColdPeers _ _ peers ->
-          labelLedgerPeerIntersection "TracePromoteColdPeers ledger peers" ledgerPeers peers
+          labelLedgerPeerIntersection "TracePromoteColdPeers ledger peers" mbLedgerPeers peers
         TracePromoteWarmPeers _ _ peers ->
-          labelLedgerPeerIntersection "TracePromoteWarmPeers ledger peers" ledgerPeers peers
+          labelLedgerPeerIntersection "TracePromoteWarmPeers ledger peers" mbLedgerPeers peers
         TraceDemoteWarmPeers _ _ peers ->
-          labelLedgerPeerIntersection "TraceDemoteWarmPeers ledger peers" ledgerPeers peers
+          labelLedgerPeerIntersection "TraceDemoteWarmPeers ledger peers" mbLedgerPeers peers
         TraceDemoteHotPeers _ _ peers ->
-          labelLedgerPeerIntersection "TraceDemoteHotPeers ledger peers" ledgerPeers peers
+          labelLedgerPeerIntersection "TraceDemoteHotPeers ledger peers" mbLedgerPeers peers
         TraceForgetColdPeers _ _ peers ->
-          labelLedgerPeerIntersection "TraceForgetColdPeers ledger peers" ledgerPeers peers
+          labelLedgerPeerIntersection "TraceForgetColdPeers ledger peers" mbLedgerPeers peers
         _ -> Nothing
 
       labelLedgerPeerIntersection
-        :: Ord peeraddr
-        => String
-        -> Set peeraddr
-        -> Set peeraddr
+        :: String
+        -> Maybe (Set NtNAddr)
+        -> Set NtNAddr
         -> Maybe String
-      labelLedgerPeerIntersection name ledgerPeers peers =
-        let usedLedgerPeers = Set.intersection ledgerPeers peers
-         in Just $ name ++ " " ++ show (Set.size usedLedgerPeers)
+      labelLedgerPeerIntersection _ Nothing _ = Nothing
+      labelLedgerPeerIntersection name (Just ledgerPeers) peers =
+        let selectedLedgerPeers = Set.intersection ledgerPeers peers
+         in Just $ name ++ " " ++ show (Set.size selectedLedgerPeers)
 
    -- TODO: Add checkCoverage here
    in tabulate "peer selection trace" eventsSeenNames

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -2092,10 +2092,25 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
       peerSelectionTraceMap (TraceVerifyPeerSnapshot result)         =
         "TraceVerifyPeerSnapshot " <> show result
       eventsSeenNames = map peerSelectionTraceMap events
+      ledgerPeerUsageLabels =
+        mapMaybe ledgerPeerUsageLabel events
+
+      ledgerPeerUsageLabel
+        :: TracePeerSelection extraState extraFlags extraPeers peeraddr
+        -> Maybe String
+      ledgerPeerUsageLabel = \case
+        TraceBigLedgerPeersResults peers _ _ -> Just $ "TraceBigLedgerPeersResults " ++ show (Set.size peers)
+        TraceForgetBigLedgerPeers _ _ peers -> Just $ "TraceForgetBigLedgerPeers " ++ show (Set.size peers)
+        TracePromoteColdBigLedgerPeers _ _ peers -> Just $ "TracePromoteColdBigLedgerPeers " ++ show (Set.size peers)
+        TracePromoteWarmBigLedgerPeers _ _ peers -> Just $ "TracePromoteWarmBigLedgerPeers " ++ show (Set.size peers)
+        TraceDemoteWarmBigLedgerPeers _ _ peers -> Just $ "TraceDemoteWarmBigLedgerPeers " ++ show (Set.size peers)
+        TraceDemoteHotBigLedgerPeers _ _ peers -> Just $ "TraceDemoteHotBigLedgerPeers " ++ show (Set.size peers)
+        _ -> Nothing
 
    -- TODO: Add checkCoverage here
    in tabulate "peer selection trace" eventsSeenNames
-      True
+       $ tabulate "distribution of used ledger peers" ledgerPeerUsageLabels
+         True
 
 -- | A variant of
 -- 'Test.Ouroboros.Network.ConnectionHandler.Network.PeerSelection.prop_governor_nolivelock'

--- a/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
+++ b/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet.hs
@@ -2092,24 +2092,100 @@ prop_peer_selection_trace_coverage defaultBearerInfo diffScript =
       peerSelectionTraceMap (TraceVerifyPeerSnapshot result)         =
         "TraceVerifyPeerSnapshot " <> show result
       eventsSeenNames = map peerSelectionTraceMap events
-      ledgerPeerUsageLabels =
-        mapMaybe ledgerPeerUsageLabel events
 
-      ledgerPeerUsageLabel
-        :: TracePeerSelection extraState extraFlags extraPeers peeraddr
+      (ledgerPeerResultLabels, ledgerPeerActionLabels) = ledgerPeerLabelsFromTrace events
+
+      -- Generic peer-selection actions, such as 'TracePromoteWarmPeers',
+      -- only carry the selected peers.  They do not say whether those peers
+      -- are ledger peers.
+      --
+      -- This is a trace-derived classification: generic peer-action events are
+      -- classified using the ledger-peer set from the most recent debug-state
+      -- snapshot in the same ordered trace stream.
+      --
+      -- The first result - ledger-peer result sizes.
+      -- The second result - how many ledger peers were selected by actions.
+      ledgerPeerLabelsFromTrace
+        :: [TracePeerSelection Cardano.ExtraState
+                               PeerTrustable
+                               (ExtraPeers NtNAddr)
+                               NtNAddr]
+        -> ([String], [String])
+      ledgerPeerLabelsFromTrace =
+        go Set.empty
+        where
+          go
+            :: Set NtNAddr
+            -- ^ Ledger peers from the most recent 'TraceDebugState'.
+            -> [TracePeerSelection Cardano.ExtraState
+                                   PeerTrustable
+                                   (ExtraPeers NtNAddr)
+                                   NtNAddr]
+            -> ([String], [String])
+          go _ [] = ([], [])
+          go _ (TraceDebugState _ st : evs) =
+            let currentLedgerPeers = PublicRootPeers.getLedgerPeers (dpssPublicRootPeers st)
+             in go currentLedgerPeers evs
+          go ledgerPeers (event : evs) =
+            let (resultLabels, actionLabels) = go ledgerPeers evs
+                resultLabels' =
+                  case ledgerPeerResultLabel event of
+                    Nothing -> resultLabels
+                    Just rl -> rl : resultLabels
+                actionLabels' =
+                  case ledgerPeerActionLabel ledgerPeers event of
+                    Nothing -> actionLabels
+                    Just al -> al : actionLabels
+             in (resultLabels', actionLabels')
+
+      ledgerPeerResultLabel
+        :: TracePeerSelection extraDebugState extraFlags extraPeers peeraddr
         -> Maybe String
-      ledgerPeerUsageLabel = \case
-        TraceBigLedgerPeersResults peers _ _ -> Just $ "TraceBigLedgerPeersResults " ++ show (Set.size peers)
+      ledgerPeerResultLabel = \case
+        TraceBigLedgerPeersResults peers _ _ ->
+          Just $ "TraceBigLedgerPeersResults " ++ show (Set.size peers)
+        TracePublicRootsResults publicRootPeers _ _ ->
+          let ledgerPeers = PublicRootPeers.getLedgerPeers publicRootPeers
+          in Just $ "TracePublicRootsResults ledger peers " ++ show (Set.size ledgerPeers)
+        _ -> Nothing
+
+      ledgerPeerActionLabel
+        :: Ord peeraddr
+        => Set peeraddr
+        -> TracePeerSelection extraDebugState extraFlags extraPeers peeraddr
+        -> Maybe String
+      ledgerPeerActionLabel ledgerPeers = \case
         TraceForgetBigLedgerPeers _ _ peers -> Just $ "TraceForgetBigLedgerPeers " ++ show (Set.size peers)
         TracePromoteColdBigLedgerPeers _ _ peers -> Just $ "TracePromoteColdBigLedgerPeers " ++ show (Set.size peers)
         TracePromoteWarmBigLedgerPeers _ _ peers -> Just $ "TracePromoteWarmBigLedgerPeers " ++ show (Set.size peers)
         TraceDemoteWarmBigLedgerPeers _ _ peers -> Just $ "TraceDemoteWarmBigLedgerPeers " ++ show (Set.size peers)
         TraceDemoteHotBigLedgerPeers _ _ peers -> Just $ "TraceDemoteHotBigLedgerPeers " ++ show (Set.size peers)
+        TracePromoteColdPeers _ _ peers ->
+          labelLedgerPeerIntersection "TracePromoteColdPeers ledger peers" ledgerPeers peers
+        TracePromoteWarmPeers _ _ peers ->
+          labelLedgerPeerIntersection "TracePromoteWarmPeers ledger peers" ledgerPeers peers
+        TraceDemoteWarmPeers _ _ peers ->
+          labelLedgerPeerIntersection "TraceDemoteWarmPeers ledger peers" ledgerPeers peers
+        TraceDemoteHotPeers _ _ peers ->
+          labelLedgerPeerIntersection "TraceDemoteHotPeers ledger peers" ledgerPeers peers
+        TraceForgetColdPeers _ _ peers ->
+          labelLedgerPeerIntersection "TraceForgetColdPeers ledger peers" ledgerPeers peers
         _ -> Nothing
+
+      labelLedgerPeerIntersection
+        :: Ord peeraddr
+        => String
+        -> Set peeraddr
+        -> Set peeraddr
+        -> Maybe String
+      labelLedgerPeerIntersection name ledgerPeers peers =
+        let usedLedgerPeers = Set.intersection ledgerPeers peers
+         in Just $ name ++ " " ++ show (Set.size usedLedgerPeers)
 
    -- TODO: Add checkCoverage here
    in tabulate "peer selection trace" eventsSeenNames
-       $ tabulate "distribution of used ledger peers" ledgerPeerUsageLabels
+       $ tabulate "ledger peer result sizes" ledgerPeerResultLabels
+       $ tabulate "ledger peers selected by actions" ledgerPeerActionLabels
          True
 
 -- | A variant of


### PR DESCRIPTION
# Description

Fixes #4683

Issue reference comment for `ledgerPeers` in `genNodeArgs` :

https://github.com/IntersectMBO/ouroboros-network/blob/d842a238a9ac329a4bb676dd95e46ee25a7a1a94/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet/Simulation.hs#L450-L451

`genNodeArgs` is used in generator for `DiffusionScript`:

https://github.com/IntersectMBO/ouroboros-network/blob/d842a238a9ac329a4bb676dd95e46ee25a7a1a94/cardano-diffusion/tests/lib/Test/Cardano/Network/Diffusion/Testnet/Simulation.hs#L677-L677

It is used in many properties, but most likely target seems `prop_peer_selection_trace_coverage` that already tabulate `TracePeerSelection` events. I added another tabulate - over events with `Set peeraddr` (and not on single  `peeraddr`):
```
cabal run cardano-diffusion:test:cardano-diffusion-sim-tests -- -p '/peer selection trace coverage/'
```
now shows:
```text
cardano-diffusion-sim-tests
  Ouroboros.Network.Testnet
    IOSim
      coverage
        peer selection trace coverage: OK (35.13s)
          +++ OK, passed 100 tests.                                                                                                                                                         
          
          distribution of used ledger peers (8350 in total):
          63.15% TraceBigLedgerPeersResults 0
          26.49% TracePromoteColdBigLedgerPeers 1
           8.90% TraceBigLedgerPeersResults 1
           1.20% TraceForgetBigLedgerPeers 1
           0.18% TracePromoteWarmBigLedgerPeers 1
           0.08% TraceBigLedgerPeersResults 2
          
          peer selection trace (65219 in total):
          16.330% TraceGovernorWakeup
          12.394% TracePromoteColdFailed
```

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
