### PR TITLE
ping: improved output

### DIFF
--- a/cardano-diffusion/changelog.d/20260825_143837_coot_cardano_ping.md
+++ b/cardano-diffusion/changelog.d/20260825_143837_coot_cardano_ping.md
@@ -1,0 +1,29 @@
+<!--
+A new scriv changelog fragment.
+
+Uncomment the section that is right (remove the HTML comment wrapper).
+For top level release notes, leave all the headers commented out.
+-->
+
+<!--
+### Breaking
+
+- A bullet item for the Breaking category.
+
+-->
+### Non-Breaking
+
+- Improved `cardano-diffusion:ping` output:
+  * don't report results, if there were none
+  * changed `DNSError` show instance:  it's easier to read if the error is
+    followed by dns name, especially if there are multiple errors of the
+    same type, like `NameError`.
+  * when resolving an SRV record fails show the effective domain name, e.g.
+    `_cardano._tcp.domain.com` rather than `domain.com`.
+
+<!--
+### Patch
+
+- A bullet item for the Patch category.
+
+-->

--- a/cardano-diffusion/ping/Cardano/Network/Ping.hs
+++ b/cardano-diffusion/ping/Cardano/Network/Ping.hs
@@ -415,7 +415,7 @@ instance Exception AddressResolutionError where
   displayException (NoPortNumberError addr)
     = "missing port number for " ++ ppSomeAddress addr
   displayException (DNSError addr err)
-    = ppSomeAddress addr ++ ": " ++ displayException err
+    = displayException err ++ " for " ++ ppSomeAddress addr
 
 -- | Log messages to stderr.
 --
@@ -912,14 +912,14 @@ resolveAddress
        -> IO ([Address Resolved], [AddressResolutionError])
 
     -- 1. Resolve an SRV record
-    go addr@(SRV dns) = do
+    go (SRV dns) = do
       let hostname = BS.Char.pack $ case srvPrefix of
                                       [] -> dns
                                       _  -> srvPrefix ++ "." ++ dns
       r <- DNS.lookupRaw resolver hostname DNS.SRV
       case r >>= flip DNS.fromDNSMessage selectSRV of
         Left err -> do
-          let err' = DNSError (SomeAddress addr) err
+          let err' = DNSError (SomeAddress (SRV $ BS.Char.unpack hostname)) err
           traceWith stderr (AddressResolutionError err')
           case acceptFilePath of
             AddressMightBeAFilePath ->
@@ -978,7 +978,7 @@ resolveAddress
         (ips, errs) -> do
           let errs' = [ DNSError (SomeAddress addr) err | err <- errs ]
           traverse_ (traceWith stderr . AddressResolutionError) errs'
-          unless pingOptsQuiet $
+          unless (pingOptsQuiet || null ips) $
             traceWith stderr $ DNSResolution hostname ips port
           return ( [ IP ip port | ip <- ips ]
                  , errs'


### PR DESCRIPTION
* don't report resolutions, if there was no result
* change `DNSError` show instance.  It's easier to read if the error is
  followed by dns name, especially if there are multiple errors of the
  same type, like `NameError`).
