### PR TITLE
Optional JobPool Completion Queues

### DIFF
--- a/cardano-diffusion/cardano-diffusion.cabal
+++ b/cardano-diffusion/cardano-diffusion.cabal
@@ -18,7 +18,7 @@ extra-doc-files: CHANGELOG.md
 
 flag asserts
   description: Enable assertions
-  manual: False
+  manual: True
   default: False
 
 flag cddl

--- a/cardano-diffusion/changelog.d/20260817_151002_karl.fb.knutsson_jobpool.md
+++ b/cardano-diffusion/changelog.d/20260817_151002_karl.fb.knutsson_jobpool.md
@@ -1,5 +1,5 @@
-### Breaking
+### Non-Breaking
 
-- Adapt to JobPools with and without completion queues
 - Change cabal assert flag from `manual: False` to `manual: True`
+
 

--- a/network-mux/changelog.d/20260813_172328_karl.fb.knutsson_jobpool.md
+++ b/network-mux/changelog.d/20260813_172328_karl.fb.knutsson_jobpool.md
@@ -1,0 +1,6 @@
+### Breaking
+
+- Create two kinds of JobPools, one with a completion queue and one without
+- Add asserts cabal flag
+
+

--- a/network-mux/network-mux.cabal
+++ b/network-mux/network-mux.cabal
@@ -28,6 +28,11 @@ flag tracetcpinfo
   manual: True
   default: False
 
+flag asserts
+  description: Enable assertions
+  manual: True
+  default: False
+
 common demo-deps
   default-language: Haskell2010
   default-extensions: ImportQualifiedPost
@@ -123,6 +128,9 @@ library
   if impl(ghc >=9.14)
     ghc-options:
       -Wno-pattern-namespace-specifier
+
+  if flag(asserts)
+    ghc-options: -fno-ignore-asserts
 
 test-suite test
   type: exitcode-stdio-1.0

--- a/network-mux/src/Control/Concurrent/JobPool.hs
+++ b/network-mux/src/Control/Concurrent/JobPool.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE BlockArguments      #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE RankNTypes          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeData            #-}
 
 
 -- | This module allows the management of a multiple Async jobs which
@@ -10,8 +14,10 @@
 --
 module Control.Concurrent.JobPool
   ( JobPool
+  , HasQueue (..)
   , Job (..)
   , withJobPool
+  , withJobPool_
   , forkJob
   , forkJobOn
   , readSize
@@ -32,12 +38,25 @@ import Control.Monad.Class.MonadFork (MonadThread (..))
 import Control.Monad.Class.MonadThrow
 
 
+-- | Whether a 'JobPool' was created with a completion queue.  Only a
+-- 'WithQueue' pool can be passed to 'waitForJob'.
+--
+type data HasQueue = WithQueue | WithoutQueue
+
+-- | A completion queue, indexed by whether it exists at all.  Matching on
+-- this GADT is what makes 'waitForJob' total: at index 'WithQueue' the only
+-- constructor is 'CompletionQueue'.
+--
+data CompletionQueue (q :: HasQueue) m a where
+  CompletionQueue   :: !(TQueue m a) -> CompletionQueue WithQueue    m a
+  NoCompletionQueue ::                  CompletionQueue WithoutQueue m a
+
 -- | JobPool allows to submit asynchronous jobs, wait for their completion or
 -- cancel.  Jobs are grouped, each group can be cancelled separately.
 --
-data JobPool group m a = JobPool {
+data JobPool (q :: HasQueue) group m a = JobPool {
        jobsVar         :: !(TVar m (Map (group, ThreadId m) (Async m ()))),
-       completionQueue :: !(TQueue m a)
+       completionQueue :: !(CompletionQueue q m a)
      }
 
 -- | An asynchronous job which belongs to some group and its exception handler.
@@ -50,36 +69,54 @@ data Job group m a =
 
 withJobPool :: forall group m a b.
                (MonadAsync m, MonadThrow m, MonadLabelledSTM m)
-            => (JobPool group m a -> m b) -> m b
+            => (JobPool WithQueue group m a -> m b) -> m b
 withJobPool =
-    bracket create close
+    bracket create closeJobPool
   where
-    create :: m (JobPool group m a)
+    create :: m (JobPool WithQueue group m a)
     create =
       atomically $
         JobPool <$> (newTVar Map.empty >>= \v -> labelTVar v "job-pool" $> v)
-                <*> newTQueue
+                <*> (CompletionQueue <$> newTQueue)
 
-    -- 'bracket' requires that the 'close' callback is uninterruptible.  Note
-    -- also that 'async' library is using 'uninterruptibleClose' in
-    -- 'withAsync' combinator.  This can only deadlock if the threads in
-    -- 'JobPool' got deadlocked so that the asynchronous exception cannot be
-    -- delivered, e.g. deadlock in an ffi call or a tight loop which does not
-    -- allocate (which is not a deadlock per se, but rather a rare unfortunate
-    -- condition).
-    close :: JobPool group m a -> m ()
-    close JobPool{jobsVar} = do
-      jobs <- readTVarIO jobsVar
-      mapM_ uninterruptibleCancel jobs
+-- | Like 'withJobPool', but for a pool whose jobs' results nobody ever
+-- inspects: no 'TQueue' is created, so there is nothing for 'forkJob'\/
+-- 'forkJobOn' to write a finished job's result into, and nothing to
+-- remember to drain.  'waitForJob' does not typecheck against a pool
+-- created this way.
+--
+withJobPool_ :: forall group m a b.
+                (MonadAsync m, MonadThrow m, MonadLabelledSTM m)
+             => (JobPool WithoutQueue group m a -> m b) -> m b
+withJobPool_ =
+    bracket create closeJobPool
+  where
+    create :: m (JobPool WithoutQueue group m a)
+    create =
+      atomically $
+        JobPool <$> (newTVar Map.empty >>= \v -> labelTVar v "job-pool" $> v)
+                <*> pure NoCompletionQueue
+
+-- 'bracket' requires that this callback is uninterruptible.  Note also that
+-- 'async' library is using 'uninterruptibleCancel' in 'withAsync' combinator.
+-- This can only deadlock if the threads in 'JobPool' got deadlocked so that
+-- the asynchronous exception cannot be delivered, e.g. deadlock in an ffi
+-- call or a tight loop which does not allocate (which is not a deadlock per
+-- se, but rather a rare unfortunate condition).
+closeJobPool :: (MonadAsync m, MonadThrow m)
+             => JobPool q group m a -> m ()
+closeJobPool JobPool{jobsVar} = do
+  jobs <- readTVarIO jobsVar
+  mapM_ uninterruptibleCancel jobs
 
 
-forkJob' :: forall group m a.
+forkJob' :: forall q group m a.
             ( MonadAsync m, MonadMask m
             , Ord group
             )
          => (((forall x. m x -> m x) -> m ()) -> m (Async m ()))
          -- ^ how to fork a thread, e.g. `async`, `asyncOn`.
-         -> JobPool group m a
+         -> JobPool q group m a
          -> Job     group m a
          -> m ()
 forkJob' doFork JobPool{jobsVar, completionQueue} (Job action handler group label) =
@@ -88,13 +125,25 @@ forkJob' doFork JobPool{jobsVar, completionQueue} (Job action handler group labe
         tid <- myThreadId
         io tid restore
           `onException`
-          atomically (modifyTVar' jobsVar (Map.delete (group, tid)))
-        atomically (modifyTVar' jobsVar (Map.delete (group, tid)))
+          deregister tid
+        deregister tid
 
       let !tid = asyncThreadId jobAsync
       atomically $ modifyTVar' jobsVar (Map.insert (group, tid) $! jobAsync)
       return ()
   where
+    -- | Remove this job's own @(group, tid)@ entry from 'jobsVar', once it is
+    -- actually there.  This can only block before the parent's insert, which
+    -- is guaranteed to follow, since the parent is masked.
+    --
+    deregister :: ThreadId m -> m ()
+    deregister tid =
+      atomically $ do
+        registered <- Map.member (group, tid) <$> readTVar jobsVar
+        if registered
+          then modifyTVar' jobsVar (Map.delete (group, tid))
+          else retry
+
     notAsyncExceptions :: SomeException -> Maybe SomeException
     notAsyncExceptions e
       | Just (SomeAsyncException _) <- fromException e
@@ -110,17 +159,19 @@ forkJob' doFork JobPool{jobsVar, completionQueue} (Job action handler group labe
       -- the exception handler, see `Network.Mux.miniProtocolJob`.
       !res <- handleJust notAsyncExceptions handler $
               restore action
-      atomically $ writeTQueue completionQueue res
+      case completionQueue of
+        NoCompletionQueue  -> pure ()
+        CompletionQueue cq -> atomically $ writeTQueue cq res
 
 
 
 -- | Fork a `Job` using `async`.
 --
-forkJob :: forall group m a.
+forkJob :: forall q group m a.
            ( MonadAsync m, MonadMask m
            , Ord group
            )
-        => JobPool group m a
+        => JobPool q group m a
         -> Job     group m a
         -> m ()
 forkJob = forkJob' asyncWithUnmask
@@ -128,24 +179,24 @@ forkJob = forkJob' asyncWithUnmask
 
 -- | Fork a `Job` using `asyncOn`.
 --
-forkJobOn :: forall group m a.
+forkJobOn :: forall q group m a.
              ( MonadAsync m, MonadMask m
              , Ord group
              )
           => Int
-          -> JobPool group m a
+          -> JobPool q group m a
           -> Job     group m a
           -> m ()
 forkJobOn cap = forkJob' (asyncOnWithUnmask cap)
 
 
-readSize :: MonadSTM m => JobPool group m a -> STM m Int
+readSize :: MonadSTM m => JobPool q group m a -> STM m Int
 readSize JobPool{jobsVar} = Map.size <$> readTVar jobsVar
 
 readGroupSize :: ( MonadSTM m
                  , Eq group
                  )
-              => JobPool group m a -> group -> STM m Int
+              => JobPool q group m a -> group -> STM m Int
 readGroupSize JobPool{jobsVar} group =
       Map.size
     . Map.filterWithKey (\(group', _) _ -> group' == group)
@@ -154,15 +205,15 @@ readGroupSize JobPool{jobsVar} group =
 -- | Wait for next successfully completed job.  Unlike 'wait' it will not throw
 -- if a job errors.
 --
-waitForJob :: MonadSTM m => JobPool group m a -> STM m a
-waitForJob JobPool{completionQueue} = readTQueue completionQueue
+waitForJob :: MonadSTM m => JobPool WithQueue group m a -> STM m a
+waitForJob JobPool{completionQueue = CompletionQueue cq} = readTQueue cq
 
 -- | Cancel all threads in a given group.  Blocks until all threads terminated.
 --
 cancelGroup :: ( MonadAsync m
                , Eq group
                )
-            => JobPool group m a -> group -> m ()
+            => JobPool q group m a -> group -> m ()
 cancelGroup JobPool { jobsVar } group = do
     jobs <- readTVarIO jobsVar
     void $ Map.traverseWithKey

--- a/network-mux/src/Network/Mux.hs
+++ b/network-mux/src/Network/Mux.hs
@@ -410,7 +410,7 @@ monitor :: forall mode m.
            )
         => Tracers m
         -> TimeoutFn m
-        -> JobPool.JobPool Group m JobResult
+        -> JobPool.JobPool JobPool.WithQueue Group m JobResult
         -> EgressQueue m
         -> StrictTQueue m (ControlCmd mode m)
         -> StrictTVar m Status

--- a/ouroboros-network/changelog.d/20260814_085030_karl.fb.knutsson_jobpool.md
+++ b/ouroboros-network/changelog.d/20260814_085030_karl.fb.knutsson_jobpool.md
@@ -1,0 +1,4 @@
+### Breaking
+
+- Adapt to JobPools with and without completion queues
+

--- a/ouroboros-network/framework/lib/Ouroboros/Network/Server/Simple.hs
+++ b/ouroboros-network/framework/lib/Ouroboros/Network/Server/Simple.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -79,7 +80,7 @@ with :: forall fd addr vNumber vData m a b.
      -- server accept loop
      -> m a
 with sn tracer muxTracers makeBearer configureSock addr handshakeArgs versions k =
-   JobPool.withJobPool $ \jobPool ->
+   JobPool.withJobPool_ $ \jobPool ->
    bracket
      (do sd <- Snocket.open sn (Snocket.addrFamily sn addr)
          configureSock sd addr
@@ -94,7 +95,7 @@ with sn tracer muxTracers makeBearer configureSock addr handshakeArgs versions k
                  (k localAddress)
      )
   where
-    acceptLoop :: JobPool.JobPool () m ()
+    acceptLoop :: JobPool.JobPool JobPool.WithoutQueue () m ()
                -> addr
                -> Snocket.Accept m fd addr
                -> m Void

--- a/ouroboros-network/framework/sim-tests/Test/Ouroboros/Network/Server/Sim.hs
+++ b/ouroboros-network/framework/sim-tests/Test/Ouroboros/Network/Server/Sim.hs
@@ -669,7 +669,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
                     muxTracers stdGen0 snocket makeBearer addrFamily serverAddr accInit
                     dataFlow0 acceptedConnLimit
                     (MultiNodeScript script _) =
-  withJobPool $ \jobpool -> do
+  withJobPool_ $ \jobpool -> do
   stdGenVar <- newTVarIO stdGen0
   connStateIdSupply <- atomically $ CM.newConnStateIdSupply (Proxy @m)
   cc <- startServerConnectionHandler stdGenVar connStateIdSupply MainServer dataFlow0 [accInit] serverAddr jobpool
@@ -681,7 +681,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
          -> Map.Map peerAddr acc
          -> Map.Map peerAddr (StrictTQueue m (ConnectionHandlerMessage peerAddr req))
          -> [ConnectionEvent req peerAddr]
-         -> JobPool () m ()
+         -> JobPool WithoutQueue () m ()
          -> m ()
     loop _ _ _ _ [] _ = threadDelay 3600
     loop stdGenVar connStateIdSupply nodeAccs servers (event : events) jobpool =
@@ -753,7 +753,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
                                  -> CM.ConnStateIdSupply m
                                  -> Name peerAddr
                                  -> peerAddr
-                                 -> JobPool () m ()
+                                 -> JobPool WithoutQueue () m ()
                                  -> m (StrictTQueue m (ConnectionHandlerMessage peerAddr req))
     startClientConnectionHandler stdGenVar connStateIdSupply name localAddr jobpool  = do
         cc <- atomically newTQueue
@@ -784,7 +784,7 @@ multinodeExperiment inboundTrTracer trTracer inboundTracer debugTracer cmTracer
                                  -> DataFlow
                                  -> acc
                                  -> peerAddr
-                                 -> JobPool () m ()
+                                 -> JobPool WithoutQueue () m ()
                                  -> m (StrictTQueue m (ConnectionHandlerMessage peerAddr req))
     startServerConnectionHandler stdGenVar connStateIdSupply name dataFlow serverAcc localAddr jobpool = do
         fd <- Snocket.open snocket addrFamily

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns        #-}
 {-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE NamedFieldPuns      #-}
@@ -55,7 +56,7 @@ import Data.Void (Void)
 
 import Control.Applicative (Alternative ((<|>)))
 import Control.Concurrent.Class.MonadSTM.Strict
-import Control.Concurrent.JobPool (JobPool)
+import Control.Concurrent.JobPool (HasQueue (..), JobPool)
 import Control.Concurrent.JobPool qualified as JobPool
 import Control.Exception (SomeAsyncException (..))
 import Control.Monad.Class.MonadAsync
@@ -535,7 +536,7 @@ peerSelectionGovernorLoop :: forall m extraState extraDebugState extraFlags extr
                           -> PeerSelectionInterfaces
                               extraState extraFlags extraPeers
                               peeraddr peerconn m
-                          -> JobPool () m (Completion m extraState extraDebugState extraFlags extraPeers peeraddr peerconn)
+                          -> JobPool WithQueue () m (Completion m extraState extraDebugState extraFlags extraPeers peeraddr peerconn)
                           -> PeerSelectionState extraState extraFlags extraPeers peeraddr peerconn
                           -> m Void
 peerSelectionGovernorLoop tracer

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/Governor/Monitor.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE NamedFieldPuns      #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -23,7 +24,7 @@ import Data.Maybe (fromMaybe, isJust)
 import Data.Set (Set)
 import Data.Set qualified as Set
 
-import Control.Concurrent.JobPool (JobPool)
+import Control.Concurrent.JobPool (HasQueue (..), JobPool)
 import Control.Concurrent.JobPool qualified as JobPool
 import Control.Exception (assert)
 import Control.Monad.Class.MonadSTM
@@ -97,7 +98,7 @@ targetPeers PeerSelectionActions{ readPeerSelectionTargets,
 -- | Await for the first result from 'JobPool' and return its 'Decision'.
 --
 jobs :: MonadSTM m
-     => JobPool () m (Completion m extraState extraDebugState extraFlags extraPeers peeraddr peerconn)
+     => JobPool WithQueue () m (Completion m extraState extraDebugState extraFlags extraPeers peeraddr peerconn)
      -> PeerSelectionState extraState extraFlags extraPeers peeraddr peerconn
      -> Guarded (STM m) (TimedDecision m extraState extraDebugState extraFlags extraPeers peeraddr peerconn)
 jobs jobPool st =

--- a/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
+++ b/ouroboros-network/lib/Ouroboros/Network/PeerSelection/PeerStateActions.hs
@@ -45,7 +45,7 @@ import Control.Monad.Class.MonadThrow
 import Control.Monad.Class.MonadTime.SI
 import Control.Monad.Class.MonadTimer.SI
 
-import Control.Concurrent.JobPool (Job (..), JobPool)
+import Control.Concurrent.JobPool (HasQueue (..), Job (..), JobPool)
 import Control.Concurrent.JobPool qualified as JobPool
 import Control.Tracer (Tracer, traceWith)
 
@@ -627,7 +627,7 @@ withPeerStateActions PeerStateActionsArguments {
                        spsMainThreadId
                      }
                      k =
-    JobPool.withJobPool $ \jobPool ->
+    JobPool.withJobPool_ $ \jobPool ->
       k PeerStateActions {
           establishPeerConnection = establishPeerConnection jobPool,
           monitorPeerConnection,
@@ -774,7 +774,7 @@ withPeerStateActions PeerStateActionsArguments {
             tracePeerHotDuration pch >>
             traceWith spsTracer (PeerStatusChanged (CoolingToCold pchConnectionId))
 
-    establishPeerConnection :: JobPool () m (Maybe SomeException)
+    establishPeerConnection :: JobPool WithoutQueue () m (Maybe SomeException)
                             -> IsBigLedgerPeer
                             -> DiffusionMode
                             -> Provenance

--- a/ouroboros-network/ouroboros-network.cabal
+++ b/ouroboros-network/ouroboros-network.cabal
@@ -17,7 +17,7 @@ extra-doc-files: CHANGELOG.md
 
 flag asserts
   description: Enable assertions
-  manual: False
+  manual: True
   default: False
 
 flag ipv6


### PR DESCRIPTION
# Description

Some users of the JobPool left it undrained. This makes the the queue optional.

# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [x] Added labels.
* [x] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
