### PR TITLE
More performant mux header encoding / decoding.

### DIFF
--- a/network-mux/bench/socket_read_write/Main.hs
+++ b/network-mux/bench/socket_read_write/Main.hs
@@ -23,6 +23,7 @@ import Test.Tasty.Bench
 
 import Network.Mux
 import Network.Mux.Bearer
+import Network.Mux.Codec (decodeSDU, encodeSDU)
 import Network.Mux.Egress
 import Network.Mux.Ingress
 import Network.Mux.Timeout (withTimeoutSerial)
@@ -184,19 +185,33 @@ startServerMany sndSizeV ad = forever $ do
           let sdus = replicate runtSdus $ wrap $ BL.replicate sndSize 0xa5
           void $ writeMany bearer activeTracer timeoutFn sdus
      )
- where
-  -- wrap a 'ByteString' as 'SDU'
-  wrap :: BL.ByteString -> SDU
-  wrap blob = SDU {
-        -- it will be filled when the 'SDU' is send by the 'bearer'
-       msHeader = SDUHeader {
-           mhTimestamp = RemoteClockModel 0,
-           mhNum       = MiniProtocolNum 42,
-           mhDir       = ResponderDir,
-           mhLength    = fromIntegral $ BL.length blob
-          },
-        msBlob = blob
-     }
+
+-- | Wrap a 'ByteString' as 'SDU'
+wrap :: BL.ByteString -> SDU
+wrap blob = SDU {
+      -- it will be filled when the 'SDU' is send by the 'bearer'
+     msHeader = SDUHeader {
+         mhTimestamp = RemoteClockModel 0,
+         mhNum       = MiniProtocolNum 42,
+         mhDir       = ResponderDir,
+         mhLength    = fromIntegral $ BL.length blob
+        },
+      msBlob = blob
+   }
+
+-- | An 'SDU' with a payload of the given size.
+mkSDU :: Int64 -> SDU
+mkSDU size = wrap $ BL.replicate size 0xa5
+
+-- | An encoded 'SDU' header, input for the 'decodeSDU' benchmarks.
+hdrBytes :: Int64 -> BL.ByteString
+hdrBytes size = BL.take msHeaderLength $ encodeSDU $ mkSDU size
+
+-- | Decode an 'SDU' header, forcing the result.
+decodeHdr :: BL.ByteString -> Word16
+decodeHdr b = case decodeSDU b of
+                   Right sdu -> msLength sdu
+                   Left  _   -> 0
 
 -- | Run a server that accept connections on `ad`.
 -- It will send streams of data over the 41 and 42 miniprotocol.
@@ -297,29 +312,47 @@ main = do
           withAsync (startServerMany sndSizeMV ad2) $ \saidM -> do
             withAsync (startServerEgresss 0.001 sndSizeEV ad3) $ \saidE -> withAsync (startServerEgresss 0 sndSizeEV ad4) $ \saidF -> do
               defaultMain [
-                  -- Suggested Max SDU size for Socket bearer
-                  bench "Read/Write Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 12288 addr
+                  -- Micro-benchmarks for SDU header encoding, isolated
+                  -- from socket IO.
+                  bgroup "Codec" [
+                    bench "encodeSDU 12288 byte SDU" $ nf encodeSDU (mkSDU 12288)
+                  , bench "encodeSDU 10 byte SDU"    $ nf encodeSDU (mkSDU 10)
+                    -- mirrors the batching used by writeMany
+                  , bench "encodeSDU 10x12288 byte SDUs" $
+                      nf (map encodeSDU) (replicate 10 $ mkSDU 12288)
+                  , bench "decodeSDU 12288 byte SDU" $
+                      whnf decodeHdr (hdrBytes 12288)
+                  , bench "decodeSDU 10 byte SDU" $
+                      whnf decodeHdr (hdrBytes 10)
+                  , bench "decodeSDU 10x12288 byte SDUs" $
+                      nf (map decodeHdr) (replicate 10 $ hdrBytes 12288)
+                  ]
+
+                , bgroup "Socket" [
+                    -- Suggested Max SDU size for Socket bearer
+                    bench "Read/Write Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 12288 addr
+                    -- Payload size for ChainSync's RequestNext
+                  , bench "Read/Write Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 914 addr
                   -- Payload size for ChainSync's RequestNext
-                , bench "Read/Write Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 914 addr
-                -- Payload size for ChainSync's RequestNext
-                , bench "Read/Write Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 10 addr
+                  , bench "Read/Write Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeV 10 addr
 
-                  -- Send batches of SDUs at the same time
-                , bench "Read/Write-Many Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 12288 addrM
-                , bench "Read/Write-Many Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 914 addrM
-                , bench "Read/Write-Many Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 10 addrM
+                    -- Send batches of SDUs at the same time
+                  , bench "Read/Write-Many Benchmark 12288 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 12288 addrM
+                  , bench "Read/Write-Many Benchmark 914 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 914 addrM
+                  , bench "Read/Write-Many Benchmark 10 byte SDUs"  $ nfIO $ readBenchmark sndSizeMV 10 addrM
 
-                  -- Use standard muxer and demuxer, 1ms poll
-                , bench "Read/Write Mux Benchmark 800+10 byte SDUs, 1ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 800 addrE
-                , bench "Read/Write Mux Benchmark 12288+10 byte SDUs, 1ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 12288 addrE
+                    -- Use standard muxer and demuxer, 1ms poll
+                  , bench "Read/Write Mux Benchmark 800+10 byte SDUs, 1ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 800 addrE
+                  , bench "Read/Write Mux Benchmark 12288+10 byte SDUs, 1ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 12288 addrE
 
-                  -- Use standard muxer and demuxer, 0ms poll
-                , bench "Read/Write Mux Benchmark 800+10 byte SDUs, 0ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 800 addrF
-                , bench "Read/Write Mux Benchmark 12288+10 byte SDUs, 0ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 12288 addrF
+                    -- Use standard muxer and demuxer, 0ms poll
+                  , bench "Read/Write Mux Benchmark 800+10 byte SDUs, 0ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 800 addrF
+                  , bench "Read/Write Mux Benchmark 12288+10 byte SDUs, 0ms Poll"  $ nfIO $ readDemuxerBenchmark sndSizeEV 12288 addrF
 
-                  -- Use standard demuxer
-                , bench "Read/Write Demuxer Queuing Benchmark 10 byte SDUs"  $ nfIO $ readDemuxerQueueBenchmark sndSizeV 10 addr
-                , bench "Read/Write Demuxer Queuing Benchmark 256 byte SDUs"  $ nfIO $ readDemuxerQueueBenchmark sndSizeV 256 addr
+                    -- Use standard demuxer
+                  , bench "Read/Write Demuxer Queuing Benchmark 10 byte SDUs"  $ nfIO $ readDemuxerQueueBenchmark sndSizeV 10 addr
+                  , bench "Read/Write Demuxer Queuing Benchmark 256 byte SDUs"  $ nfIO $ readDemuxerQueueBenchmark sndSizeV 256 addr
+                  ]
                 ]
               cancel said
               cancel saidM

--- a/network-mux/changelog.d/20260805_093641_karl.fb.knutsson_mux_hdr.md
+++ b/network-mux/changelog.d/20260805_093641_karl.fb.knutsson_mux_hdr.md
@@ -1,0 +1,4 @@
+### Non-Breaking
+
+- More efficient codec for mux header
+

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -55,7 +55,6 @@ library
     -- https://github.com/haskell/network/issues/484
     array >=0.5 && <0.6,
     base >=4.14 && <4.23,
-    binary >=0.8 && <0.11,
     bytestring >=0.10 && <0.13,
     containers >=0.5 && <0.9,
     contra-tracer ^>=0.2.1,
@@ -140,7 +139,7 @@ test-suite test
     QuickCheck,
     Win32-network,
     base >=4.14 && <4.23,
-    binary,
+    binary >=0.8 && <0.11,
     bytestring,
     cardano-base:testlib >=0.1.5.0,
     cborg,
@@ -255,7 +254,7 @@ benchmark socket-read-write-benchmarks
   ghc-options:
     -threaded
     -rtsopts
-    "-with-rtsopts=-T"
+    -with-rtsopts=-T
     -fproc-alignment=64
     -Wall
     -Wcompat

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -255,6 +255,7 @@ benchmark socket-read-write-benchmarks
   ghc-options:
     -threaded
     -rtsopts
+    "-with-rtsopts=-T"
     -fproc-alignment=64
     -Wall
     -Wcompat

--- a/network-mux/src/Network/Mux/Codec.hs
+++ b/network-mux/src/Network/Mux/Codec.hs
@@ -2,9 +2,10 @@
 
 module Network.Mux.Codec where
 
-import Data.Binary.Get qualified as Bin
-import Data.Binary.Put qualified as Bin
 import Data.Bits
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder qualified as Bld
+import Data.ByteString.Builder.Extra qualified as Bld
 import Data.ByteString.Lazy qualified as BL
 import Data.Word
 
@@ -36,13 +37,15 @@ import Network.Mux.Types
 --
 encodeSDU :: SDU -> BL.ByteString
 encodeSDU sdu =
-  let hdr = Bin.runPut enc in
-  BL.append hdr $ msBlob sdu
+    Bld.toLazyByteStringWith
+      (Bld.untrimmedStrategy hdrLength hdrLength)
+      (msBlob sdu) hdr
   where
-    enc = do
-        Bin.putWord32be $ unRemoteClockModel $ msTimestamp sdu
-        Bin.putWord16be $ putNumAndMode (msNum sdu) (msDir sdu)
-        Bin.putWord16be $ fromIntegral $ BL.length $ msBlob sdu
+    hdrLength = fromIntegral msHeaderLength
+
+    hdr = Bld.word32BE (unRemoteClockModel (msTimestamp sdu))
+       <> Bld.word16BE (putNumAndMode (msNum sdu) (msDir sdu))
+       <> Bld.word16BE (fromIntegral (BL.length (msBlob sdu)))
 
     putNumAndMode :: MiniProtocolNum -> MiniProtocolDir -> Word16
     putNumAndMode (MiniProtocolNum n) InitiatorDir = n
@@ -52,31 +55,34 @@ encodeSDU sdu =
 -- | Decode a 'MuSDU' header.  A left inverse of 'encodeSDU'.
 --
 decodeSDU :: BL.ByteString -> Either Error SDU
-decodeSDU buf =
-    case Bin.runGetOrFail dec buf of
-         Left  (_, _, e)  -> Left $ SDUDecodeError e
-         Right (_, _, h) ->
-           if mhLength h > 0
-             then
-               Right $ SDU {
-                     msHeader = h
-                   , msBlob   = BL.empty
-                   }
-             else Left $ SDUDecodeError "short SDU"
+decodeSDU buf
+    | BL.length buf < msHeaderLength
+    = Left $ SDUDecodeError "not enough bytes"
+    | mhLength > 0
+    = Right $ SDU {
+          msHeader = SDUHeader {
+              mhTimestamp,
+              mhNum,
+              mhDir,
+              mhLength
+            }
+        , msBlob   = BL.empty
+        }
+    | otherwise
+    = Left $ SDUDecodeError "short SDU"
   where
-    dec = do
-        mhTimestamp <- RemoteClockModel <$> Bin.getWord32be
-        a <- Bin.getWord16be
-        mhLength <- Bin.getWord16be
-        let mhDir  = getDir a
-            mhNum  = MiniProtocolNum (a .&. 0x7fff)
-        return $ SDUHeader {
-            mhTimestamp,
-            mhNum,
-            mhDir,
-            mhLength
-          }
+    hdr = BL.toStrict $ BL.take msHeaderLength buf
 
-    getDir mid =
-        if mid .&. 0x8000 == 0 then InitiatorDir
-                               else ResponderDir
+    byte :: Int -> Word32
+    byte i = fromIntegral $ BS.index hdr i
+
+    mhTimestamp = RemoteClockModel $
+                      byte 0 `shiftL` 24
+                  .|. byte 1 `shiftL` 16
+                  .|. byte 2 `shiftL`  8
+                  .|. byte 3
+    a           = fromIntegral $ byte 4 `shiftL` 8 .|. byte 5 :: Word16
+    mhLength    = fromIntegral $ byte 6 `shiftL` 8 .|. byte 7
+    mhNum       = MiniProtocolNum $ a .&. 0x7fff
+    mhDir       = if a .&. 0x8000 == 0 then InitiatorDir
+                                       else ResponderDir

--- a/network-mux/test/Test/Mux.hs
+++ b/network-mux/test/Test/Mux.hs
@@ -111,6 +111,7 @@ tests =
   , testProperty "trailing bytes (IO)"          prop_mux_trailing_bytes_io
   , testProperty "pure exception (Sim)"         prop_mux_pure_exception_iosim
   , testProperty "pure exception (IO)"          prop_mux_pure_exception_io
+  , testProperty "sdu codec"                    prop_sdu_codec
   , testGroup "Generators"
     [ testProperty "genByteString"              prop_arbitrary_genByteString
     , testProperty "genLargeByteString"         prop_arbitrary_genLargeByteString
@@ -1150,6 +1151,71 @@ encodeInvalidMuxSDU sdu =
         Bin.putWord32be $ Mx.unRemoteClockModel $ isTimestamp sdu
         Bin.putWord16be $ isIdAndMode sdu
         Bin.putWord16be $ isLength sdu
+
+-- | An 'Mx.SDU' header for the codec round-trip test: covers both
+-- directions as well as boundary timestamps, mini-protocol numbers and
+-- payload lengths.
+--
+data SDUCodecCase = SDUCodecCase Word32 Word16 Mx.MiniProtocolDir Word16
+  deriving Show
+
+instance Arbitrary SDUCodecCase where
+    arbitrary =
+        SDUCodecCase
+          <$> boundary [0, maxBound]                  -- timestamp
+          <*> ((.&. 0x7fff) <$> boundary [0, 0x7fff]) -- mini-protocol number
+          <*> elements [Mx.InitiatorDir, Mx.ResponderDir]
+          <*> boundary [0, 1, maxBound]               -- payload length
+      where
+        boundary :: Arbitrary a => [a] -> Gen a
+        boundary xs = frequency ([(1, pure x) | x <- xs] ++ [(3, arbitrary)])
+
+-- | Wire format and round-trip check of 'Mx.encodeSDU' / 'Mx.decodeSDU'.
+--
+-- The encoding must be byte identical to a reference 'Bin.runPut' based
+-- encoder (the previous implementation of 'Mx.encodeSDU') and
+-- 'Mx.decodeSDU' must recover the header exactly.  Note that
+-- 'Mx.decodeSDU' rejects zero length SDUs and truncated headers.
+--
+prop_sdu_codec :: SDUCodecCase -> Property
+prop_sdu_codec (SDUCodecCase ts num dir len) =
+         counterexample "wire format differs from reference encoder"
+           (encoded === reference)
+    .&&. forAll (choose (0, Mx.msHeaderLength - 1)) (\k ->
+           counterexample ("truncated header of length " ++ show k ++ " not rejected") $
+             case Mx.decodeSDU (BL.take k encoded) of
+               Left (Mx.SDUDecodeError _) -> True
+               _                          -> False)
+    .&&. case Mx.decodeSDU encoded of
+           Left (Mx.SDUDecodeError e) ->
+             counterexample ("unexpected decode error: " ++ e) (len === 0)
+           Left e ->
+             counterexample ("unexpected error: " ++ show e) False
+           Right sdu' ->
+                  len =/= 0
+             .&&. Mx.unRemoteClockModel (Mx.msTimestamp sdu') === ts
+             .&&. Mx.msNum sdu'    === Mx.MiniProtocolNum num
+             .&&. Mx.msDir sdu'    === dir
+             .&&. Mx.msLength sdu' === len
+  where
+    blob = BL.replicate (fromIntegral len) 0xa5
+    sdu  = Mx.SDU {
+        Mx.msHeader = Mx.SDUHeader {
+            Mx.mhTimestamp = Mx.RemoteClockModel ts,
+            Mx.mhNum       = Mx.MiniProtocolNum num,
+            Mx.mhDir       = dir,
+            Mx.mhLength    = len
+          },
+        Mx.msBlob = blob
+      }
+    encoded   = Mx.encodeSDU sdu
+    reference = Bin.runPut refPut `BL.append` blob
+    refPut = do
+        Bin.putWord32be ts
+        Bin.putWord16be $ case dir of
+                            Mx.InitiatorDir -> num
+                            Mx.ResponderDir -> num .|. 0x8000
+        Bin.putWord16be len
 
 -- | Verify ingress processing of valid and invalid SDUs.
 --


### PR DESCRIPTION
# Description

Improved encoding and decoding of the mux header.

Benchmark improvements:

```
Codec micro-benchmarks (per call):

  ┌────────────────────┬─────────────────────────┬─────────────────────────┐
  │     Benchmark      │          Time           │        Allocated        │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ encodeSDU 12288 B  │ 136 ns → 37 ns (−73%)   │ 4,839 B → 383 B (−92%)  │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ encodeSDU 10 B     │ 131 ns → 34 ns (−74%)   │ 4,839 B → 383 B (−92%)  │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ encodeSDU 10×12288 │ 1.39 μs → 419 ns (−70%) │ 49.0 KB → 4.4 KB (−91%) │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ decodeSDU 12288 B  │ 63 ns → 22 ns (−65%)    │ 792 B → 240 B (−70%)    │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ decodeSDU 10 B     │ 62 ns → 22 ns (−65%)    │ 792 B → 240 B (−70%)    │
  ├────────────────────┼─────────────────────────┼─────────────────────────┤
  │ decodeSDU 10×12288 │ 677 ns → 268 ns (−60%)  │ 8.5 KB → 3.0 KB (−65%)  │
  └────────────────────┴─────────────────────────┴─────────────────────────┘

  Socket benchmarks (100,000 SDUs per iteration; client and server in-process,
  so both encode and decode sides count):

  ┌──────────────────────────┬────────────────────────┬───────────────────────┐
  │        Benchmark         │          Time          │       Allocated       │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write 12288 B       │ 364 → 337 ms (−7%)     │ 2.09 → 1.59 GB (−24%) │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write 914 B         │ 137 → 109 ms (−21%)    │ 876 → 375 MB (−57%)   │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write 10 B          │ 121 → 81 ms (−33%)     │ 784 → 284 MB (−64%)   │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write-Many 12288 B  │ 363 → 295 ms (−19%)    │ 2.10 → 1.60 GB (−24%) │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write-Many 914 B    │ 104 → 70 ms (−33%)     │ 862 → 362 MB (−58%)   │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Read/Write-Many 10 B     │ 68 → 45 ms (−34%)      │ 771 → 270 MB (−65%)   │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Mux 800+10 B, 1ms poll   │ 680 → 682 ms (noise)   │ 2.63 → 2.59 GB (−1%)  │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Mux 12288+10 B, 1ms poll │ 7.01 → 6.71 s (noise¹) │ 3.08 → 2.55 GB (−17%) │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Mux 800+10 B, 0ms poll   │ 403 → 372 ms (−8%¹)    │ 2.62 → 2.59 GB (−1%)  │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Mux 12288+10 B, 0ms poll │ 3.21 → 2.53 s (−21%)   │ 3.06 → 2.54 GB (−17%) │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Demuxer Queuing 10 B     │ 248 → 217 ms (−13%)    │ 932 → 431 MB (−54%)   │
  ├──────────────────────────┼────────────────────────┼───────────────────────┤
  │ Demuxer Queuing 256 B    │ 301 → 239 ms (−21%)    │ 987 → 486 MB (−51%)   │
  └──────────────────────────┴────────────────────────┴───────────────────────┘
  ```
  
A/B testing with [cardano-ignite](https://github.com/cardano-foundation/cardano-ignite/) showed that these changes  caused load to switch from the unpatched to patched nodes. The patched nodes ended up having 10% more hot nodes, and serving 10% more blocks while having the same CPU load and allocation rates.


# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
