### PR TITLE
smol-world changes

### DIFF
--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -411,21 +411,32 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
                     rtoBase = rttBase * (1 + 4 * rttVar)
                     rto = min (tpRtoMaxS tp)
                               (max (tpRtoMinS tp) rtoBase * 2 ^ min (fsConsecTO fsB) (30 :: Int))
-                    fs' = (rtoCollapse tp (fromIntegral effCwnd) fsB) { fsConsecTO = fsConsecTO fsB + 1 }
+                    -- did this round put anything on the wire?  If so its originals are
+                    -- Karn-legal (RFC 6298 §3) and the sample collapses the backoff; if
+                    -- not, the backoff compounds (§5.5).  Covers both RTO channels: a
+                    -- GE-RTO delivers its pre-loss prefix, an oversub RTO the whole bin.
+                    fs' | fsBytesSent fsB > flRoundB0 f
+                        = onDelivery rtt (rtoCollapse tp (fromIntegral effCwnd) fsB)
+                        | otherwise
+                        = (rtoCollapse tp (fromIntegral effCwnd) fsB)
+                            { fsConsecTO = fsConsecTO fsB + 1 }
                 in (fs', False, t + rto, t + rto, r1)           -- HOL: no delivery/egress until stall ends
             | lossNow =                                         -- recoverable loss ⇒ fast-retransmit / SACK fast-recovery: graceful cut
-                -- data delivered ⇒ fresh RTT samples ⇒ RTO backoff clears (fresh RTT sample recomputes RTO, RFC 6298 §2.2/2.3 + Karn)
-                ((onCongestionEvent tp Loss (fromIntegral effCwnd) fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
+                -- fast recovery acks at least three originals by construction, so the round
+                -- always yields a Karn-legal sample, which also clears the backoff (§3 and
+                -- the note after §5.7)
+                (onDelivery rtt (onCongestionEvent tp Loss (fromIntegral effCwnd) fsB), False, flNext f + rtt, flReady f, r1)
             | reorder && dupAckable =                           -- reordering ⇒ spurious fast-retransmit
                 -- a spurious fast retransmit needs the same three dup-ACKs; below that the
-                -- reordered packet simply arrives late and nothing fires (not a timeout)
-                ((onCongestionEvent tp Loss (fromIntegral effCwnd) fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
+                -- reordered packet simply arrives late and nothing fires (not a timeout).
+                -- The round was in fact clean, so it samples like one.
+                (onDelivery rtt (onCongestionEvent tp Loss (fromIntegral effCwnd) fsB), False, flNext f + rtt, flReady f, r1)
             | otherwise =                                       -- clean round: grow, reset RTO backoff
                 -- `attempt`, not effCwnd: §4.3 Figure 4 credits W_est by
                 -- alpha_cubic * segments_acked / cwnd, and a share-throttled round puts
                 -- fewer than cwnd segments on the wire
                 let grown = growOnAck tp rtt (fromIntegral attempt) fsB  -- advances t - t_epoch itself (§4.2)
-                in (grown { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
+                in (onDelivery rtt grown, False, flNext f + rtt, flReady f, r1)
           rb0'       = if boundary then fsBytesSent fs2 else flRoundB0 f  -- next round starts at this round's delivered total
       in if fsBytesSent fs2 >= tpFileBytes tp
            then if flPhase f == Body

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -407,10 +407,13 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
           (fs2, loss2, next2, ready2, round2)
             | not boundary = (fsB, lossNow, flNext f, flReady f, flRound f)
             | lossNow && rtoNow =                               -- RTO: oversub OR a ≥2-loss/tail burst; backed-off stall + HOL + restart
-                let rttVar = max 0.25 (dpJitter dp)             -- jitter inflates RTTVAR ⇒ larger RTO
-                    rtoBase = rttBase * (1 + 4 * rttVar)
-                    rto = min (tpRtoMaxS tp)
-                              (max (tpRtoMinS tp) rtoBase * 2 ^ min (fsConsecTO fsB) (30 :: Int))
+                -- RFC 6298 §2/§5.5, shared with stepRound.  `fsRttEst fsB` is the
+                -- estimator from before this round's sample -- that is what armed the
+                -- timer that just expired.  This replaces a nominal RTTVAR derived from
+                -- the `--jitter` knob: the estimator now measures the variance of the
+                -- per-round RTTs the DES actually draws, so the timer responds to real
+                -- jitter rather than to its configured bound.
+                let rto = rtoAfter tp (fsRttEst fsB) (fsConsecTO fsB)
                     -- did this round put anything on the wire?  If so its originals are
                     -- Karn-legal (RFC 6298 §3) and the sample collapses the backoff; if
                     -- not, the backoff compounds (§5.5).  Covers both RTO channels: a

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -413,7 +413,7 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
                 -- the `--jitter` knob: the estimator now measures the variance of the
                 -- per-round RTTs the DES actually draws, so the timer responds to real
                 -- jitter rather than to its configured bound.
-                let rto = rtoAfter tp (fsRttEst fsB) (fsConsecTO fsB)
+                let rto = rtoAfter tp fsB
                     -- did this round put anything on the wire?  If so its originals are
                     -- Karn-legal (RFC 6298 §3) and the sample collapses the backoff; if
                     -- not, the backoff compounds (§5.5).  Covers both RTO channels: a

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -279,9 +279,7 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
           startFlow u =
             let (v, rtt, tier, _) = minimumBy (comparing (\(_, _, _, a) -> a)) (announces u) -- first announcer
                 tpB = mkTcpParams bodyB rtt 0 (egressOf v)
-                fs0 | warm v    = (initFlow tpB) { fsCwnd = tpSsthresh0 tpB
-                                                 , fsPhase = CA
-                                                 , fsWMax = tpSsthresh0 tpB }  -- Finding 5: prime the CUBIC epoch from ssthresh (mirror the SS->CA clamp); else a warm flow regrows from origin 0, slower than cold
+                fs0 | warm v    = warmFlow tpB   -- already-ramped; epoch built by enterCA
                     | otherwise = initFlow tpB
             in Flow tpB Body v fs0 rtt (t + 2 * rtt) False (t + rtt) 0 tier False 0  -- body req: flReady = 1 RTT to first byte; flNext = grow at the NEXT boundary, not this one (Finding 4)
           fetch1 = Foldable.foldl' (\m u -> IM.insert u (startFlow u) m) fetch startable
@@ -376,8 +374,16 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
           geLoss     = not geClean
           geRTO      = uLoss >= cutThresh                     -- past the recoverable band ⇒ timeout
           oversubRTO = windowRate > share * dpRtoThresh dp
+          -- RFC 5681 §3.2: a fast retransmit needs three dup-ACKs, so a loss in a window of
+          -- fewer than four packets cannot be recovered without a timeout.  The GE channel
+          -- already encodes this analytically (with a3 = 0 both pRecov and pFastRtx vanish,
+          -- so every GE loss becomes a geRTO); the oversub and carried (flLoss) channels did
+          -- not.  Gating all of them keeps onCongestionEvent to windows where a real sender
+          -- could fast-retransmit — the precondition RFC 9438 §4.6 Figure 5 relies on when it
+          -- floors cwnd at 2 SMSS with no guard of its own.
+          dupAckable = a3 > 0                                 -- attempt >= 4
           lossNow    = flLoss f || oversub || geLoss
-          rtoNow     = oversubRTO || geRTO
+          rtoNow     = oversubRTO || geRTO || not dupAckable
           -- Final-window fast-retransmit: a recoverable (non-RTO) loss in the LAST window
           -- has no following data to overlap the retransmit, so the in-order prefix closes
           -- only ~1 RTT on (the fill lands next round).  Mid-transfer that RTT is absorbed
@@ -405,17 +411,17 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
                     rtoBase = rttBase * (1 + 4 * rttVar)
                     rto = min (tpRtoMaxS tp)
                               (max (tpRtoMinS tp) rtoBase * 2 ^ min (fsConsecTO fsB) (30 :: Int))
-                    fs' = (rtoCollapse effCwnd fsB) { fsConsecTO = fsConsecTO fsB + 1 }
+                    fs' = (rtoCollapse tp (fromIntegral effCwnd) fsB) { fsConsecTO = fsConsecTO fsB + 1 }
                 in (fs', False, t + rto, t + rto, r1)           -- HOL: no delivery/egress until stall ends
             | lossNow =                                         -- recoverable loss ⇒ fast-retransmit / SACK fast-recovery: graceful cut
                 -- data delivered ⇒ fresh RTT samples ⇒ RTO backoff clears (fresh RTT sample recomputes RTO, RFC 6298 §2.2/2.3 + Karn)
-                ((cutOnLoss tp effCwnd fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
-            | reorder =                                         -- reordering ⇒ spurious fast-retransmit
-                ((cutOnLoss tp effCwnd fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
+                ((onCongestionEvent tp Loss (fromIntegral effCwnd) fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
+            | reorder && dupAckable =                           -- reordering ⇒ spurious fast-retransmit
+                -- a spurious fast retransmit needs the same three dup-ACKs; below that the
+                -- reordered packet simply arrives late and nothing fires (not a timeout)
+                ((onCongestionEvent tp Loss (fromIntegral effCwnd) fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
             | otherwise =                                       -- clean round: grow, reset RTO backoff
-                let grown = growOnAck tp (if fsPhase fsB == CA
-                                            then fsB { fsCaElapsed = fsCaElapsed fsB + rtt }
-                                            else fsB)
+                let grown = growOnAck tp rtt fsB   -- advances t - t_epoch itself (§4.2)
                 in (grown { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
           rb0'       = if boundary then fsBytesSent fs2 else flRoundB0 f  -- next round starts at this round's delivered total
       in if fsBytesSent fs2 >= tpFileBytes tp

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -278,8 +278,9 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
           startFlow u =
             let (v, rtt, tier, _) = minimumBy (comparing (\(_, _, _, a) -> a)) (announces u) -- first announcer
                 tpB = mkTcpParams bodyB rtt 0 (egressOf v)
-                fs0 | warm v    = (initFlow tpB) { fsCwnd = tpSsthresh0 tpB, fsPhase = CA
-                                                 , fsWMax = tpSsthresh0 tpB, fsCubicOrigin = tpSsthresh0 tpB }  -- Finding 5: prime the CUBIC epoch from ssthresh (mirror the SS->CA clamp); else a warm flow regrows from origin 0, slower than cold
+                fs0 | warm v    = (initFlow tpB) { fsCwnd = tpSsthresh0 tpB
+                                                 , fsPhase = CA
+                                                 , fsWMax = tpSsthresh0 tpB }  -- Finding 5: prime the CUBIC epoch from ssthresh (mirror the SS->CA clamp); else a warm flow regrows from origin 0, slower than cold
                     | otherwise = initFlow tpB
             in Flow tpB Body v fs0 rtt (t + 2 * rtt) False (t + rtt) 0 tier False 0  -- body req: flReady = 1 RTT to first byte; flNext = grow at the NEXT boundary, not this one (Finding 4)
           fetch1 = foldl' (\m u -> IM.insert u (startFlow u) m) fetch startable

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -39,7 +39,8 @@ module SmallWorld.Diffusion
   , simulateBattle
   ) where
 
-import           Data.List          (foldl', minimumBy, sortBy)
+import           Data.List          (minimumBy, sortBy)
+import qualified Data.Foldable as Foldable
 import           Data.Ord           (comparing, Down(..))
 import qualified Data.IntMap.Strict as IM
 import qualified Data.IntSet        as IS
@@ -283,14 +284,14 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
                                                  , fsWMax = tpSsthresh0 tpB }  -- Finding 5: prime the CUBIC epoch from ssthresh (mirror the SS->CA clamp); else a warm flow regrows from origin 0, slower than cold
                     | otherwise = initFlow tpB
             in Flow tpB Body v fs0 rtt (t + 2 * rtt) False (t + rtt) 0 tier False 0  -- body req: flReady = 1 RTT to first byte; flNext = grow at the NEXT boundary, not this one (Finding 4)
-          fetch1 = foldl' (\m u -> IM.insert u (startFlow u) m) fetch startable
+          fetch1 = Foldable.foldl' (\m u -> IM.insert u (startFlow u) m) fetch startable
           -- only actively-transmitting flows consume egress: a flow waiting on a
           -- request RTT or stalled in an RTO backoff (flReady > t) sends nothing,
           -- so it must not dilute the hub's egress share
           load  = IM.fromListWith (+) [ (flSrc f, 1 :: Int) | f <- IM.elems fetch1, flReady f <= t ]
           shareOf v = egressOf v / fromIntegral (max 1 (IM.findWithDefault 1 v load))
           (fetch2, done) = IM.foldrWithKey (advance t shareOf) (IM.empty, []) fetch1
-          has1 = foldl' (\m (u, tc) -> IM.insert u tc m) has done
+          has1 = Foldable.foldl' (\m (u, tc) -> IM.insert u tc m) has done
       in (fetch2, has1)
 
     advance t shareOf u f (accF, accDone)

--- a/smol-world/src/SmallWorld/Diffusion.hs
+++ b/smol-world/src/SmallWorld/Diffusion.hs
@@ -421,7 +421,10 @@ diffuseTimesGen dp topo sources closureOf warm egressOf
                 -- reordered packet simply arrives late and nothing fires (not a timeout)
                 ((onCongestionEvent tp Loss (fromIntegral effCwnd) fsB) { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
             | otherwise =                                       -- clean round: grow, reset RTO backoff
-                let grown = growOnAck tp rtt fsB   -- advances t - t_epoch itself (§4.2)
+                -- `attempt`, not effCwnd: §4.3 Figure 4 credits W_est by
+                -- alpha_cubic * segments_acked / cwnd, and a share-throttled round puts
+                -- fewer than cwnd segments on the wire
+                let grown = growOnAck tp rtt (fromIntegral attempt) fsB  -- advances t - t_epoch itself (§4.2)
                 in (grown { fsConsecTO = 0 }, False, flNext f + rtt, flReady f, r1)
           rb0'       = if boundary then fsBytesSent fs2 else flRoundB0 f  -- next round starts at this round's delivered total
       in if fsBytesSent fs2 >= tpFileBytes tp

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -75,7 +75,6 @@ data FlowState = FlowState
   , fsWMax        :: !Double
   , fsLastWMax    :: !Double
   , fsK           :: !Double
-  , fsCubicOrigin :: !Double
   , fsCaElapsed   :: !Double
   , fsBytesSent   :: !Int
   , fsT           :: !Double
@@ -85,7 +84,7 @@ data FlowState = FlowState
 initFlow :: TcpParams -> FlowState
 initFlow tp = FlowState
   { fsCwnd = tpCwnd0 tp, fsSsthresh = tpSsthresh0 tp, fsPhase = SlowStart
-  , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCubicOrigin = 0, fsCaElapsed = 0
+  , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCaElapsed = 0
   , fsBytesSent = 0, fsT = 0, fsConsecTO = 0 }
 
 -- Loss-free round: slow-start doubling to ssthresh, then CUBIC convex regrowth.
@@ -97,10 +96,10 @@ growOnAck tp fs
            then let w = max (fsSsthresh fs) (fsCwnd fs)  -- Finding 8: never shrink on a clean round (post-idleReset ssthresh<cwnd corner); no-op when cwnd<ssthresh
                 in fs { fsCwnd = w, fsWMax = w
                       , fsLastWMax = 0, fsK = 0   -- no prior loss yet; RFC 8312 §4.6 W_last_max starts unset
-                      , fsCubicOrigin = w, fsCaElapsed = 0, fsPhase = CA }
+                      , fsCaElapsed = 0, fsPhase = CA }
            else fs { fsCwnd = c }
   | otherwise =
-      fs { fsCwnd = max 1 (tpCubicC tp * (fsCaElapsed fs - fsK fs) ** 3 + fsCubicOrigin fs) }
+      fs { fsCwnd = max 1 (tpCubicC tp * (fsCaElapsed fs - fsK fs) ** 3 + fsWMax fs) }
 
 -- Graceful fast recovery: CUBIC multiplicative decrease + fresh concave epoch.
 -- fsBytesSent is untouched — a loss costs a cwnd cut + ~1 RTT, not delivered data
@@ -116,7 +115,6 @@ cutOnLoss tp effCwnd fs =
         , fsLastWMax = cwndAtLoss   -- RFC 8312 §4.6: W_last_max = the pre-reduction cwnd-at-loss (may descend)
         , fsCwnd = max 1 (cwndAtLoss * (1 - beta))
         , fsK = (max 0 (wMax - max 1 (cwndAtLoss * (1 - beta))) / tpCubicC tp) ** (1/3)  -- regrow CA from the installed cwnd, not a fast-conv-dipped value (Finding 1; no-op outside the fast-conv corner)
-        , fsCubicOrigin = wMax
         , fsCaElapsed = 0
         , fsPhase = CA }
 
@@ -127,7 +125,7 @@ rtoCollapse :: Int -> FlowState -> FlowState
 rtoCollapse effCwnd fs =
   fs { fsSsthresh = max 2 (fromIntegral effCwnd * 0.7)   -- RFC 8312 §4.7: ssthresh = beta_cubic·cwnd (0.7), not Standard-TCP 0.5
      , fsCwnd = 1, fsPhase = SlowStart
-     , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCubicOrigin = 0, fsCaElapsed = 0 }  -- Finding 11: clear the high-water mark on RTO (Linux bictcp_reset)
+     , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCaElapsed = 0 }  -- Finding 11: clear the high-water mark on RTO (Linux bictcp_reset)
 
 -- | Linux @tcp_slow_start_after_idle@: a connection idle for longer than one RTO
 -- restarts its window at the initial cwnd (back into slow-start), keeping
@@ -145,7 +143,7 @@ idleReset keepsWarm idleGapS tp fs
   | keepsWarm                 = fs
   | idleGapS <= max (tpRtoMinS tp) (tpBaseRtoS tp) = fs   -- within one (floored) RTO: not idle, stays warm (Finding 7 — the RTO the model charges is floored at tpRtoMinS)
   | otherwise                 = fs { fsCwnd = tpCwnd0 tp, fsPhase = SlowStart
-                                   , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCubicOrigin = 0
+                                   , fsWMax = 0, fsLastWMax = 0, fsK = 0
                                    , fsCaElapsed = 0, fsConsecTO = 0 }   -- Finding 11: clear the high-water mark on idle-reset too
 
 -- | Sample losses in a window of @n@ packets at per-packet rate @p@: returns
@@ -225,4 +223,4 @@ flowTimeFrom tp fs0 g0
 -- avoidance, so a WARM transfer skips the cold slow-start penalty.  (Losses still cut it via CUBIC.)
 warmFlow :: TcpParams -> FlowState
 warmFlow tp = (initFlow tp) { fsCwnd = fromIntegral (tpBdpCapSegs tp), fsSsthresh = fromIntegral (tpBdpCapSegs tp)
-                            , fsPhase = CA, fsWMax = fromIntegral (tpBdpCapSegs tp), fsCubicOrigin = fromIntegral (tpBdpCapSegs tp) }
+                            , fsPhase = CA, fsWMax = fromIntegral (tpBdpCapSegs tp) }

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -406,21 +406,14 @@ baseRto tp (RttEst srtt rttVar)  = srtt + max (tpClockG tp) (4 * rttVar)
 -- | The timeout to charge for the @n@-th consecutive expiry: RFC 6298 §5.5's exponential
 -- backoff applied to §2's RTO, with §2.4's floor and §2.5's ceiling.
 --
--- @n@ is the count of *prior* consecutive timeouts, so the first expiry charges the
--- un-doubled RTO -- the timer that just fired was armed (§5.1/§5.2) before §5.5 doubled
--- anything.  The floor goes on *before* the doubling, because §2.4 rounds up whenever the
--- RTO is computed and §5.5 then doubles that result.  For the same reason the estimator
--- passed in must be the one from before this round's sample: that is what armed the timer.
 rtoAfter :: TcpParams
-         -> RttEst
-         -> Int
-         -- ^ prior consecutive timeouts
+         -> FlowState
          -> Double
-rtoAfter tp est n =
+rtoAfter tp FlowState { fsRttEst, fsConsecTO } =
   min (tpRtoMaxS tp) (flooredRto * backoff)
     where
-      flooredRto = max (tpRtoMinS tp) (baseRto tp est)
-      backoff = 2 ^ min n (30 :: Int)
+      flooredRto = max (tpRtoMinS tp) (baseRto tp fsRttEst)
+      backoff = 2 ^ min fsConsecTO (30 :: Int)
 
 -- | Bookkeeping shared by every round that delivered non-retransmitted data.
 --
@@ -570,7 +563,7 @@ stepRound tp rtt lossP fs g =
                   )
       else -- RTO
         let delivered = max 0 (firstLoss - 1)
-            rto       = rtoAfter tp (fsRttEst fs) (fsConsecTO fs)
+            rto       = rtoAfter tp fs
             -- RFC 6298 §3: the packets ahead of the hole are original transmissions, so
             -- they are Karn-legal and §3 requires a measurement where one is possible;
             -- with nothing acked there is no sample and the backoff compounds (§5.5).
@@ -595,20 +588,60 @@ stepRound tp rtt lossP fs g =
         , fsT = fsT f + rtt'
         }
 
+
+-- | RFC 5681 §4.1 "Restarting Idle Connections": a sender that has not *sent* for longer
+-- than the retransmission timeout collapses its window before transmitting again, because
+-- "after an idle period, TCP cannot use the ACK clock to strobe new segments into the
+-- network, as all the ACKs have drained", and "changing network conditions may have
+-- rendered TCP's notion of the available end-to-end network capacity ... inaccurate".
+--
+-- @RW = min(IW, cwnd)@, so this can only ever *reduce* the window: a connection already
+-- below the initial window keeps what it has.
+--
+-- The trigger is "has not *sent*", not "has not received".  §4.1 calls that out
+-- explicitly: a receive-based test "can fail to deflate cwnd in the common case of
+-- persistent HTTP connections", where an inbound request lets the server restart on a
+-- stale window.
+--
+-- ssthresh is deliberately untouched -- §4.1 says nothing about it, and Linux's
+-- 'tcp_cwnd_restart' explicitly preserves it (@snd_ssthresh = tcp_current_ssthresh(sk)@)
+-- -- so the congestion history the last cut recorded survives the idle gap and the
+-- re-ramp stops where it should.  Returning to 'SlowStart' is [Jac88]'s recommendation
+-- quoted by §4.1, and it also drops the CUBIC epoch, which is what RFC 9438 §4.8/§4.10
+-- want: the next slow-start exit re-seeds W_max and K from the window actually reached.
+restartIdle :: TcpParams
+            -> Double
+            -- ^ time since this flow last SENT data
+            -> FlowState
+            -> FlowState
+restartIdle tp idleGapS fs
+  | idleGapS <= rto = fs
+  | otherwise       = fs'
+  where
+    fs' = fs { fsCwnd     = min (tpCwnd0 tp) (fsCwnd fs)   -- RW = min(IW, cwnd)
+             , fsPhase    = SlowStart
+             , fsConsecTO = 0
+             }
+    -- "an interval exceeding the retransmission timeout" -- the current RTO, floored, with
+    -- no backoff applied: an idle connection is not mid-retransmission.
+    rto = rtoAfter tp fs'
+
 -- | Isolated single-flow completion: (download time s, effective loss events).
-flowTime :: RandomGen g => TcpParams -> g -> (Double, Int)
-flowTime tp = flowTimeFrom tp (initFlow tp)
+flowTime :: RandomGen g => TcpParams -> g -> (Int, FlowState)
+flowTime tp = flowTimeFrom tp 0 (initFlow tp)
 
 -- | As 'flowTime' but from an arbitrary initial 'FlowState' -- lets a caller start a
 -- transfer WARM (cwnd already ramped) instead of cold slow-start.
-flowTimeFrom :: RandomGen g => TcpParams -> FlowState -> g -> (Double, Int)
-flowTimeFrom tp fs0 g0
-  | tpFileBytes tp <= 0 = (0, 0)
-  | otherwise           = loop fs0 { fsBytesSent = 0, fsT = 0 } 0 g0 (0 :: Int)
+--
+flowTimeFrom :: RandomGen g => TcpParams -> Double -> FlowState -> g -> (Int, FlowState)
+flowTimeFrom tp idleGapS fs0 g0
+  | tpFileBytes tp <= 0 = (0, fs0)
+  | otherwise           = loop (restartIdle tp idleGapS fs0) { fsBytesSent = 0 }
+                          0 g0 (0 :: Int)
   where
     loop !fs !nLoss !g !rounds
-      | fsBytesSent fs >= tpFileBytes tp = (fsT fs, nLoss)
-      | rounds > 10000000                = (1/0, nLoss)
+      | fsBytesSent fs >= tpFileBytes tp = (nLoss, fs)
+      | rounds > 10000000                = (nLoss, fs { fsT = 1/0 })
       | otherwise =
           let (fs', lossRound, g') = stepRound tp (tpRttS tp) (tpLossP tp) fs g
           in loop fs' (if lossRound then nLoss + 1 else nLoss) g' (rounds + 1)

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -37,6 +37,7 @@ module SmallWorld.TCP
   , rtoCollapse
   , idleReset
   , onDelivery
+  , rtoAfter
     -- * Round drivers
   , growOnAck
   , stepRound
@@ -402,6 +403,25 @@ baseRto :: TcpParams -> RttEst -> Double
 baseRto tp NoSample              = tpInitRtoS tp
 baseRto tp (RttEst srtt rttVar)  = srtt + max (tpClockG tp) (4 * rttVar)
 
+-- | The timeout to charge for the @n@-th consecutive expiry: RFC 6298 §5.5's exponential
+-- backoff applied to §2's RTO, with §2.4's floor and §2.5's ceiling.
+--
+-- @n@ is the count of *prior* consecutive timeouts, so the first expiry charges the
+-- un-doubled RTO -- the timer that just fired was armed (§5.1/§5.2) before §5.5 doubled
+-- anything.  The floor goes on *before* the doubling, because §2.4 rounds up whenever the
+-- RTO is computed and §5.5 then doubles that result.  For the same reason the estimator
+-- passed in must be the one from before this round's sample: that is what armed the timer.
+rtoAfter :: TcpParams
+         -> RttEst
+         -> Int
+         -- ^ prior consecutive timeouts
+         -> Double
+rtoAfter tp est n =
+  min (tpRtoMaxS tp) (flooredRto * backoff)
+    where
+      flooredRto = max (tpRtoMinS tp) (baseRto tp est)
+      backoff = 2 ^ min n (30 :: Int)
+
 -- | Bookkeeping shared by every round that delivered non-retransmitted data.
 --
 -- Such a round yields a Karn-legal RTT sample (RFC 6298 §3), and because a new measurement
@@ -550,8 +570,7 @@ stepRound tp rtt lossP fs g =
                   )
       else -- RTO
         let delivered = max 0 (firstLoss - 1)
-            backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
-            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (baseRto tp (fsRttEst fs)) * fromIntegral backoff)
+            rto       = rtoAfter tp (fsRttEst fs) (fsConsecTO fs)
             -- RFC 6298 §3: the packets ahead of the hole are original transmissions, so
             -- they are Karn-legal and §3 requires a measurement where one is possible;
             -- with nothing acked there is no sample and the backoff compounds (§5.5).

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -18,6 +18,7 @@ module SmallWorld.TCP
   ( -- * RFC 9438 §4.1.2 state
     Epoch(..)
   , Phase(..)
+  , RttEst(..)
   , FlowState(..)
   , TcpParams(..)
   , mkTcpParams
@@ -65,6 +66,15 @@ data Phase =
    -- ^ congestion avoidance phase with internal state
  deriving (Eq, Show)
 
+-- | RFC 6298 §2's retransmission-timer state.  'NoSample' is §2.1 -- before any RTT
+-- measurement has been made -- kept as its own constructor so §2.2's initialisation
+-- cannot be confused with §2.3's update.
+data RttEst = NoSample
+              -- ^ §2.1: no measurement yet
+            | RttEst !Double !Double
+              -- ^ SRTT and RTTVAR, seconds
+  deriving (Eq, Show)
+
 -- | Static per-flow parameters (constant over the transfer).
 data TcpParams = TcpParams
   { tpFileBytes  :: !Int
@@ -78,14 +88,14 @@ data TcpParams = TcpParams
   , tpBetaCubic  :: !Double   -- ^ beta_cubic, the RETAINED fraction (§4.6: SHOULD be 0.7)
   , tpRtoMinS    :: !Double
   , tpRtoMaxS    :: !Double
-  , tpBaseRtoS   :: !Double
+  , tpClockG     :: !Double   -- ^ clock granularity G (§2.2/§2.3's @max(G, K*RTTVAR)@)
+  , tpInitRtoS   :: !Double   -- ^ RTO before any RTT measurement (§2.1: SHOULD be 1 s)
   , tpFastConv   :: !Bool     -- ^ §4.7
   , tpEnableRto  :: !Bool
   } deriving (Show)
 
 -- | Smart constructor: derive the BDP window cap and initial ssthresh from a capacity
--- (bits/s) and RTT (ssthresh at link saturation; base RTO = RTT + 4·RTTVAR with the
--- no-jitter RTTVAR = RTT/4, floored at Linux's TCP_RTO_MIN rather than RFC 6298 §2.4's 1 s).
+-- (bits/s) and RTT (ssthresh at link saturation).
 mkTcpParams :: Int -> Double -> Double -> Double -> TcpParams
 mkTcpParams fileBytes rttS lossP capBps = TcpParams
   { tpFileBytes  = fileBytes
@@ -99,7 +109,8 @@ mkTcpParams fileBytes rttS lossP capBps = TcpParams
   , tpBetaCubic  = 0.7
   , tpRtoMinS    = 0.2
   , tpRtoMaxS    = 120
-  , tpBaseRtoS   = rttS + 4 * (0.25 * rttS)
+  , tpClockG     = 0.001
+  , tpInitRtoS   = 1.0
   , tpFastConv   = True
   , tpEnableRto  = True
   }
@@ -112,6 +123,9 @@ data FlowState = FlowState
   , fsSsthresh  :: !Double   -- ^ ssthresh, segments
   , fsCwndPrior :: !Double   -- ^ cwnd_prior (§4.1.2): cwnd when ssthresh was last set
   , fsPhase     :: !Phase
+  , fsRttEst    :: !RttEst   -- ^ RFC 6298 §2: SRTT/RTTVAR, or NoSample before the first
+                             --   measurement.  Only rounds that deliver non-retransmitted
+                             --   data update it (§3, Karn's algorithm).
   , fsBytesSent :: !Int
   , fsT         :: !Double
   , fsConsecTO  :: !Int
@@ -120,7 +134,8 @@ data FlowState = FlowState
 initFlow :: TcpParams -> FlowState
 initFlow tp = FlowState
   { fsCwnd = tpCwnd0 tp, fsSsthresh = tpSsthresh0 tp, fsCwndPrior = 0
-  , fsPhase = SlowStart, fsBytesSent = 0, fsT = 0, fsConsecTO = 0 }
+  , fsPhase = SlowStart, fsRttEst = NoSample
+  , fsBytesSent = 0, fsT = 0, fsConsecTO = 0 }
 
 -- | A warm flow at (near-)steady cwnd: already ramped to the BDP cap and in congestion
 -- avoidance, so a WARM transfer skips the cold slow-start ramp.  Its epoch is §4.10's
@@ -355,6 +370,37 @@ onCongestionEvent tp ev flightSize fs = fs
         flightSize
 
 
+-- | RFC 6298 §2.2 on the first RTT measurement, §2.3 on every subsequent one.
+--
+-- @
+--   (2.2)  SRTT <- R                 (2.3)  RTTVAR <- (1-beta)*RTTVAR + beta*|SRTT - R'|
+--          RTTVAR <- R/2                    SRTT   <- (1-alpha)*SRTT + alpha*R'
+-- @
+--
+-- with alpha = 1/8 and beta = 1/4.  §2.3 makes the *order* a MUST -- RTTVAR is updated
+-- using the value of SRTT from before SRTT itself is updated -- which holds here because
+-- @rttVar'@ refers to the pattern-bound @srtt@, not to @srtt'@.
+--
+-- Karn's algorithm (§3) forbids sampling a retransmitted segment, so this is called only
+-- from a round that delivered original transmissions: 'stepRound' applies it in 'advance',
+-- which runs on clean and fast-retransmit rounds but not on a timeout.
+sampleRtt :: Double
+          -- ^ the round's measured RTT
+          -> RttEst
+          -> RttEst
+sampleRtt r  NoSample             = RttEst r (r / 2)
+sampleRtt r' (RttEst srtt rttVar) = RttEst srtt' rttVar'
+  where
+    rttVar' = (1 - 0.25)  * rttVar + 0.25  * abs (srtt - r')
+    srtt'   = (1 - 0.125) * srtt   + 0.125 * r'
+
+-- | RFC 6298 @RTO <- SRTT + max(G, K*RTTVAR)@ with K = 4 (§2.2/§2.3), or §2.1's initial
+-- value while no measurement has been taken.  §2.4's floor and §2.5's ceiling are applied
+-- by the caller, around §5.5's backoff, because §5.5 doubles an already-floored RTO.
+baseRto :: TcpParams -> RttEst -> Double
+baseRto tp NoSample              = tpInitRtoS tp
+baseRto tp (RttEst srtt rttVar)  = srtt + max (tpClockG tp) (4 * rttVar)
+
 -- | §4.8 Timeout: "CUBIC follows Reno to reduce cwnd but sets ssthresh using beta_cubic
 -- (same as in Section 4.6)".  cwnd goes to 1 and the flow returns to slow start, which
 -- drops the epoch and with it W_max -- §4.8's requirement that the next congestion
@@ -379,7 +425,7 @@ rtoCollapse tp flightSize fs =
 idleReset :: Bool -> Double -> TcpParams -> FlowState -> FlowState
 idleReset keepsWarm idleGapS tp fs
   | keepsWarm                                      = fs
-  | idleGapS <= max (tpRtoMinS tp) (tpBaseRtoS tp) = fs
+  | idleGapS <= max (tpRtoMinS tp) (baseRto tp (fsRttEst fs)) = fs
   | otherwise = fs { fsCwnd = tpCwnd0 tp, fsPhase = SlowStart, fsConsecTO = 0 }
 
 -- | Sample losses in a window of @n@ packets at per-packet rate @p@: returns
@@ -408,7 +454,9 @@ sampleLosses n p = go 1 0 0
 stepRound :: RandomGen g
           => TcpParams
           -> Double
+          -- ^ RTT of this round
           -> Double
+          -- ^ loss probability, thus from the interval [0, 1]
           -> FlowState
           -> g
           -> (FlowState, Bool, g)
@@ -482,9 +530,23 @@ stepRound tp rtt lossP fs g =
       else -- RTO
         let delivered = max 0 (firstLoss - 1)
             backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
-            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (tpBaseRtoS tp) * fromIntegral backoff)
+            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (baseRto tp (fsRttEst fs)) * fromIntegral backoff)
+            acked     = delivered > 0
             fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
-                     , fsT = fsT fs + rto, fsConsecTO = fsConsecTO fs + 1 }
+                     , fsT = fsT fs + rto
+                     , -- RFC 6298 §3: original transmissions ahead of the hole are Karn-legal, and §3 requires
+                       -- at least one measurement per RTT where one is possible; the §5 note then
+                       -- collapses the backed-off RTO.  With nothing acked there is no sample and the
+                       -- backoff compounds (§5.5).
+                       fsRttEst =
+                         if acked
+                           then sampleRtt rtt (fsRttEst fs)
+                           else fsRttEst fs
+                     , fsConsecTO =
+                         if acked
+                           then 0
+                           else fsConsecTO fs + 1
+                     }
         in ( rtoCollapse tp flight fs1
            , True
            , g'
@@ -496,6 +558,9 @@ stepRound tp rtt lossP fs g =
     advance pkts rtt' f =
       f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
         , fsT = fsT f + rtt'
+          -- this round delivered original transmissions, so it yields a Karn-legal RTT
+          -- sample (§3); a timeout round does not call `advance` and so does not sample
+        , fsRttEst = sampleRtt rtt' (fsRttEst f)
         }
 
 -- | Isolated single-flow completion: (download time s, effective loss events).

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -5,7 +5,7 @@
 -- (one-RTT) granularity.
 --
 -- Each RFC clause is one named function that can be diffed against the text:
--- 'enterCA' is §4.2 Figure 2, 'nextCwnd' is §4.4/§4.5, 'fastConvergence' is §4.7,
+-- 'enterCA' is §4.2 Figure 2, 'cubicTarget' is §4.4/§4.5, 'fastConvergence' is §4.7,
 -- 'multiplicativeDecrease' is §4.6 Figure 5, and 'onCongestionEvent' composes the last
 -- three in the RFC's own order (§4.7 runs "before the window reduction described in
 -- Section 4.6").  Names and units follow §4.1: all windows in segments, all times in
@@ -25,7 +25,10 @@ module SmallWorld.TCP
   , warmFlow
     -- * The clauses
   -- , enterCA
-  -- , nextCwnd
+  -- , wCubic
+  -- , nextWEst
+  -- , nextCACwnd
+  -- , cubicTarget
   -- , fastConvergence
   -- , multiplicativeDecrease
   , CongestionEvent(..)
@@ -50,6 +53,7 @@ data Epoch = Epoch
   , epCwndEpoch :: !Double   -- ^ cwnd_epoch
   , epK         :: !Double   -- ^ K, seconds
   , epElapsed   :: !Double   -- ^ t - t_epoch, seconds
+  , epWEst      :: !Double   -- ^ W_est (§4.3), the Reno-friendly window estimate
   } deriving (Eq, Show)
 
 -- | Slow start carries no epoch: W_max is undefined until the first congestion event
@@ -145,12 +149,15 @@ enterCA c wMax cwndEpoch
              , epCwndEpoch = cwndEpoch
              , epK = 0
              , epElapsed = 0
+             , epWEst = cwndEpoch   -- §4.3, and §4.8/§4.10 for the post-timeout stage
              }
   | otherwise
   = CA Epoch { epWMax = wMax
              , epCwndEpoch = cwndEpoch
              , epK = ((wMax - cwndEpoch) / c) ** (1/3) -- Figure 2
              , epElapsed = 0
+             , epWEst = cwndEpoch   -- §4.3: "W_est is set equal to cwnd_epoch at the
+                                    -- start of the congestion avoidance stage"
              }
 
 -- | The per-round rendering of §4.4/§4.5.
@@ -163,21 +170,80 @@ enterCA c wMax cwndEpoch
 -- is non-decreasing and is less than the increase rate of slow start": @max cwnd@ (Linux:
 -- @ca->cnt = 100 * cwnd@ when the target is at or below cwnd) and @min (1.5 * cwnd)@
 -- (Linux: @ca->cnt = max(ca->cnt, 2U)@).
-nextCwnd :: Double
-         -- ^ @C@
-         -> Epoch
+cubicTarget :: Double
+            -- ^ @C@
+            -> Epoch
+            -> Double
+            -- ^ @cwnd@
+            -> Double
+cubicTarget c ep cwnd =
+    -- Section §4.2, `target` formula
+    if | w < cwnd      -> cwnd
+       | w > cwndLimit -> cwndLimit
+       | otherwise     -> w
+  where
+    w          = wCubic c ep
+    cwndLimit  = 1.5 * cwnd
+
+-- | §4.2 Figure 1: @W_cubic(t) = C*(t - K)^3 + W_max@.  Kept separate from 'cubicTarget'
+-- because §4.3's region test is on this raw value, not on the clamped target.
+wCubic :: Double
+       -- ^ @C@
+       -> Epoch
+       -> Double
+wCubic c ep = c * (epElapsed ep - epK ep) ** 3 + epWMax ep
+
+-- | §4.3 Figure 4: @W_est = W_est + alpha_cubic * segments_acked / cwnd@, applied once per
+-- round with the round's acknowledged-segment count.
+--
+-- @alpha_cubic = 3*(1 - beta_cubic)/(1 + beta_cubic)@ (= 0.529 at 0.7) is the additive
+-- factor that "achieves approximately the same average window size as Reno".  §4.3 then
+-- escalates it: "Once W_est has grown to reach the cwnd at the time of most recently
+-- setting ssthresh -- that is, W_est >= cwnd_prior -- the sender SHOULD set alpha_cubic
+-- to 1 to ensure that it can achieve the same congestion window increment rate as Reno".
+nextWEst :: Double
+         -- ^ @β_cubic@
+         -> Double
+         -- ^ @cwnd_prior@
          -> Double
          -- ^ @cwnd@
          -> Double
-nextCwnd c ep cwnd =
-    -- Section §4.2, `target` formula
-    if | wCubic < cwnd      -> cwnd
-       | wCubic > cwndLimit -> cwndLimit
-       | otherwise          -> wCubic
+         -- ^ @segments_acked@ this round
+         -> Double
+         -- ^ @W_est@
+         -> Double
+nextWEst betaCubic cwndPrior cwnd segmentsAcked wEst =
+    wEst + alphaCubic * segmentsAcked / cwnd
   where
-    --  Figure 1
-    wCubic     = c * (epElapsed ep - epK ep) ** 3 + epWMax ep
-    cwndLimit  = 1.5 * cwnd
+    -- α_cubic
+    alphaCubic | wEst >= cwndPrior = 1
+               | otherwise         = 3 * (1 - betaCubic) / (1 + betaCubic)
+
+-- | The congestion-avoidance window for the next round: §4.3's region choice.
+--
+-- "CUBIC checks whether W_cubic(t) is less than W_est.  If so, CUBIC is in the
+-- Reno-friendly region and cwnd SHOULD be set to W_est at each reception of a new ACK";
+-- otherwise §4.2's @target@ applies.  Two details of that sentence matter: the test is on
+-- the RAW W_cubic(t), not on the clamped target, and the W_est arm *assigns* rather than
+-- taking a maximum, so §4.2's bounds do not gate it.  (They coincide in practice -- W_est
+-- starts at cwnd_epoch, both only grow, and in this region W_est is the larger -- but the
+-- branch is what the RFC specifies.)  The region is orthogonal to concave/convex: §4.3
+-- applies "where cwnd could be greater than or less than W_max".
+nextCACwnd :: Double
+           -- ^ @C@
+           -> Epoch
+           -> Double
+           -- ^ @cwnd@
+           -> Double
+nextCACwnd c ep cwnd
+  -- Reno-friendly region
+  | wCubic c ep < epWEst ep
+  = epWEst ep
+
+  -- CUBIC region
+  | otherwise
+  = cubicTarget c ep cwnd
+
 
 -- | One loss-free round: RFC 5681 slow-start doubling up to ssthresh, then §4.4/§4.5.
 -- Takes the round's RTT and owns the epoch clock, so @t - t_epoch@ has exactly one writer
@@ -185,9 +251,12 @@ nextCwnd c ep cwnd =
 growOnAck :: TcpParams
           -> Double
           -- ^ @RTT@
+          -> Double
+          -- ^ @segments_acked@ this round: what the round actually put on the wire, which
+          -- is below @cwnd@ for a share-throttled round or the file tail
           -> FlowState
           -> FlowState
-growOnAck tp rtt fs = case fsPhase fs of
+growOnAck tp rtt segmentsAcked fs = case fsPhase fs of
   SlowStart
     | doubled < fsSsthresh fs ->
       fs { fsCwnd = doubled }
@@ -205,8 +274,13 @@ growOnAck tp rtt fs = case fsPhase fs of
 
   -- congestion avoidance
   CA ep ->
-    let ep' = ep { epElapsed = epElapsed ep + rtt }
-    in fs { fsCwnd  = nextCwnd (tpCubicC tp) ep' (fsCwnd fs)
+    -- §4.3 updates W_est on the new ACK and only then compares it with W_cubic(t), so the
+    -- epoch clock and W_est both advance before the region choice.
+    let ep' = ep { epElapsed = epElapsed ep + rtt
+                 , epWEst    = nextWEst (tpBetaCubic tp) (fsCwndPrior fs)
+                                        (fsCwnd fs) segmentsAcked (epWEst ep)
+                 }
+    in fs { fsCwnd  = nextCACwnd (tpCubicC tp) ep' (fsCwnd fs)
           , fsPhase = CA ep'
           }
   where
@@ -347,7 +421,7 @@ stepRound tp rtt lossP fs g =
               | otherwise                   = lossRound
   in if not lossRound
        then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- clean round resets the RTO backoff
-            in (if fsBytesSent fs1 >= tpFileBytes tp then fs1 else growOnAck tp rtt fs1, 0, g')
+            in (if fsBytesSent fs1 >= tpFileBytes tp then fs1 else growOnAck tp rtt (fromIntegral attempt) fs1, 0, g')
      else if fastRtx
        then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- data delivered => fresh RTT samples clear the backoff (RFC 6298 §2.2/2.3 + Karn)
             in if fsBytesSent fs1 >= tpFileBytes tp

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -405,50 +405,98 @@ sampleLosses n p = go 1 0 0
 
 -- | One round (one RTT, or one RTO stall on timeout).  @rtt@ and @lossP@ are passed in so
 -- a driver can vary them per round (jitter, egress-derived loss).
-stepRound :: RandomGen g => TcpParams -> Double -> Double -> FlowState -> g -> (FlowState, Int, g)
+stepRound :: RandomGen g
+          => TcpParams
+          -> Double
+          -> Double
+          -> FlowState
+          -> g
+          -> (FlowState, Bool, g)
 stepRound tp rtt lossP fs g =
-  let mss     = tpMss tp
+  let mss, effCwnd, remPkts, attempt, k, firstLoss :: Int
+
+      -- maximum segment size
+      mss = tpMss tp
+
+      -- effective cwnd
       effCwnd = max 1 (min (floor (fsCwnd fs)) (tpBdpCapSegs tp))
-      remB    = tpFileBytes tp - fsBytesSent fs
-      remPkts = (remB + mss - 1) `div` mss
+
+      -- number of packets needed to finish the transmission
+      remPkts = (tpFileBytes tp - fsBytesSent fs + mss - 1) `div` mss
+
+      -- number of packets attempted to handle in this round
       attempt = min effCwnd remPkts
+
+      flight :: Double
       flight  = fromIntegral effCwnd          -- see note at the call sites below
+
+      -- k is the number of lost packets
       (k, firstLoss, g') = sampleLosses attempt lossP g
       lossRound = k > 0
       -- RFC 5681 §3.2: a fast retransmit needs three dup-ACKs, so the first loss must
       -- leave >= 3 packets behind it; anything else (or >= 2 losses, no SACK) times out.
       fastRtx | lossRound && tpEnableRto tp = k == 1 && attempt - firstLoss >= 3
               | otherwise                   = lossRound
-  in if not lossRound
-       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- clean round resets the RTO backoff
-            in (if fsBytesSent fs1 >= tpFileBytes tp then fs1 else growOnAck tp rtt (fromIntegral attempt) fs1, 0, g')
-     else if fastRtx
-       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- data delivered => fresh RTT samples clear the backoff (RFC 6298 §2.2/2.3 + Karn)
-            in if fsBytesSent fs1 >= tpFileBytes tp
-                 -- final-window fast retransmit: mid-transfer the fill RTT is absorbed by
-                 -- the next round's continued transmission, but at the file tail nothing
-                 -- rides behind the hole, so the in-order prefix closes only when the
-                 -- retransmit lands ~1 RTT on -- charge it.
-                 then (fs1 { fsT = fsT fs1 + rtt }, 1, g')
-                 -- flight_size is the BDP-capped window rather than `attempt`: §4.6 warns
-                 -- that cutting from a short flight "would decrease cwnd to a much lower
-                 -- value than necessary", and `attempt` dips below the window only at the
-                 -- file tail.  The BDP cap is the "other measure" §4.6 asks of a
-                 -- cwnd-based implementation.
-                 else (onCongestionEvent tp Loss flight fs1, 1, g')
-     else -- RTO
-       let delivered = max 0 (firstLoss - 1)
-           backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
-           rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (tpBaseRtoS tp) * fromIntegral backoff)
-           fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
-                    , fsT = fsT fs + rto, fsConsecTO = fsConsecTO fs + 1 }
-       in (rtoCollapse tp flight fs1, 1, g')
+  in
+  if not lossRound
+    then
+    -- clean round resets the RTO backoff
+    let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 } in
+    ( if fsBytesSent fs1 >= tpFileBytes tp
+        then
+            -- RFC 9438
+            -- §5.8 "CUBIC does not increase its congestion window if
+            --       a flow is application limited"
+            -- §4.2 "t MUST NOT include periods during which cwnd has not
+            --       been updated due to application-limited behaviour"
+            --
+            -- But above all, `flowTimeFrom` will terminate and will not
+            -- evaluate `cwnd` any more thus no need to recompute it.
+             fs1
+        else growOnAck tp rtt (fromIntegral attempt) fs1
+    , False
+    , g'
+    )
+    else if fastRtx
+      then
+        -- data delivered => fresh RTT samples clear the backoff (RFC 6298 §2.2/2.3 + Karn)
+        let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }
+        in if fsBytesSent fs1 >= tpFileBytes tp
+             -- final-window fast retransmit: mid-transfer the fill RTT is absorbed by
+             -- the next round's continued transmission, but at the file tail nothing
+             -- rides behind the hole, so the in-order prefix closes only when the
+             -- retransmit lands ~1 RTT on -- charge it.
+             then ( fs1 { fsT = fsT fs1 + rtt }
+                  , True
+                  , g'
+                  )
+             -- flight_size is the BDP-capped window rather than `attempt`: §4.6 warns
+             -- that cutting from a short flight "would decrease cwnd to a much lower
+             -- value than necessary", and `attempt` dips below the window only at the
+             -- file tail.  The BDP cap is the "other measure" §4.6 asks of a
+             -- cwnd-based implementation.
+             else ( onCongestionEvent tp Loss flight fs1
+                  , True
+                  , g'
+                  )
+      else -- RTO
+        let delivered = max 0 (firstLoss - 1)
+            backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
+            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (tpBaseRtoS tp) * fromIntegral backoff)
+            fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
+                     , fsT = fsT fs + rto, fsConsecTO = fsConsecTO fs + 1 }
+        in ( rtoCollapse tp flight fs1
+           , True
+           , g'
+           )
   where
     -- a delivering round: bytes and wall clock only.  The epoch clock belongs to
     -- growOnAck, and fsConsecTO to the caller (cleared on any delivering round, since a
     -- successful delivery draws fresh RTT samples; only back-to-back timeouts keep it).
-    advance pkts rtt' f = f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
-                            , fsT = fsT f + rtt' }
+    advance pkts rtt' f =
+      f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
+        , fsT = fsT f + rtt'
+        }
 
 -- | Isolated single-flow completion: (download time s, effective loss events).
 flowTime :: RandomGen g => TcpParams -> g -> (Double, Int)
@@ -465,5 +513,5 @@ flowTimeFrom tp fs0 g0
       | fsBytesSent fs >= tpFileBytes tp = (fsT fs, nLoss)
       | rounds > 10000000                = (1/0, nLoss)
       | otherwise =
-          let (fs', dl, g') = stepRound tp (tpRttS tp) (tpLossP tp) fs g
-          in loop fs' (nLoss + dl) g' (rounds + 1)
+          let (fs', lossRound, g') = stepRound tp (tpRttS tp) (tpLossP tp) fs g
+          in loop fs' (if lossRound then nLoss + 1 else nLoss) g' (rounds + 1)

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -188,7 +188,7 @@ stepRound tp rtt lossP fs g =
                  else (cutOnLoss tp effCwnd fs1, 1, g')
      else -- RTO
        let delivered = max 0 (firstLoss - 1)
-           backoff   = 2 ^ min (fsConsecTO fs) (30 :: Int)
+           backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (tpBaseRtoS tp) * fromIntegral backoff)
            fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
                     , fsT = fsT fs + rto, fsConsecTO = fsConsecTO fs + 1 }

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -36,6 +36,7 @@ module SmallWorld.TCP
   , onCongestionEvent
   , rtoCollapse
   , idleReset
+  , onDelivery
     -- * Round drivers
   , growOnAck
   , stepRound
@@ -401,6 +402,26 @@ baseRto :: TcpParams -> RttEst -> Double
 baseRto tp NoSample              = tpInitRtoS tp
 baseRto tp (RttEst srtt rttVar)  = srtt + max (tpClockG tp) (4 * rttVar)
 
+-- | Bookkeeping shared by every round that delivered non-retransmitted data.
+--
+-- Such a round yields a Karn-legal RTT sample (RFC 6298 §3), and because a new measurement
+-- recomputes the RTO it also collapses any exponential backoff -- the note after §5.7:
+-- "once a new RTT measurement is obtained (which can only happen when new data has been
+-- sent and acknowledged) ... which may result in 'collapsing' RTO back down after it has
+-- been subject to exponential back off".
+--
+-- Both drivers must apply this on exactly the rounds that put original transmissions on
+-- the wire and got them acknowledged: a clean round, a fast-retransmit round, and the
+-- pre-loss prefix of a timeout round.  Keeping it in one function is what stops them
+-- drifting apart on which rounds count.
+onDelivery :: Double
+           -- ^ the round's measured RTT
+           -> FlowState
+           -> FlowState
+onDelivery rtt fs = fs { fsRttEst = sampleRtt rtt (fsRttEst fs)
+                       , fsConsecTO = 0
+                       }
+
 -- | §4.8 Timeout: "CUBIC follows Reno to reduce cwnd but sets ssthresh using beta_cubic
 -- (same as in Section 4.6)".  cwnd goes to 1 and the flow returns to slow start, which
 -- drops the epoch and with it W_max -- §4.8's requirement that the next congestion
@@ -489,7 +510,7 @@ stepRound tp rtt lossP fs g =
   if not lossRound
     then
     -- clean round resets the RTO backoff
-    let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 } in
+    let fs1 = advance attempt rtt fs in
     ( if fsBytesSent fs1 >= tpFileBytes tp
         then
             -- RFC 9438
@@ -508,7 +529,7 @@ stepRound tp rtt lossP fs g =
     else if fastRtx
       then
         -- data delivered => fresh RTT samples clear the backoff (RFC 6298 §2.2/2.3 + Karn)
-        let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }
+        let fs1 = advance attempt rtt fs
         in if fsBytesSent fs1 >= tpFileBytes tp
              -- final-window fast retransmit: mid-transfer the fill RTT is absorbed by
              -- the next round's continued transmission, but at the file tail nothing
@@ -531,22 +552,14 @@ stepRound tp rtt lossP fs g =
         let delivered = max 0 (firstLoss - 1)
             backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
             rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (baseRto tp (fsRttEst fs)) * fromIntegral backoff)
-            acked     = delivered > 0
-            fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
-                     , fsT = fsT fs + rto
-                     , -- RFC 6298 §3: original transmissions ahead of the hole are Karn-legal, and §3 requires
-                       -- at least one measurement per RTT where one is possible; the §5 note then
-                       -- collapses the backed-off RTO.  With nothing acked there is no sample and the
-                       -- backoff compounds (§5.5).
-                       fsRttEst =
-                         if acked
-                           then sampleRtt rtt (fsRttEst fs)
-                           else fsRttEst fs
-                     , fsConsecTO =
-                         if acked
-                           then 0
-                           else fsConsecTO fs + 1
-                     }
+            -- RFC 6298 §3: the packets ahead of the hole are original transmissions, so
+            -- they are Karn-legal and §3 requires a measurement where one is possible;
+            -- with nothing acked there is no sample and the backoff compounds (§5.5).
+            fs0 | delivered > 0 = onDelivery rtt fs
+                | otherwise     = fs { fsConsecTO = fsConsecTO fs + 1 }
+            fs1 = fs0 { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
+                      , fsT = fsT fs + rto
+                      }
         in ( rtoCollapse tp flight fs1
            , True
            , g'
@@ -555,12 +568,12 @@ stepRound tp rtt lossP fs g =
     -- a delivering round: bytes and wall clock only.  The epoch clock belongs to
     -- growOnAck, and fsConsecTO to the caller (cleared on any delivering round, since a
     -- successful delivery draws fresh RTT samples; only back-to-back timeouts keep it).
+    -- `onDelivery` takes the round's RTT sample and clears the RTO backoff; a timeout
+    -- round does not call `advance`, and handles its delivered prefix separately.
     advance pkts rtt' f =
-      f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
+      (onDelivery rtt' f)
+        { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
         , fsT = fsT f + rtt'
-          -- this round delivered original transmissions, so it yields a Karn-legal RTT
-          -- sample (§3); a timeout round does not call `advance` and so does not sample
-        , fsRttEst = sampleRtt rtt' (fsRttEst f)
         }
 
 -- | Isolated single-flow completion: (download time s, effective loss events).

--- a/smol-world/src/SmallWorld/TCP.hs
+++ b/smol-world/src/SmallWorld/TCP.hs
@@ -1,52 +1,87 @@
--- | Per-flow CUBIC + full-RTO transport, a faithful Haskell port of the TCP
--- estimator's @simulate_one_run@ (round-based cwnd dynamics: slow-start / CUBIC
--- congestion avoidance, fast-retransmit vs. RTO, prefix-crediting on timeout).
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE MultiWayIf #-}
+
+-- | Per-flow CUBIC congestion control (RFC 9438) plus a full RTO, at one-round
+-- (one-RTT) granularity.
 --
--- This is the single-flow core.  Phase 2 drives it per-round from the diffusion
--- DES with a *per-round loss probability* derived from each serving node's egress
--- contention (rather than a fixed p) and a bandwidth cap from the node's egress
--- fair-share — but the cwnd/RTO arithmetic here is exactly the estimator's.
+-- Each RFC clause is one named function that can be diffed against the text:
+-- 'enterCA' is §4.2 Figure 2, 'nextCwnd' is §4.4/§4.5, 'fastConvergence' is §4.7,
+-- 'multiplicativeDecrease' is §4.6 Figure 5, and 'onCongestionEvent' composes the last
+-- three in the RFC's own order (§4.7 runs "before the window reduction described in
+-- Section 4.6").  Names and units follow §4.1: all windows in segments, all times in
+-- seconds, and beta_cubic is the RFC's 0.7 -- the RETAINED fraction -- so every formula
+-- reads as printed.
+--
+-- This is the single-flow core.  The diffusion DES drives the same primitives per round
+-- with a loss decision derived from egress contention rather than a sampled rate.
 module SmallWorld.TCP
-  ( Phase(..)
+  ( -- * RFC 9438 §4.1.2 state
+    Epoch(..)
+  , Phase(..)
   , FlowState(..)
   , TcpParams(..)
   , mkTcpParams
   , initFlow
-  , growOnAck
-  , cutOnLoss
+  , warmFlow
+    -- * The clauses
+  -- , enterCA
+  -- , nextCwnd
+  -- , fastConvergence
+  -- , multiplicativeDecrease
+  , CongestionEvent(..)
+  , onCongestionEvent
   , rtoCollapse
   , idleReset
+    -- * Round drivers
+  , growOnAck
   , stepRound
   , flowTime
   , flowTimeFrom
-  , warmFlow
   ) where
 
 import System.Random (RandomGen, randomR)
 
-data Phase = SlowStart | CA deriving (Eq, Show)
+-- | RFC 9438 §4.1.2: the congestion-avoidance epoch.  First free are defined "at the
+-- beginning of the current congestion avoidance stage", so they are built together by
+-- 'enterCA' and never assigned piecewise -- a partially-updated epoch (a new W_max with a
+-- stale K, say) has no representation.  The elapsed time is updated on by `growOnAck`.
+data Epoch = Epoch
+  { epWMax      :: !Double   -- ^ W_max
+  , epCwndEpoch :: !Double   -- ^ cwnd_epoch
+  , epK         :: !Double   -- ^ K, seconds
+  , epElapsed   :: !Double   -- ^ t - t_epoch, seconds
+  } deriving (Eq, Show)
+
+-- | Slow start carries no epoch: W_max is undefined until the first congestion event
+-- (§4.10), and an RTO returns here precisely in order to forget it (§4.8).
+data Phase =
+    SlowStart
+   -- ^ slow start phase
+ | CA !Epoch
+   -- ^ congestion avoidance phase with internal state
+ deriving (Eq, Show)
 
 -- | Static per-flow parameters (constant over the transfer).
 data TcpParams = TcpParams
   { tpFileBytes  :: !Int
   , tpRttS       :: !Double
-  , tpLossP      :: !Double   -- per-packet loss this transfer (Phase-2 overrides per round)
+  , tpLossP      :: !Double   -- ^ per-packet loss this transfer (the DES overrides per round)
   , tpMss        :: !Int
-  , tpBdpCapSegs :: !Int      -- window cap = BDP/MSS (bandwidth ceiling)
+  , tpBdpCapSegs :: !Int      -- ^ window cap = BDP/MSS (bandwidth ceiling)
   , tpCwnd0      :: !Double
   , tpSsthresh0  :: !Double
-  , tpCubicC     :: !Double
-  , tpCubicBeta  :: !Double
+  , tpCubicC     :: !Double   -- ^ C, segments/s^3 (§4.1.1)
+  , tpBetaCubic  :: !Double   -- ^ beta_cubic, the RETAINED fraction (§4.6: SHOULD be 0.7)
   , tpRtoMinS    :: !Double
   , tpRtoMaxS    :: !Double
   , tpBaseRtoS   :: !Double
-  , tpFastConv   :: !Bool
+  , tpFastConv   :: !Bool     -- ^ §4.7
   , tpEnableRto  :: !Bool
   } deriving (Show)
 
--- | Smart constructor: derive the BDP window cap and initial ssthresh from a
--- capacity (bits/s) and RTT, matching the estimator's auto-sizing (ssthresh at
--- link saturation; base RTO = RTT + 4·RTTVAR with the no-jitter RTTVAR = RTT/4).
+-- | Smart constructor: derive the BDP window cap and initial ssthresh from a capacity
+-- (bits/s) and RTT (ssthresh at link saturation; base RTO = RTT + 4·RTTVAR with the
+-- no-jitter RTTVAR = RTT/4, floored at Linux's TCP_RTO_MIN rather than RFC 6298 §2.4's 1 s).
 mkTcpParams :: Int -> Double -> Double -> Double -> TcpParams
 mkTcpParams fileBytes rttS lossP capBps = TcpParams
   { tpFileBytes  = fileBytes
@@ -57,7 +92,7 @@ mkTcpParams fileBytes rttS lossP capBps = TcpParams
   , tpCwnd0      = 10
   , tpSsthresh0  = fromIntegral bdpCap
   , tpCubicC     = 0.4
-  , tpCubicBeta  = 0.3
+  , tpBetaCubic  = 0.7
   , tpRtoMinS    = 0.2
   , tpRtoMaxS    = 120
   , tpBaseRtoS   = rttS + 4 * (0.25 * rttS)
@@ -66,101 +101,236 @@ mkTcpParams fileBytes rttS lossP capBps = TcpParams
   }
   where
     mss    = 1460
-    bdpCap = max 1 (floor (capBps * rttS / 8 / fromIntegral mss))  -- floor matches the reference estimator; inert in-regime (BDP ≥ ~850 segs)
+    bdpCap = max 1 (floor (capBps * rttS / 8 / fromIntegral mss))
 
 data FlowState = FlowState
-  { fsCwnd        :: !Double
-  , fsSsthresh    :: !Double
-  , fsPhase       :: !Phase
-  , fsWMax        :: !Double
-  , fsLastWMax    :: !Double
-  , fsK           :: !Double
-  , fsCaElapsed   :: !Double
-  , fsBytesSent   :: !Int
-  , fsT           :: !Double
-  , fsConsecTO    :: !Int
+  { fsCwnd      :: !Double   -- ^ cwnd, segments
+  , fsSsthresh  :: !Double   -- ^ ssthresh, segments
+  , fsCwndPrior :: !Double   -- ^ cwnd_prior (§4.1.2): cwnd when ssthresh was last set
+  , fsPhase     :: !Phase
+  , fsBytesSent :: !Int
+  , fsT         :: !Double
+  , fsConsecTO  :: !Int
   } deriving (Show)
 
 initFlow :: TcpParams -> FlowState
 initFlow tp = FlowState
-  { fsCwnd = tpCwnd0 tp, fsSsthresh = tpSsthresh0 tp, fsPhase = SlowStart
-  , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCaElapsed = 0
-  , fsBytesSent = 0, fsT = 0, fsConsecTO = 0 }
+  { fsCwnd = tpCwnd0 tp, fsSsthresh = tpSsthresh0 tp, fsCwndPrior = 0
+  , fsPhase = SlowStart, fsBytesSent = 0, fsT = 0, fsConsecTO = 0 }
 
--- Loss-free round: slow-start doubling to ssthresh, then CUBIC convex regrowth.
-growOnAck :: TcpParams -> FlowState -> FlowState
-growOnAck tp fs
-  | fsPhase fs == SlowStart =
-      let c = fsCwnd fs * 2
-      in if c >= fsSsthresh fs
-           then let w = max (fsSsthresh fs) (fsCwnd fs)  -- Finding 8: never shrink on a clean round (post-idleReset ssthresh<cwnd corner); no-op when cwnd<ssthresh
-                in fs { fsCwnd = w, fsWMax = w
-                      , fsLastWMax = 0, fsK = 0   -- no prior loss yet; RFC 8312 §4.6 W_last_max starts unset
-                      , fsCaElapsed = 0, fsPhase = CA }
-           else fs { fsCwnd = c }
-  | otherwise =
-      fs { fsCwnd = max 1 (tpCubicC tp * (fsCaElapsed fs - fsK fs) ** 3 + fsWMax fs) }
+-- | A warm flow at (near-)steady cwnd: already ramped to the BDP cap and in congestion
+-- avoidance, so a WARM transfer skips the cold slow-start ramp.  Its epoch is §4.10's
+-- loss-free-exit shape: W_max = cwnd_epoch = cwnd, K = 0.
+warmFlow :: TcpParams -> FlowState
+warmFlow tp = (initFlow tp) { fsCwnd = cap, fsSsthresh = cap, fsCwndPrior = cap
+                            , fsPhase = enterCA (tpCubicC tp) cap cap }
+  where cap = fromIntegral (tpBdpCapSegs tp)
 
--- Graceful fast recovery: CUBIC multiplicative decrease + fresh concave epoch.
--- fsBytesSent is untouched — a loss costs a cwnd cut + ~1 RTT, not delivered data
--- (no-round-discard; see tcpcheck's self-check and mechanics.md §4/§5).
-cutOnLoss :: TcpParams -> Int -> FlowState -> FlowState
-cutOnLoss tp effCwnd fs =
-  let beta = tpCubicBeta tp
-      cwndAtLoss = fromIntegral effCwnd
-      wMax | tpFastConv tp && fsLastWMax fs > 0 && cwndAtLoss < fsLastWMax fs
-               = cwndAtLoss * (2 - beta) / 2
-           | otherwise = cwndAtLoss
-  in fs { fsWMax = wMax
-        , fsLastWMax = cwndAtLoss   -- RFC 8312 §4.6: W_last_max = the pre-reduction cwnd-at-loss (may descend)
-        , fsCwnd = max 1 (cwndAtLoss * (1 - beta))
-        , fsK = (max 0 (wMax - max 1 (cwndAtLoss * (1 - beta))) / tpCubicC tp) ** (1/3)  -- regrow CA from the installed cwnd, not a fast-conv-dipped value (Finding 1; no-op outside the fast-conv corner)
-        , fsCaElapsed = 0
-        , fsPhase = CA }
+-- | §4.2 Figure 2: @K = cbrt((W_max - cwnd_epoch)/C)@.  The only way to build an 'Epoch',
+-- so @W_cubic(0) == cwnd_epoch@ holds by construction and the curve can never start below
+-- the installed window.  The first branch is §4.8/§4.10's rule for an epoch beginning at
+-- or above W_max -- "K is set to 0, and W_max is set to the congestion window size at the
+-- beginning of the current congestion avoidance stage" (Linux: @last_max_cwnd <= cwnd =>
+-- bic_K = 0, bic_origin_point = cwnd@).
+enterCA :: Double
+        -- ^ @C@
+        -> Double
+        -- ^ @W_max@
+        -> Double
+        -- ^ @cwnd_epoch@
+        -> Phase
+enterCA c wMax cwndEpoch
+  | wMax <= cwndEpoch
+  = CA Epoch { epWMax = cwndEpoch
+             , epCwndEpoch = cwndEpoch
+             , epK = 0
+             , epElapsed = 0
+             }
+  | otherwise
+  = CA Epoch { epWMax = wMax
+             , epCwndEpoch = cwndEpoch
+             , epK = ((wMax - cwndEpoch) / c) ** (1/3) -- Figure 2
+             , epElapsed = 0
+             }
 
--- RTO: collapse to a slow-start restart (cwnd->1, ssthresh = beta_cubic·cwnd).
--- fsBytesSent is untouched — the RTO costs a backoff stall + slow-start re-ramp,
--- not the round; the transfer resumes from where it was.
-rtoCollapse :: Int -> FlowState -> FlowState
-rtoCollapse effCwnd fs =
-  fs { fsSsthresh = max 2 (fromIntegral effCwnd * 0.7)   -- RFC 8312 §4.7: ssthresh = beta_cubic·cwnd (0.7), not Standard-TCP 0.5
-     , fsCwnd = 1, fsPhase = SlowStart
-     , fsWMax = 0, fsLastWMax = 0, fsK = 0, fsCaElapsed = 0 }  -- Finding 11: clear the high-water mark on RTO (Linux bictcp_reset)
-
--- | Linux @tcp_slow_start_after_idle@: a connection idle for longer than one RTO
--- restarts its window at the initial cwnd (back into slow-start), keeping
--- ssthresh — so a *reused* connection does not send from a stale warm window.
--- Stacks that disable it (@tcp_slow_start_after_idle=0@, @keepsWarm=True@) retain
--- the warm cwnd across the idle gap.  @idleGapS@ is the inactivity since the
--- connection last sent.  Gaps within one RTO (e.g. the ~1-RTT body→closure
--- request within a single EB) are not idle and stay warm regardless.
+-- | The per-round rendering of §4.4/§4.5.
 --
--- In single-EB diffusion every connection is used once, so this never fires;
--- it is the seam the Phase-4 multi-round driver uses when a connection is reused
--- for the next EB after seconds of inactivity (see design.md D12).
+-- The RFC's per-ACK rule is @cwnd += (target - cwnd)/cwnd@ with @target = W_cubic(t+RTT)@.
+-- That is a first-order lag of time constant RTT, so the cwnd it *achieves* at time t is
+-- W_cubic(t) to within O(RTT^2·W''), not the target -- a model that assigns once per round
+-- assigns W_cubic(t) and must NOT also apply the lookahead, or it runs a full RTT of curve
+-- fast.  §4.2's two bounds still apply, ensuring "CUBIC's congestion window increase rate
+-- is non-decreasing and is less than the increase rate of slow start": @max cwnd@ (Linux:
+-- @ca->cnt = 100 * cwnd@ when the target is at or below cwnd) and @min (1.5 * cwnd)@
+-- (Linux: @ca->cnt = max(ca->cnt, 2U)@).
+nextCwnd :: Double
+         -- ^ @C@
+         -> Epoch
+         -> Double
+         -- ^ @cwnd@
+         -> Double
+nextCwnd c ep cwnd =
+    -- Section §4.2, `target` formula
+    if | wCubic < cwnd      -> cwnd
+       | wCubic > cwndLimit -> cwndLimit
+       | otherwise          -> wCubic
+  where
+    --  Figure 1
+    wCubic     = c * (epElapsed ep - epK ep) ** 3 + epWMax ep
+    cwndLimit  = 1.5 * cwnd
+
+-- | One loss-free round: RFC 5681 slow-start doubling up to ssthresh, then §4.4/§4.5.
+-- Takes the round's RTT and owns the epoch clock, so @t - t_epoch@ has exactly one writer
+-- per round (§4.2: t must exclude any period in which cwnd was not updated).
+growOnAck :: TcpParams
+          -> Double
+          -- ^ @RTT@
+          -> FlowState
+          -> FlowState
+growOnAck tp rtt fs = case fsPhase fs of
+  SlowStart
+    | doubled < fsSsthresh fs ->
+      fs { fsCwnd = doubled }
+    -- §4.10: cwnd is no longer at or below ssthresh, so leave slow start.  A loss-free
+    -- exit leaves W_max undefined; the RFC's remedy is "CUBIC sets cwnd_prior = cwnd and
+    -- switches to congestion avoidance ... K is set to 0, and W_max is set to the
+    -- congestion window size at the beginning of the current congestion avoidance stage".
+    -- `max` because after an idleReset ssthresh can sit below cwnd, and slow start must
+    -- never reduce the window.
+    | otherwise ->
+      fs { fsCwnd      = w
+         , fsCwndPrior = w
+         , fsPhase     = enterCA (tpCubicC tp) w w
+         }
+
+  -- congestion avoidance
+  CA ep ->
+    let ep' = ep { epElapsed = epElapsed ep + rtt }
+    in fs { fsCwnd  = nextCwnd (tpCubicC tp) ep' (fsCwnd fs)
+          , fsPhase = CA ep'
+          }
+  where
+    doubled = fsCwnd fs * 2
+    w       = fsSsthresh fs `max` fsCwnd fs
+
+-- | W_max as of now: undefined (0) in slow start, so fast convergence cannot fire on a
+-- flow that has not been cut in this stage -- which is also how §4.8's "forget W_max on a
+-- timeout" falls out, since 'rtoCollapse' returns to slow start.
+currentWMax :: FlowState -> Double
+currentWMax fs = case fsPhase fs of
+  CA ep     -> epWMax ep
+  SlowStart -> 0
+
+-- | §4.7 Fast Convergence.  Runs BEFORE the reduction, on the pre-reduction cwnd, and
+-- compares against W_max -- the value a previous firing may already have reduced (§4.1.2:
+-- "if fast convergence is enabled, W_max may be further reduced") -- never against
+-- cwnd_prior.  RFC 8312's separate W_last_max, which compared against the un-reduced
+-- pre-cut cwnd and so fired more often, does not exist in RFC 9438.
+fastConvergence :: Bool -> Double -> Double -> Double -> Double
+fastConvergence enabled betaCubic cwnd wMax
+  | enabled && cwnd < wMax = cwnd * (1 + betaCubic) / 2
+  | otherwise              = cwnd
+
+data CongestionEvent = Loss | ECE
+  deriving Show
+
+-- | §4.6 Figure 5, returning all three outputs at once so none can be dropped.
+--
+-- @flightSize@ is the RFC's flight_size.  §4.6 permits cwnd in its place, but only for
+-- implementations that "use other measures to prevent cwnd from growing when the volume of
+-- bytes in flight is smaller than cwnd" -- a caller substituting cwnd takes on that
+-- obligation.  Figure 5 applies the cwnd floor to the *unfloored* ssthresh and floors
+-- ssthresh on the following line, hence the order here.
+multiplicativeDecrease
+  :: Double
+  -> CongestionEvent
+  -> Double
+  -- ^ @cwnd@
+  -> Double
+  -> (Double, Double, Double)
+  -- ^ @(ssthresh, cwnd_prior, cwnd)@
+multiplicativeDecrease betaCubic ev cwnd flightSize =
+  ( max ssthresh 2                            -- ssthresh = max(ssthresh, 2)
+  , cwnd                                      -- cwnd_prior = cwnd
+  , max ssthresh floorSegs )                  -- cwnd = max(ssthresh, 2) / max(ssthresh, 1)
+  where
+    ssthresh  = flightSize * betaCubic
+    floorSegs = case ev of Loss -> 2; ECE -> 1
+
+-- | A congestion event (§4.6): fast convergence, then the multiplicative decrease, then a
+-- fresh epoch -- in the RFC's order.  fsBytesSent and fsT are untouched: a loss costs a
+-- window reduction (and, at the caller's discretion, a recovery RTT), never delivered data.
+onCongestionEvent :: TcpParams -> CongestionEvent -> Double -> FlowState -> FlowState
+onCongestionEvent tp ev flightSize fs = fs
+  { fsSsthresh  = ssthresh
+  , fsCwndPrior = cwndPrior
+  , fsCwnd      = cwnd
+  , fsPhase     = enterCA (tpCubicC tp) wMax cwnd }
+  where
+    wMax = fastConvergence
+            (tpFastConv tp)
+            (tpBetaCubic tp)
+            (fsCwnd fs)
+            (currentWMax fs)
+
+    (ssthresh, cwndPrior, cwnd) =
+      multiplicativeDecrease
+        (tpBetaCubic tp)
+        ev
+        (fsCwnd fs)
+        flightSize
+
+
+-- | §4.8 Timeout: "CUBIC follows Reno to reduce cwnd but sets ssthresh using beta_cubic
+-- (same as in Section 4.6)".  cwnd goes to 1 and the flow returns to slow start, which
+-- drops the epoch and with it W_max -- §4.8's requirement that the next congestion
+-- avoidance stage begin with K = 0 and W_max = cwnd_epoch (Linux: bictcp_reset on
+-- TCP_CA_Loss).  fsBytesSent/fsT are untouched; the caller charges the backoff stall.
+rtoCollapse :: TcpParams -> Double -> FlowState -> FlowState
+rtoCollapse tp flightSize fs =
+  fs { fsSsthresh  = max 2 (flightSize * tpBetaCubic tp)
+     , fsCwndPrior = fsCwnd fs
+     , fsCwnd      = 1
+     , fsPhase     = SlowStart }
+
+-- | Linux @tcp_slow_start_after_idle@ (RFC 5681 §4.1): a connection idle for longer than
+-- one RTO restarts its window at the initial cwnd, back in slow start, keeping ssthresh --
+-- so a *reused* connection does not send from a stale warm window.  Stacks that disable it
+-- (@tcp_slow_start_after_idle=0@, @keepsWarm=True@) retain the warm cwnd.  @idleGapS@ is
+-- the inactivity since the connection last sent; gaps within one RTO (e.g. the ~1-RTT
+-- body->closure request inside a single EB) are not idle and stay warm regardless.
+--
+-- In single-EB diffusion every connection is used once, so this never fires; it is the
+-- seam a multi-round driver uses when a connection is reused after seconds of inactivity.
 idleReset :: Bool -> Double -> TcpParams -> FlowState -> FlowState
 idleReset keepsWarm idleGapS tp fs
-  | keepsWarm                 = fs
-  | idleGapS <= max (tpRtoMinS tp) (tpBaseRtoS tp) = fs   -- within one (floored) RTO: not idle, stays warm (Finding 7 — the RTO the model charges is floored at tpRtoMinS)
-  | otherwise                 = fs { fsCwnd = tpCwnd0 tp, fsPhase = SlowStart
-                                   , fsWMax = 0, fsLastWMax = 0, fsK = 0
-                                   , fsCaElapsed = 0, fsConsecTO = 0 }   -- Finding 11: clear the high-water mark on idle-reset too
+  | keepsWarm                                      = fs
+  | idleGapS <= max (tpRtoMinS tp) (tpBaseRtoS tp) = fs
+  | otherwise = fs { fsCwnd = tpCwnd0 tp, fsPhase = SlowStart, fsConsecTO = 0 }
 
 -- | Sample losses in a window of @n@ packets at per-packet rate @p@: returns
 -- (loss count, 1-based first-loss position or 0, rng').
-sampleLosses :: RandomGen g => Int -> Double -> g -> (Int, Int, g)
+sampleLosses :: RandomGen g
+             => Int
+             -- ^ window size in packets
+             -> Double
+             -- ^ per packet loss probability
+             -> g
+             -> (Int, Int, g)
 sampleLosses n p = go 1 0 0
   where
-    go i k firstPos g
-      | i > n     = (k, firstPos, g)
-      | otherwise = let (u, g') = randomR (0, 1) g
-                    in if u < p
-                         then go (i+1) (k+1) (if firstPos == 0 then i else firstPos) g'
-                         else go (i+1) k firstPos g'
+    go !i !k !firstPos !g
+      | i > n
+      = (k, firstPos, g)
 
--- | One round (one RTT, or one RTO stall on timeout).  @rtt@ and @lossP@ are
--- passed in so the Phase-2 DES can vary them per round (jitter, egress-derived
--- loss); the isolated single-flow driver just passes the flow's constants.
+      | otherwise
+      = let (u, g') = randomR (0, 1) g in
+        if u < p
+        then go (i+1) (k+1) (if firstPos == 0 then i else firstPos) g'
+        else go (i+1) k firstPos g'
+
+-- | One round (one RTT, or one RTO stall on timeout).  @rtt@ and @lossP@ are passed in so
+-- a driver can vary them per round (jitter, egress-derived loss).
 stepRound :: RandomGen g => TcpParams -> Double -> Double -> FlowState -> g -> (FlowState, Int, g)
 stepRound tp rtt lossP fs g =
   let mss     = tpMss tp
@@ -168,59 +338,58 @@ stepRound tp rtt lossP fs g =
       remB    = tpFileBytes tp - fsBytesSent fs
       remPkts = (remB + mss - 1) `div` mss
       attempt = min effCwnd remPkts
+      flight  = fromIntegral effCwnd          -- see note at the call sites below
       (k, firstLoss, g') = sampleLosses attempt lossP g
       lossRound = k > 0
+      -- RFC 5681 §3.2: a fast retransmit needs three dup-ACKs, so the first loss must
+      -- leave >= 3 packets behind it; anything else (or >= 2 losses, no SACK) times out.
       fastRtx | lossRound && tpEnableRto tp = k == 1 && attempt - firstLoss >= 3
               | otherwise                   = lossRound
   in if not lossRound
-       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- clean round resets RTO backoff
-            in (if fsBytesSent fs1 >= tpFileBytes tp then fs1 else growOnAck tp fs1, 0, g')
+       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- clean round resets the RTO backoff
+            in (if fsBytesSent fs1 >= tpFileBytes tp then fs1 else growOnAck tp rtt fs1, 0, g')
      else if fastRtx
-       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- data delivered ⇒ RTO backoff clears (fresh RTT sample recomputes RTO, RFC 6298 §2.2/2.3 + Karn)
+       then let fs1 = (advance attempt rtt fs) { fsConsecTO = 0 }  -- data delivered => fresh RTT samples clear the backoff (RFC 6298 §2.2/2.3 + Karn)
             in if fsBytesSent fs1 >= tpFileBytes tp
-                 -- final-window fast-retransmit: mid-transfer the fill RTT is absorbed by the
-                 -- next round's continued transmission (M0), but at the file tail nothing rides
-                 -- behind the hole, so the in-order prefix closes only when the retransmit lands
-                 -- ~1 RTT on — charge it (faithful Linux fast recovery; mechanics.md §4).
+                 -- final-window fast retransmit: mid-transfer the fill RTT is absorbed by
+                 -- the next round's continued transmission, but at the file tail nothing
+                 -- rides behind the hole, so the in-order prefix closes only when the
+                 -- retransmit lands ~1 RTT on -- charge it.
                  then (fs1 { fsT = fsT fs1 + rtt }, 1, g')
-                 else (cutOnLoss tp effCwnd fs1, 1, g')
+                 -- flight_size is the BDP-capped window rather than `attempt`: §4.6 warns
+                 -- that cutting from a short flight "would decrease cwnd to a much lower
+                 -- value than necessary", and `attempt` dips below the window only at the
+                 -- file tail.  The BDP cap is the "other measure" §4.6 asks of a
+                 -- cwnd-based implementation.
+                 else (onCongestionEvent tp Loss flight fs1, 1, g')
      else -- RTO
        let delivered = max 0 (firstLoss - 1)
            backoff   = (2 :: Int) ^ min (fsConsecTO fs) (30 :: Int)
            rto       = min (tpRtoMaxS tp) (max (tpRtoMinS tp) (tpBaseRtoS tp) * fromIntegral backoff)
            fs1 = fs { fsBytesSent = min (tpFileBytes tp) (fsBytesSent fs + delivered * mss)
                     , fsT = fsT fs + rto, fsConsecTO = fsConsecTO fs + 1 }
-       in (rtoCollapse effCwnd fs1, 1, g')
+       in (rtoCollapse tp flight fs1, 1, g')
   where
-    -- advance a delivering round; does NOT reset fsConsecTO itself — the caller
-    -- clears it on any data-delivering round (clean or fast-retransmit), since a
-    -- successful delivery draws fresh RTT samples and clears the RTO backoff
-    -- (a fresh RTT sample recomputes RTO, RFC 6298 §2.2/2.3 + Karn); only back-to-back timeouts keep the backoff.
-    advance pkts rtt' f =
-      let f1 = f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
-                 , fsT = fsT f + rtt' }
-      in if fsPhase f1 == CA then f1 { fsCaElapsed = fsCaElapsed f1 + rtt' } else f1
+    -- a delivering round: bytes and wall clock only.  The epoch clock belongs to
+    -- growOnAck, and fsConsecTO to the caller (cleared on any delivering round, since a
+    -- successful delivery draws fresh RTT samples; only back-to-back timeouts keep it).
+    advance pkts rtt' f = f { fsBytesSent = min (tpFileBytes tp) (fsBytesSent f + pkts * tpMss tp)
+                            , fsT = fsT f + rtt' }
 
 -- | Isolated single-flow completion: (download time s, effective loss events).
 flowTime :: RandomGen g => TcpParams -> g -> (Double, Int)
 flowTime tp = flowTimeFrom tp (initFlow tp)
 
--- | As 'flowTime' but from an arbitrary initial 'FlowState' — lets a caller start a transfer WARM (cwnd
--- already ramped, e.g. a continuous gossip link or a warm-idle node) instead of cold slow-start.
+-- | As 'flowTime' but from an arbitrary initial 'FlowState' -- lets a caller start a
+-- transfer WARM (cwnd already ramped) instead of cold slow-start.
 flowTimeFrom :: RandomGen g => TcpParams -> FlowState -> g -> (Double, Int)
 flowTimeFrom tp fs0 g0
   | tpFileBytes tp <= 0 = (0, 0)
   | otherwise           = loop fs0 { fsBytesSent = 0, fsT = 0 } 0 g0 (0 :: Int)
   where
-    loop fs nLoss g rounds
+    loop !fs !nLoss !g !rounds
       | fsBytesSent fs >= tpFileBytes tp = (fsT fs, nLoss)
       | rounds > 10000000                = (1/0, nLoss)
       | otherwise =
           let (fs', dl, g') = stepRound tp (tpRttS tp) (tpLossP tp) fs g
           in loop fs' (nLoss + dl) g' (rounds + 1)
-
--- | A warm flow at (near-)steady cwnd: ramped through slow-start to ssthresh and into congestion
--- avoidance, so a WARM transfer skips the cold slow-start penalty.  (Losses still cut it via CUBIC.)
-warmFlow :: TcpParams -> FlowState
-warmFlow tp = (initFlow tp) { fsCwnd = fromIntegral (tpBdpCapSegs tp), fsSsthresh = fromIntegral (tpBdpCapSegs tp)
-                            , fsPhase = CA, fsWMax = fromIntegral (tpBdpCapSegs tp) }


### PR DESCRIPTION
# Description

Claude assisted, human reviewed `SmallWorld.TCP` implementation (except the last two commits which fix two issues in the `SmallWorld.Diffusion`, only `SmallWorld.TCP` part of them I reviewed).  The `SmallWorld.Diffusion` module is just scary at the moment :dragon: :grin:.
     
- **smol-world: one RTO formula, from the measured estimator**
- **smol-world: feed the RFC 6298 estimator in the DES too**  
- **smol-world: RFC 6298 compatible RTO**
- **smol-world: refactored stepRound function**               
- **smol-world: Reno-friendly region**
- **smol-world: restructure the CUBIC core around RFC 9438**  
- **smol-world: fixed another warning**
- **smol-world: removed fsCubicOrigin**                       
- **smol-world: added type signature to avoid a warning**

## Relevant RFCs:

- [RFC 6298](https://www.rfc-editor.org/info/rfc6298) - TCP RTO timer 
- [RFC 9438](https://www.rfc-editor.org/info/rfc9438) - TCP CUBIC

# Checklist

### Quality
* [ ] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [ ] New tests are added and existing tests are updated.
* [ ] Self-reviewed the PR.

### Maintenance
* [ ] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
