### PR TITLE
object diffusion: more client agency for graceful termination, and make server idleness explicit

### DIFF
--- a/cardano-diffusion/protocols/cddl/Main.hs
+++ b/cardano-diffusion/protocols/cddl/Main.hs
@@ -912,8 +912,19 @@ unit_decodeObjectDiffusion spec =
     validateDecoder (Just indefiniteListFix)
       spec objectDiffusionCodec
       [ SomeAgency   ObjectDiffusion.SingInit
-      , SomeAgency $ ObjectDiffusion.SingObjectIds ObjectDiffusion.SingBlocking
-      , SomeAgency $ ObjectDiffusion.SingObjectIds ObjectDiffusion.SingNonBlocking
+      , SomeAgency $
+          ObjectDiffusion.SingObjectIds
+            ( ObjectDiffusion.SingObjectIdsBlocking
+                ObjectDiffusion.SingCanAwait
+            )
+      , SomeAgency $
+          ObjectDiffusion.SingObjectIds
+            ( ObjectDiffusion.SingObjectIdsBlocking
+                ObjectDiffusion.SingMustReply
+            )
+      , SomeAgency $
+          ObjectDiffusion.SingObjectIds
+            ObjectDiffusion.SingObjectIdsNonBlocking
       , SomeAgency   ObjectDiffusion.SingObjects
       , SomeAgency   ObjectDiffusion.SingIdle
       ]

--- a/cardano-diffusion/protocols/cddl/specs/object-diffusion.cddl
+++ b/cardano-diffusion/protocols/cddl/specs/object-diffusion.cddl
@@ -14,6 +14,7 @@ objectDiffusion2Message
     / msgRequestObjects
     / msgReplyObjects
     / msgDone
+    / msgServerIdle
 
 
 msgInit             = [0]
@@ -22,6 +23,7 @@ msgReplyObjectIds   = [2, objectIdList ]
 msgRequestObjects   = [3, objectIdList ]
 msgReplyObjects     = [4, objectList ]
 msgDone             = [5]
+msgServerIdle       = [6]
 
 tsBlocking          = false / true
 objectCount         = base.word16

--- a/cardano-diffusion/protocols/cddl/specs/object-diffusion.cddl
+++ b/cardano-diffusion/protocols/cddl/specs/object-diffusion.cddl
@@ -15,6 +15,7 @@ objectDiffusion2Message
     / msgReplyObjects
     / msgDone
     / msgServerIdle
+    / msgAwaitReply
 
 
 msgInit             = [0]
@@ -24,6 +25,7 @@ msgRequestObjects   = [3, objectIdList ]
 msgReplyObjects     = [4, objectList ]
 msgDone             = [5]
 msgServerIdle       = [6]
+msgAwaitReply       = [7]
 
 tsBlocking          = false / true
 objectCount         = base.word16

--- a/ouroboros-network/api/lib/Ouroboros/Network/PerasSupport.hs
+++ b/ouroboros-network/api/lib/Ouroboros/Network/PerasSupport.hs
@@ -10,6 +10,7 @@ module Ouroboros.Network.PerasSupport
 
 import Control.DeepSeq (NFData)
 import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
 
 -- | The flag which indicates whether the node can support Peras protocol.
 --
@@ -19,7 +20,7 @@ import GHC.Generics (Generic)
 
 data PerasSupport = PerasUnsupported | PerasSupported
   deriving stock    (Eq, Ord, Show, Bounded, Generic)
-  deriving anyclass (NFData)
+  deriving anyclass (NFData, NoThunks)
 
 
 perasSupportToBool :: PerasSupport -> Bool

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec.hs
@@ -151,6 +151,9 @@ encodeObjectDiffusion encodeObjectId encodeObject = encode
     encode MsgDone =
          CBOR.encodeListLen 1
       <> CBOR.encodeWord 5
+    encode MsgServerIdle =
+         CBOR.encodeListLen 1
+      <> CBOR.encodeWord 6
 
 decodeObjectDiffusion
   :: forall (objectId :: Type) (object :: Type)
@@ -218,6 +221,8 @@ decodeObjectDiffusion decodeObjectId decodeObject = decode
           return $ SomeMessage $ MsgReplyObjects objIds
         (SingIdle, 1, 5) ->
           return $ SomeMessage MsgDone
+        (SingObjectIds SingBlocking, 1, 6) ->
+          return $ SomeMessage MsgServerIdle
         (SingDone, _, _) -> notActiveState stok
         -- failures per protocol state
         (SingInit, _, _) ->
@@ -281,6 +286,8 @@ codecObjectDiffusionId = Codec {encode, decode}
           DecodeDone (SomeMessage msg) Nothing
         (SingObjectIds b, Just (AnyMessage msg)) -> case (b, msg) of
           (SingBlocking, MsgReplyObjectIds (BlockingReply {})) ->
+            DecodeDone (SomeMessage msg) Nothing
+          (SingBlocking, MsgServerIdle) ->
             DecodeDone (SomeMessage msg) Nothing
           (SingNonBlocking, MsgReplyObjectIds (NonBlockingReply {})) ->
             DecodeDone (SomeMessage msg) Nothing

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec.hs
@@ -23,6 +23,7 @@ import Control.Monad.Class.MonadTime.SI
 import Data.ByteString.Lazy (ByteString)
 import Data.Kind (Type)
 import Data.List.NonEmpty qualified as NonEmpty
+import Data.Singletons (withSingI)
 import Formatting (formatToString, (%+))
 import Formatting qualified as F
 import Network.TypedProtocol.Codec.CBOR
@@ -41,28 +42,29 @@ byteLimitsObjectDiffusion = ProtocolSizeLimits stateToLimit
          ActiveState st
       => StateToken st
       -> Word
-    stateToLimit SingInit                        = smallByteLimit
-    stateToLimit (SingObjectIds SingBlocking)    = largeByteLimit
-    stateToLimit (SingObjectIds SingNonBlocking) = largeByteLimit
-    stateToLimit SingObjects                     = largeByteLimit
-    stateToLimit SingIdle                        = smallByteLimit
-    stateToLimit a@SingDone                      = notActiveState a
+    stateToLimit SingInit          = smallByteLimit
+    stateToLimit (SingObjectIds _) = largeByteLimit
+    stateToLimit SingObjects       = largeByteLimit
+    stateToLimit SingIdle          = smallByteLimit
+    stateToLimit a@SingDone        = notActiveState a
 
 -- | 'ObjectDiffusion' time limits.
 --
--- +---------------------------------+---------------+
--- | 'ObjectDiffusion' state         | timeout (s)   |
--- +=================================+===============+
--- | `StInit`                        | `waitForever` |
--- +---------------------------------+---------------+
--- | `StIdle`                        | `waitForever` |
--- +---------------------------------+---------------+
--- | @'StObjectIds' 'StBlocking'@    | `waitForever` |
--- +---------------------------------+---------------+
--- | @'StObjectIds' 'StNonBlocking'@ | `shortWait`   |
--- +---------------------------------+---------------+
--- | `StObjects`                     | `shortWait`   |
--- +---------------------------------+---------------+
+-- +-------------------------------------------------------+---------------+
+-- | 'ObjectDiffusion' state                               | timeout (s)   |
+-- +=======================================================+===============+
+-- | `StInit`                                              | `waitForever` |
+-- +-------------------------------------------------------+---------------+
+-- | `StIdle`                                              | `waitForever` |
+-- +-------------------------------------------------------+---------------+
+-- | @'StObjectIds' 'StObjectIdsNonBlocking'@              | `shortWait`   |
+-- +-------------------------------------------------------+---------------+
+-- | @'StObjectIds' ('StObjectIdsBlocking' 'StCanAwait')@  | `shortWait`   |
+-- +-------------------------------------------------------+---------------+
+-- | @'StObjectIds' ('StObjectIdsBlocking' 'StMustReply')@ | `longWait`    |
+-- +-------------------------------------------------------+---------------+
+-- | `StObjects`                                           | `shortWait`   |
+-- +-------------------------------------------------------+---------------+
 timeLimitsObjectDiffusion
   :: forall (objectId :: Type) (object :: Type).
      ProtocolTimeLimits (ObjectDiffusion objectId object)
@@ -73,12 +75,13 @@ timeLimitsObjectDiffusion = ProtocolTimeLimits stateToLimit
          ActiveState st
       => StateToken st
       -> Maybe DiffTime
-    stateToLimit SingInit                        = waitForever
-    stateToLimit (SingObjectIds SingBlocking)    = waitForever
-    stateToLimit (SingObjectIds SingNonBlocking) = shortWait
-    stateToLimit SingObjects                     = shortWait
-    stateToLimit SingIdle                        = waitForever
-    stateToLimit a@SingDone                      = notActiveState a
+    stateToLimit SingInit = waitForever
+    stateToLimit (SingObjectIds SingObjectIdsNonBlocking) = shortWait
+    stateToLimit (SingObjectIds (SingObjectIdsBlocking SingCanAwait)) = shortWait
+    stateToLimit (SingObjectIds (SingObjectIdsBlocking SingMustReply)) = longWait
+    stateToLimit SingObjects = shortWait
+    stateToLimit SingIdle = waitForever
+    stateToLimit a@SingDone = notActiveState a
 
 codecObjectDiffusion
   :: forall (objectId :: Type) (object :: Type) m.
@@ -120,13 +123,13 @@ encodeObjectDiffusion encodeObjectId encodeObject = encode
     encode MsgInit =
          CBOR.encodeListLen 1
       <> CBOR.encodeWord 0
-    encode (MsgRequestObjectIds blocking (NumObjectIdsAck ackNo) (NumObjectIdsReq reqNo)) =
+    encode (MsgRequestObjectIds requestKind (NumObjectIdsAck ackNo) (NumObjectIdsReq reqNo)) =
          CBOR.encodeListLen 4
       <> CBOR.encodeWord 1
       <> CBOR.encodeBool
-           ( case blocking of
-               SingBlocking    -> True
-               SingNonBlocking -> False
+           ( case requestKind of
+               RequestObjectIdsBlocking    -> True
+               RequestObjectIdsNonBlocking -> False
            )
       <> CBOR.encodeWord16 ackNo
       <> CBOR.encodeWord16 reqNo
@@ -154,6 +157,9 @@ encodeObjectDiffusion encodeObjectId encodeObject = encode
     encode MsgServerIdle =
          CBOR.encodeListLen 1
       <> CBOR.encodeWord 6
+    encode MsgAwaitReply =
+         CBOR.encodeListLen 1
+      <> CBOR.encodeWord 7
 
 decodeObjectDiffusion
   :: forall (objectId :: Type) (object :: Type)
@@ -183,25 +189,25 @@ decodeObjectDiffusion decodeObjectId decodeObject = decode
           ackNo <- NumObjectIdsAck <$> CBOR.decodeWord16
           reqNo <- NumObjectIdsReq <$> CBOR.decodeWord16
           return $! if blocking
-            then SomeMessage $ MsgRequestObjectIds SingBlocking ackNo reqNo
-            else SomeMessage $ MsgRequestObjectIds SingNonBlocking ackNo reqNo
-        (SingObjectIds b, 2, 2) -> do
+            then SomeMessage $ MsgRequestObjectIds RequestObjectIdsBlocking ackNo reqNo
+            else SomeMessage $ MsgRequestObjectIds RequestObjectIdsNonBlocking ackNo reqNo
+        (SingObjectIds kind, 2, 2) -> withSingI kind $ do
           CBOR.decodeListLenIndef
           objIds <- CBOR.decodeSequenceLenIndef
                       (flip (:))
                       []
                       reverse
                       decodeObjectId
-          case (b, objIds) of
-            (SingBlocking, t : ts) ->
+          case (kind, objIds) of
+            (SingObjectIdsBlocking _, t : ts) ->
               return
                 $ SomeMessage
                 $ MsgReplyObjectIds (BlockingReply (t NonEmpty.:| ts))
-            (SingNonBlocking, ts) ->
+            (SingObjectIdsNonBlocking, ts) ->
               return
                 $ SomeMessage
                 $ MsgReplyObjectIds (NonBlockingReply ts)
-            (SingBlocking, []) ->
+            (SingObjectIdsBlocking _, []) ->
               fail "codecObjectDiffusion: MsgReplyObjectIds: empty list not permitted"
         (SingIdle, 2, 3) -> do
           CBOR.decodeListLenIndef
@@ -221,15 +227,15 @@ decodeObjectDiffusion decodeObjectId decodeObject = decode
           return $ SomeMessage $ MsgReplyObjects objIds
         (SingIdle, 1, 5) ->
           return $ SomeMessage MsgDone
-        (SingObjectIds SingBlocking, 1, 6) ->
+        (SingObjectIds (SingObjectIdsBlocking SingMustReply), 1, 6) ->
           return $ SomeMessage MsgServerIdle
+        (SingObjectIds (SingObjectIdsBlocking SingCanAwait), 1, 7) ->
+          return $ SomeMessage MsgAwaitReply
         (SingDone, _, _) -> notActiveState stok
         -- failures per protocol state
         (SingInit, _, _) ->
           fail (formatToString fmterr (activeAgency :: ActiveAgency st') stok key len)
-        (SingObjectIds SingBlocking, _, _) ->
-          fail (formatToString fmterr (activeAgency :: ActiveAgency st') stok key len)
-        (SingObjectIds SingNonBlocking, _, _) ->
+        (SingObjectIds _, _, _) ->
           fail (formatToString fmterr (activeAgency :: ActiveAgency st') stok key len)
         (SingObjects, _, _) ->
           fail (formatToString fmterr (activeAgency :: ActiveAgency st') stok key len)
@@ -276,23 +282,30 @@ codecObjectDiffusionId = Codec {encode, decode}
       return $ case (stok, bytes) of
         (SingInit, Just (AnyMessage msg@MsgInit)) ->
           DecodeDone (SomeMessage msg) Nothing
-        (SingIdle, Just (AnyMessage msg@(MsgRequestObjectIds SingBlocking _ _))) ->
+        (SingIdle, Just (AnyMessage msg@(MsgRequestObjectIds RequestObjectIdsBlocking _ _))) ->
           DecodeDone (SomeMessage msg) Nothing
-        (SingIdle, Just (AnyMessage msg@(MsgRequestObjectIds SingNonBlocking _ _))) ->
+        (SingIdle, Just (AnyMessage msg@(MsgRequestObjectIds RequestObjectIdsNonBlocking _ _))) ->
           DecodeDone (SomeMessage msg) Nothing
         (SingIdle, Just (AnyMessage msg@(MsgRequestObjects {}))) ->
           DecodeDone (SomeMessage msg) Nothing
         (SingObjects, Just (AnyMessage msg@(MsgReplyObjects {}))) ->
           DecodeDone (SomeMessage msg) Nothing
-        (SingObjectIds b, Just (AnyMessage msg)) -> case (b, msg) of
-          (SingBlocking, MsgReplyObjectIds (BlockingReply {})) ->
-            DecodeDone (SomeMessage msg) Nothing
-          (SingBlocking, MsgServerIdle) ->
-            DecodeDone (SomeMessage msg) Nothing
-          (SingNonBlocking, MsgReplyObjectIds (NonBlockingReply {})) ->
-            DecodeDone (SomeMessage msg) Nothing
-          (_, _) ->
-            DecodeFail $ CodecFailure "codecObjectDiffusionId: no matching message"
+        (SingObjectIds kind, Just (AnyMessage msg)) -> withSingI kind $
+          case (kind, msg) of
+            (SingObjectIdsBlocking _, MsgReplyObjectIds (BlockingReply objectIds)) ->
+              DecodeDone
+                (SomeMessage (MsgReplyObjectIds (BlockingReply objectIds)))
+                Nothing
+            (SingObjectIdsBlocking SingCanAwait, MsgAwaitReply) ->
+              DecodeDone (SomeMessage MsgAwaitReply) Nothing
+            (SingObjectIdsBlocking SingMustReply, MsgServerIdle) ->
+              DecodeDone (SomeMessage MsgServerIdle) Nothing
+            (SingObjectIdsNonBlocking, MsgReplyObjectIds (NonBlockingReply objectIds)) ->
+              DecodeDone
+                (SomeMessage (MsgReplyObjectIds (NonBlockingReply objectIds)))
+                Nothing
+            (_, _) ->
+              DecodeFail $ CodecFailure "codecObjectDiffusionId: no matching message"
         (SingIdle, Just (AnyMessage msg@MsgDone)) ->
           DecodeDone (SomeMessage msg) Nothing
         (SingDone, _) ->

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Inbound.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Inbound.hs
@@ -48,6 +48,7 @@ data InboundStIdle (n :: N) objectId object m a where
   SendMsgRequestObjectIdsBlocking
     :: NumObjectIdsAck -- ^ number of objectIds to acknowledge
     -> NumObjectIdsReq -- ^ number of objectIds to request
+    -> m () -- ^ promptly invoked on receiving 'MsgAwaitReply'
     -> (NonEmpty objectId -> InboundStIdle Z objectId object m a)
     -> InboundStIdle Z objectId object m a
     -> InboundStIdle Z objectId object m a
@@ -73,7 +74,7 @@ data InboundStIdle (n :: N) objectId object m a where
 -- | Transform a 'ObjectDiffusionInboundPipelined' into a 'PeerPipelined'.
 objectDiffusionInboundPeerPipelined
   :: forall objectId object m a.
-     (Functor m)
+     Functor m
   => ObjectDiffusionInboundPipelined objectId object m a
   -> PeerPipelined (ObjectDiffusion objectId object) AsClient StInit m a
 objectDiffusionInboundPeerPipelined (ObjectDiffusionInboundPipelined inboundSt) =
@@ -83,17 +84,23 @@ objectDiffusionInboundPeerPipelined (ObjectDiffusionInboundPipelined inboundSt) 
       :: InboundStIdle n objectId object m a
       -> Peer (ObjectDiffusion objectId object) AsClient (Pipelined n (Collect objectId object)) StIdle m a
 
-    run (SendMsgRequestObjectIdsBlocking ackNo reqNo k onServerIdle) =
-          Yield (MsgRequestObjectIds SingBlocking ackNo reqNo)
+    run (SendMsgRequestObjectIdsBlocking ackNo reqNo onAwaitReply k onServerIdle) =
+          Yield (MsgRequestObjectIds RequestObjectIdsBlocking ackNo reqNo)
             $ Await
             $ \case
                 MsgReplyObjectIds (BlockingReply objectIds) ->
                   run (k objectIds)
-                MsgServerIdle ->
-                  run onServerIdle
+                MsgAwaitReply ->
+                  Effect $
+                    (Await $ \case
+                      MsgReplyObjectIds (BlockingReply objectIds) ->
+                        run (k objectIds)
+                      MsgServerIdle ->
+                        run onServerIdle
+                    ) <$ onAwaitReply
     run (SendMsgRequestObjectIdsPipelined ackNo reqNo k) =
           YieldPipelined
-            (MsgRequestObjectIds SingNonBlocking ackNo reqNo)
+            (MsgRequestObjectIds RequestObjectIdsNonBlocking ackNo reqNo)
             (ReceiverAwait
               $ \(MsgReplyObjectIds (NonBlockingReply objectIds)) ->
                   ReceiverDone (CollectObjectIds reqNo objectIds)

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Inbound.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Inbound.hs
@@ -50,6 +50,7 @@ data InboundStIdle (n :: N) objectId object m a where
     -> NumObjectIdsReq -- ^ number of objectIds to request
     -> (NonEmpty objectId -> InboundStIdle Z objectId object m a)
     -> InboundStIdle Z objectId object m a
+    -> InboundStIdle Z objectId object m a
   SendMsgRequestObjectIdsPipelined
     :: NumObjectIdsAck
     -> NumObjectIdsReq
@@ -82,12 +83,14 @@ objectDiffusionInboundPeerPipelined (ObjectDiffusionInboundPipelined inboundSt) 
       :: InboundStIdle n objectId object m a
       -> Peer (ObjectDiffusion objectId object) AsClient (Pipelined n (Collect objectId object)) StIdle m a
 
-    run (SendMsgRequestObjectIdsBlocking ackNo reqNo k) =
+    run (SendMsgRequestObjectIdsBlocking ackNo reqNo k onServerIdle) =
           Yield (MsgRequestObjectIds SingBlocking ackNo reqNo)
             $ Await
             $ \case
                 MsgReplyObjectIds (BlockingReply objectIds) ->
                   run (k objectIds)
+                MsgServerIdle ->
+                  run onServerIdle
     run (SendMsgRequestObjectIdsPipelined ackNo reqNo k) =
           YieldPipelined
             (MsgRequestObjectIds SingNonBlocking ackNo reqNo)

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Outbound.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Outbound.hs
@@ -61,6 +61,9 @@ data OutboundStObjectIds blocking objectId object m a where
     :: BlockingReplyList blocking objectId
     -> OutboundStIdle objectId object m a
     -> OutboundStObjectIds blocking objectId object m a
+  SendMsgServerIdle
+    :: OutboundStIdle objectId object m a
+    -> OutboundStObjectIds 'StBlocking objectId object m a
 
 data OutboundStObjects objectId object m a where
   SendMsgReplyObjects
@@ -86,6 +89,11 @@ objectDiffusionOutboundPeer (ObjectDiffusionOutbound outboundSt) =
         MsgRequestObjectIds blocking ackNo reqNo -> Effect $ do
           reply <- recvMsgRequestObjectIds blocking ackNo reqNo
           case reply of
+            SendMsgServerIdle k ->
+              return $
+                Yield
+                  MsgServerIdle
+                  (run k)
             SendMsgReplyObjectIds objectIds k ->
               -- TODO: investigate why GHC cannot infer `SingI`; it used to in
               -- `coot/typed-protocols-rewrite` branch

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Outbound.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Outbound.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE EmptyCase           #-}
 {-# LANGUAGE GADTs               #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE LambdaCase          #-}
@@ -24,6 +25,7 @@ module Ouroboros.Network.Protocol.ObjectDiffusion.Outbound
   , objectDiffusionOutboundPeer
   ) where
 
+import Data.Singletons (withSingI)
 import Network.TypedProtocol.Core
 import Network.TypedProtocol.Peer (Peer)
 import Network.TypedProtocol.Peer.Server
@@ -46,24 +48,27 @@ newtype ObjectDiffusionOutbound objectId object m a = ObjectDiffusionOutbound {
 --
 -- It must be prepared to handle any of these.
 data OutboundStIdle objectId object m a = OutboundStIdle {
-      recvMsgRequestObjectIds :: forall blocking.
-                                 SingBlockingStyle blocking
+      recvMsgRequestObjectIds :: forall kind.
+                                 ObjectIdsRequestKind kind
                               -> NumObjectIdsAck
                               -> NumObjectIdsReq
-                              -> m (OutboundStObjectIds blocking objectId object m a),
+                              -> m (OutboundStObjectIds kind objectId object m a),
       recvMsgRequestObjects   :: [objectId]
                               -> m (OutboundStObjects objectId object m a),
       recvMsgDone             :: m a
     }
 
-data OutboundStObjectIds blocking objectId object m a where
+data OutboundStObjectIds kind objectId object m a where
   SendMsgReplyObjectIds
-    :: BlockingReplyList blocking objectId
+    :: ObjectIdsReplyList kind objectId
     -> OutboundStIdle objectId object m a
-    -> OutboundStObjectIds blocking objectId object m a
+    -> OutboundStObjectIds kind objectId object m a
+  SendMsgAwaitReply
+    :: m (OutboundStObjectIds ('StObjectIdsBlocking 'StMustReply) objectId object m a)
+    -> OutboundStObjectIds ('StObjectIdsBlocking 'StCanAwait) objectId object m a
   SendMsgServerIdle
     :: OutboundStIdle objectId object m a
-    -> OutboundStObjectIds 'StBlocking objectId object m a
+    -> OutboundStObjectIds ('StObjectIdsBlocking 'StMustReply) objectId object m a
 
 data OutboundStObjects objectId object m a where
   SendMsgReplyObjects
@@ -86,26 +91,33 @@ objectDiffusionOutboundPeer (ObjectDiffusionOutbound outboundSt) =
       -> Peer (ObjectDiffusion objectId object) AsServer NonPipelined StIdle m a
     run OutboundStIdle {recvMsgRequestObjectIds, recvMsgRequestObjects, recvMsgDone} =
       Await $ \case
-        MsgRequestObjectIds blocking ackNo reqNo -> Effect $ do
-          reply <- recvMsgRequestObjectIds blocking ackNo reqNo
-          case reply of
-            SendMsgServerIdle k ->
-              return $
-                Yield
-                  MsgServerIdle
-                  (run k)
-            SendMsgReplyObjectIds objectIds k ->
-              -- TODO: investigate why GHC cannot infer `SingI`; it used to in
-              -- `coot/typed-protocols-rewrite` branch
-              return $ case blocking of
-                SingBlocking ->
+        MsgRequestObjectIds requestKind ackNo reqNo ->
+          withSingI (singObjectIdsRequestKind requestKind) $ Effect $ do
+            reply <- recvMsgRequestObjectIds requestKind ackNo reqNo
+            case reply of
+              SendMsgAwaitReply waitForReply ->
+                return $
+                  Yield
+                    MsgAwaitReply
+                    (Effect $ do
+                      finalReply <- waitForReply
+                      pure $ case finalReply of
+                        SendMsgServerIdle k ->
+                          Yield MsgServerIdle (run k)
+                        SendMsgReplyObjectIds objectIds k ->
+                          Yield (MsgReplyObjectIds objectIds) (run k))
+              SendMsgReplyObjectIds objectIds k ->
+                return $
                   Yield
                     (MsgReplyObjectIds objectIds)
                     (run k)
-                SingNonBlocking ->
-                  Yield
-                    (MsgReplyObjectIds objectIds)
-                    (run k)
+              -- Matching 'SendMsgServerIdle' refines @kind@ to the blocking
+              -- 'StMustReply' state, but 'ObjectIdsRequestKind' has no
+              -- constructor for that state. A request can only enter the
+              -- non-blocking state or blocking 'StCanAwait'; 'StMustReply' is
+              -- reached later by sending 'MsgAwaitReply'. The empty case
+              -- discharges this statically impossible branch.
+              SendMsgServerIdle _ -> case requestKind of {}
         MsgRequestObjects objectIds -> Effect $ do
           SendMsgReplyObjects objects k <- recvMsgRequestObjects objectIds
           return $

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Type.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Type.hs
@@ -176,10 +176,11 @@ instance Protocol (ObjectDiffusion objectId object) where
     -- | Request a list of object identifiers from the server, and confirm a
     -- number of outstanding object identifiers.
     --
-    -- With 'TokBlocking' this is a blocking operation: the response will always
-    -- have at least one object identifier, and it does not expect a prompt
-    -- response: there is no timeout. This covers the case when there is nothing
-    -- else to do but wait.
+    -- With 'TokBlocking' this is a blocking operation: the response will either
+    -- have at least one object identifier, or be a 'MsgServerIdle'. This covers
+    -- the case when there is nothing else to do but wait. 'MsgServerIdle'
+    -- periodically returns agency to the client so it can react to control
+    -- messages while remaining caught up.
     --
     -- With 'TokNonBlocking' this is a non-blocking operation: the response may
     -- be an empty list and this does expect a prompt response. This covers high
@@ -233,6 +234,15 @@ instance Protocol (ObjectDiffusion objectId object) where
     MsgReplyObjectIds
       :: BlockingReplyList blocking objectId
       -> Message (ObjectDiffusion objectId object) (StObjectIds blocking) StIdle
+    -- | The server has no object identifiers after its current cursor.
+    --
+    -- This response is only valid for a blocking request. It returns agency to
+    -- the client, which can terminate or immediately issue another blocking
+    -- request. In the latter case the protocol remains a continuous wait for
+    -- new objects, without a client-side polling delay.
+
+    MsgServerIdle
+      :: Message (ObjectDiffusion objectId object) (StObjectIds 'StBlocking) StIdle
     -- | Request one or more objects corresponding to the given object
     -- identifiers.
     --
@@ -283,6 +293,7 @@ instance ( NFData objectId
   rnf MsgInit                          = ()
   rnf (MsgRequestObjectIds tkbs w1 w2) = rnf tkbs `seq` rnf w1 `seq` rnf w2
   rnf (MsgReplyObjectIds brl)          = rnf brl
+  rnf MsgServerIdle                    = ()
   rnf (MsgRequestObjects objIds)       = rnf objIds
   rnf (MsgReplyObjects objects)        = rnf objects
   rnf MsgDone                          = ()

--- a/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Type.hs
+++ b/ouroboros-network/protocols/lib/Ouroboros/Network/Protocol/ObjectDiffusion/Type.hs
@@ -17,28 +17,31 @@
 module Ouroboros.Network.Protocol.ObjectDiffusion.Type
   ( ObjectDiffusion (..)
   , Message (..)
+  , ObjectIdsReplyList (..)
+  , ObjectIdsRequestKind (..)
+  , singObjectIdsRequestKind
   , SingObjectDiffusion (..)
+  , SingStObjectIdsKind (..)
+  , SingStObjectIdsPhase (..)
+  , StObjectIdsKind (..)
+  , StObjectIdsPhase (..)
   , NumObjectIdsAck (..)
   , NumObjectIdsReq (..)
   , NumObjectsReq (..)
   , NumObjectsUnacknowledged (..)
     -- re-exports
-  , BlockingReplyList (..)
-  , SingBlockingStyle (..)
   , SizeInBytes (..)
-  , StBlockingStyle (..)
   ) where
 
 import Control.DeepSeq (NFData (..))
 import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty)
 import Data.Monoid (Sum (..))
 import Data.Singletons
 import Data.Word (Word16)
 import GHC.Generics (Generic)
 import Network.TypedProtocol.Core
 import NoThunks.Class (NoThunks (..))
-import Ouroboros.Network.Protocol.TxSubmission2.Type (BlockingReplyList (..),
-           SingBlockingStyle (..), StBlockingStyle (..))
 import Ouroboros.Network.SizeInBytes (SizeInBytes (..))
 import Ouroboros.Network.Util.ShowProxy (ShowProxy (..))
 import Quiet (Quiet (..))
@@ -61,8 +64,12 @@ data ObjectDiffusion objectId object where
   -- | The outbound node has agency; it must reply with a list of object
   -- identifiers that it wishes to submit.
   --
-  -- There are two sub-states for this, for blocking and non-blocking cases.
-  StObjectIds :: StBlockingStyle -> ObjectDiffusion objectId object
+  -- A non-blocking request has one prompt reply state. A blocking request has
+  -- two phases, distinguishing the prompt reply state from the state entered
+  -- after the server has reported that it must await new objects.
+  StObjectIds
+    :: StObjectIdsKind
+    -> ObjectDiffusion objectId object
   -- | The outbound node has agency; it must reply with the list of
   -- objects.
   StObjects   :: ObjectDiffusion objectId object
@@ -84,14 +91,50 @@ instance ( ShowProxy objectId
 instance ShowProxy (StIdle :: ObjectDiffusion objectId object) where
   showProxy _ = "StIdle"
 
+-- | The two phases of a blocking object-ID reply.
+data StObjectIdsPhase = StCanAwait | StMustReply
+
+data SingStObjectIdsPhase (phase :: StObjectIdsPhase) where
+  SingCanAwait :: SingStObjectIdsPhase 'StCanAwait
+  SingMustReply :: SingStObjectIdsPhase 'StMustReply
+
+deriving instance Show (SingStObjectIdsPhase phase)
+
+type instance Sing = SingStObjectIdsPhase
+
+instance SingI 'StCanAwait where sing = SingCanAwait
+instance SingI 'StMustReply where sing = SingMustReply
+
+-- | The three legal object-ID reply states. Only blocking replies have an
+-- await phase.
+data StObjectIdsKind
+  = StObjectIdsNonBlocking
+  | StObjectIdsBlocking StObjectIdsPhase
+
+data SingStObjectIdsKind (kind :: StObjectIdsKind) where
+  SingObjectIdsNonBlocking
+    :: SingStObjectIdsKind 'StObjectIdsNonBlocking
+  SingObjectIdsBlocking
+    :: SingStObjectIdsPhase phase
+    -> SingStObjectIdsKind ('StObjectIdsBlocking phase)
+
+deriving instance Show (SingStObjectIdsKind kind)
+
+type instance Sing = SingStObjectIdsKind
+
+instance SingI 'StObjectIdsNonBlocking where
+  sing = SingObjectIdsNonBlocking
+instance SingI phase => SingI ('StObjectIdsBlocking phase) where
+  sing = SingObjectIdsBlocking sing
+
 type SingObjectDiffusion
   :: ObjectDiffusion objectId object
   -> Type
 data SingObjectDiffusion k where
   SingInit      :: SingObjectDiffusion StInit
   SingIdle      :: SingObjectDiffusion StIdle
-  SingObjectIds :: SingBlockingStyle stBlocking
-                -> SingObjectDiffusion (StObjectIds stBlocking)
+  SingObjectIds :: SingStObjectIdsKind kind
+                -> SingObjectDiffusion (StObjectIds kind)
   SingObjects   :: SingObjectDiffusion StObjects
   SingDone      :: SingObjectDiffusion StDone
 
@@ -99,8 +142,7 @@ deriving instance Show (SingObjectDiffusion k)
 
 instance StateTokenI StInit where stateToken = SingInit
 instance StateTokenI StIdle where stateToken = SingIdle
-instance (SingI stBlocking)
-      => StateTokenI (StObjectIds stBlocking) where
+instance SingI kind => StateTokenI (StObjectIds kind) where
   stateToken = SingObjectIds sing
 instance StateTokenI StObjects where stateToken = SingObjects
 instance StateTokenI StDone where stateToken = SingDone
@@ -133,6 +175,48 @@ newtype NumObjectsUnacknowledged = NumObjectsUnacknowledged {getNumObjectsUnackn
   deriving (Semigroup) via (Sum Word16)
   deriving (Monoid)    via (Sum Word16)
   deriving (Show)      via (Quiet NumObjectsUnacknowledged)
+
+-- | The two legal object-ID request kinds, indexed by the state in which the
+-- server must reply.
+data ObjectIdsRequestKind (kind :: StObjectIdsKind) where
+  RequestObjectIdsNonBlocking
+    :: ObjectIdsRequestKind 'StObjectIdsNonBlocking
+  RequestObjectIdsBlocking
+    :: ObjectIdsRequestKind ('StObjectIdsBlocking 'StCanAwait)
+
+deriving instance Eq (ObjectIdsRequestKind kind)
+deriving instance Show (ObjectIdsRequestKind kind)
+
+instance NFData (ObjectIdsRequestKind kind) where
+  rnf RequestObjectIdsNonBlocking = ()
+  rnf RequestObjectIdsBlocking    = ()
+
+singObjectIdsRequestKind
+  :: ObjectIdsRequestKind kind
+  -> SingStObjectIdsKind kind
+singObjectIdsRequestKind RequestObjectIdsNonBlocking =
+  SingObjectIdsNonBlocking
+singObjectIdsRequestKind RequestObjectIdsBlocking =
+  SingObjectIdsBlocking SingCanAwait
+
+-- | Object-ID replies indexed by the protocol state in which they can be
+-- sent. Blocking replies are non-empty and valid in either blocking phase;
+-- non-blocking replies may be empty.
+data ObjectIdsReplyList (kind :: StObjectIdsKind) a where
+  BlockingReply
+    :: NonEmpty a
+    -> ObjectIdsReplyList ('StObjectIdsBlocking phase) a
+  NonBlockingReply
+    :: [a]
+    -> ObjectIdsReplyList 'StObjectIdsNonBlocking a
+
+deriving instance Eq a => Eq (ObjectIdsReplyList kind a)
+deriving instance Show a => Show (ObjectIdsReplyList kind a)
+deriving instance Foldable (ObjectIdsReplyList kind)
+
+instance NFData a => NFData (ObjectIdsReplyList kind a) where
+  rnf (BlockingReply values)    = rnf values
+  rnf (NonBlockingReply values) = rnf values
 
 
 -- | There are some constraints of the protocol that are not captured in the
@@ -176,24 +260,24 @@ instance Protocol (ObjectDiffusion objectId object) where
     -- | Request a list of object identifiers from the server, and confirm a
     -- number of outstanding object identifiers.
     --
-    -- With 'TokBlocking' this is a blocking operation: the response will either
-    -- have at least one object identifier, or be a 'MsgServerIdle'. This covers
-    -- the case when there is nothing else to do but wait. 'MsgServerIdle'
-    -- periodically returns agency to the client so it can react to control
-    -- messages while remaining caught up.
+    -- With 'RequestObjectIdsBlocking' this is a blocking operation: the server
+    -- either replies promptly with at least one object identifier or sends
+    -- 'MsgAwaitReply'. After 'MsgAwaitReply', it waits for new objects and
+    -- eventually replies with identifiers or 'MsgServerIdle'.
     --
-    -- With 'TokNonBlocking' this is a non-blocking operation: the response may
-    -- be an empty list and this does expect a prompt response. This covers high
-    -- throughput use cases where we wish to pipeline, by interleaving requests
-    -- for additional object identifiers with requests for objects, which
-    -- requires these requests not block.
+    -- With 'RequestObjectIdsNonBlocking' this is a non-blocking operation: the
+    -- response may be an empty list and this does expect a prompt response.
+    -- This covers high throughput use cases where we wish to pipeline, by
+    -- interleaving requests for additional object identifiers with requests
+    -- for objects, which requires these requests not block.
     --
     -- The request gives the maximum number of object identifiers that can be
     -- accepted in the response. This must be greater than zero in the
-    -- 'TokBlocking' case. In the 'TokNonBlocking' case either the numbers
-    -- acknowledged or the number requested __MUST__ be non-zero. In either
-    -- case, the number requested __MUST__ not put the total outstanding over
-    -- the fixed protocol limit.
+    -- 'RequestObjectIdsBlocking' case. In the
+    -- 'RequestObjectIdsNonBlocking' case either the numbers acknowledged or
+    -- the number requested __MUST__ be non-zero. In either case, the number
+    -- requested __MUST__ not put the total outstanding over the fixed protocol
+    -- limit.
     --
     -- The request also gives the number of outstanding object identifiers that
     -- can now be acknowledged. The actual objects to acknowledge are known to
@@ -211,18 +295,19 @@ instance Protocol (ObjectDiffusion objectId object) where
     --   remaining unacknowledged objects.
 
     MsgRequestObjectIds
-      :: forall (blocking :: StBlockingStyle) objectId object.
-         SingBlockingStyle blocking
+      :: forall (kind :: StObjectIdsKind) objectId object.
+         ObjectIdsRequestKind kind
       -> NumObjectIdsAck -- ^ Acknowledge this number of outstanding objects
       -> NumObjectIdsReq -- ^ Request up to this number of object ids
-      -> Message (ObjectDiffusion objectId object) StIdle (StObjectIds blocking)
+      -> Message (ObjectDiffusion objectId object) StIdle (StObjectIds kind)
     -- | Reply with a list of object identifiers for available objects, along
     -- with the size of each object.
     --
     -- The list must not be longer than the maximum number requested.
     --
-    -- In the 'StObjectIds' 'Blocking' state the list must be non-empty while in
-    -- the 'StObjectIds' 'NonBlocking' state the list may be empty.
+    -- In a @'StObjectIds' ('StObjectIdsBlocking' phase)@ state the list must be
+    -- non-empty, while in @'StObjectIds' 'StObjectIdsNonBlocking'@ it may be
+    -- empty.
     --
     -- These objects are added to the notional FIFO of outstanding object
     -- identifiers for the protocol.
@@ -232,9 +317,21 @@ instance Protocol (ObjectDiffusion objectId object) where
     -- objects.
 
     MsgReplyObjectIds
-      :: BlockingReplyList blocking objectId
-      -> Message (ObjectDiffusion objectId object) (StObjectIds blocking) StIdle
-    -- | The server has no object identifiers after its current cursor.
+      :: ObjectIdsReplyList kind objectId
+      -> Message (ObjectDiffusion objectId object) (StObjectIds kind) StIdle
+    -- | The server has no object identifiers immediately available after its
+    -- current cursor, so it will await new objects.
+    --
+    -- This message is the prompt per-peer caught-up observation. The server
+    -- retains agency and must subsequently reply with non-empty object IDs or
+    -- 'MsgServerIdle'.
+
+    MsgAwaitReply
+      :: Message
+           (ObjectDiffusion objectId object)
+           (StObjectIds ('StObjectIdsBlocking 'StCanAwait))
+           (StObjectIds ('StObjectIdsBlocking 'StMustReply))
+    -- | The server still has no object identifiers after a bounded wait.
     --
     -- This response is only valid for a blocking request. It returns agency to
     -- the client, which can terminate or immediately issue another blocking
@@ -242,7 +339,10 @@ instance Protocol (ObjectDiffusion objectId object) where
     -- new objects, without a client-side polling delay.
 
     MsgServerIdle
-      :: Message (ObjectDiffusion objectId object) (StObjectIds 'StBlocking) StIdle
+      :: Message
+           (ObjectDiffusion objectId object)
+           (StObjectIds ('StObjectIdsBlocking 'StMustReply))
+           StIdle
     -- | Request one or more objects corresponding to the given object
     -- identifiers.
     --
@@ -278,11 +378,11 @@ instance Protocol (ObjectDiffusion objectId object) where
     MsgDone
       :: Message (ObjectDiffusion objectId object) StIdle StDone
 
-  type StateAgency StInit          = ClientAgency
-  type StateAgency StIdle          = ClientAgency
-  type StateAgency (StObjectIds b) = ServerAgency
-  type StateAgency StObjects       = ServerAgency
-  type StateAgency StDone          = NobodyAgency
+  type StateAgency StInit             = ClientAgency
+  type StateAgency StIdle             = ClientAgency
+  type StateAgency (StObjectIds kind) = ServerAgency
+  type StateAgency StObjects          = ServerAgency
+  type StateAgency StDone             = NobodyAgency
 
   type StateToken = SingObjectDiffusion
 
@@ -293,6 +393,7 @@ instance ( NFData objectId
   rnf MsgInit                          = ()
   rnf (MsgRequestObjectIds tkbs w1 w2) = rnf tkbs `seq` rnf w1 `seq` rnf w2
   rnf (MsgReplyObjectIds brl)          = rnf brl
+  rnf MsgAwaitReply                    = ()
   rnf MsgServerIdle                    = ()
   rnf (MsgRequestObjects objIds)       = rnf objIds
   rnf (MsgReplyObjects objects)        = rnf objects

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec/CDDL.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec/CDDL.hs
@@ -22,11 +22,6 @@ import Test.Data.CDDL (Any (..))
 import Test.QuickCheck (Arbitrary)
 
 -- | Simple wrapper around 'Any' matching @objectId = any@ in the CDDL spec.
--- This is intentionally different from the 'ObjectId' in
--- 'ObjectDiffusion.Test', which wraps @Maybe Word64@.
--- TODO: Change that test wrapper to @Word64@ now that @MsgServerIdle@
--- represents the caught-up state explicitly; @Maybe@ was only needed for the
--- sentinel.
 --
 newtype ObjectId = ObjectId Any
   deriving (Eq, Ord, Show, Arbitrary, Serialise, Generic, NFData)

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec/CDDL.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Codec/CDDL.hs
@@ -23,7 +23,10 @@ import Test.QuickCheck (Arbitrary)
 
 -- | Simple wrapper around 'Any' matching @objectId = any@ in the CDDL spec.
 -- This is intentionally different from the 'ObjectId' in
--- 'ObjectDiffusion.Test' which wraps @Maybe Word64@ for the caught-up sentinel.
+-- 'ObjectDiffusion.Test', which wraps @Maybe Word64@.
+-- TODO: Change that test wrapper to @Word64@ now that @MsgServerIdle@
+-- represents the caught-up state explicitly; @Maybe@ was only needed for the
+-- sentinel.
 --
 newtype ObjectId = ObjectId Any
   deriving (Eq, Ord, Show, Arbitrary, Serialise, Generic, NFData)

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Direct.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Direct.hs
@@ -12,8 +12,8 @@ import Network.TypedProtocol.Proofs (Queue (..), enqueue)
 
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
 import Ouroboros.Network.Protocol.ObjectDiffusion.Outbound
-import Ouroboros.Network.Protocol.ObjectDiffusion.Type (BlockingReplyList (..),
-           SingBlockingStyle (..))
+import Ouroboros.Network.Protocol.ObjectDiffusion.Type (ObjectIdsReplyList (..),
+           ObjectIdsRequestKind (..))
 
 directPipelined
   :: forall objectId object m a b.
@@ -31,19 +31,26 @@ directPipelined (ObjectDiffusionOutbound mOutbound)
                  -> InboundStIdle n objectId object m b
                  -> OutboundStIdle  objectId object m a
                  -> m b
-    directSender q (SendMsgRequestObjectIdsBlocking ackNo reqNo inboundNext inboundIdle)
+    directSender q (SendMsgRequestObjectIdsBlocking ackNo reqNo inboundAwait inboundNext inboundIdle)
                    OutboundStIdle{recvMsgRequestObjectIds} = do
-      reply <- recvMsgRequestObjectIds SingBlocking ackNo reqNo
+      reply <- recvMsgRequestObjectIds RequestObjectIdsBlocking ackNo reqNo
       case reply of
         SendMsgReplyObjectIds (BlockingReply objectIds) outbound' -> do
           let inbound' = inboundNext objectIds
           directSender q inbound' outbound'
-        SendMsgServerIdle outbound' ->
-          directSender q inboundIdle outbound'
+        SendMsgAwaitReply waitForReply -> do
+          inboundAwait
+          finalReply <- waitForReply
+          case finalReply of
+            SendMsgReplyObjectIds (BlockingReply objectIds) outbound' -> do
+              let inbound' = inboundNext objectIds
+              directSender q inbound' outbound'
+            SendMsgServerIdle outbound' ->
+              directSender q inboundIdle outbound'
 
     directSender q (SendMsgRequestObjectIdsPipelined ackNo reqNo inbound')
                    OutboundStIdle{recvMsgRequestObjectIds} = do
-      reply <- recvMsgRequestObjectIds SingNonBlocking ackNo reqNo
+      reply <- recvMsgRequestObjectIds RequestObjectIdsNonBlocking ackNo reqNo
       case reply of
         SendMsgReplyObjectIds (NonBlockingReply objectIds) outbound' -> do
           directSender (enqueue (CollectObjectIds reqNo objectIds) q) inbound' outbound'

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Direct.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Direct.hs
@@ -31,13 +31,15 @@ directPipelined (ObjectDiffusionOutbound mOutbound)
                  -> InboundStIdle n objectId object m b
                  -> OutboundStIdle  objectId object m a
                  -> m b
-    directSender q (SendMsgRequestObjectIdsBlocking ackNo reqNo inboundNext)
+    directSender q (SendMsgRequestObjectIdsBlocking ackNo reqNo inboundNext inboundIdle)
                    OutboundStIdle{recvMsgRequestObjectIds} = do
       reply <- recvMsgRequestObjectIds SingBlocking ackNo reqNo
       case reply of
         SendMsgReplyObjectIds (BlockingReply objectIds) outbound' -> do
           let inbound' = inboundNext objectIds
           directSender q inbound' outbound'
+        SendMsgServerIdle outbound' ->
+          directSender q inboundIdle outbound'
 
     directSender q (SendMsgRequestObjectIdsPipelined ackNo reqNo inbound')
                    OutboundStIdle{recvMsgRequestObjectIds} = do

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Examples.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Examples.hs
@@ -11,7 +11,6 @@ module Ouroboros.Network.Protocol.ObjectDiffusion.Examples
   , testObjectDiffusionInbound
   , InboundState (..)
   , initialInboundState
-  , WithCaughtUpDetection (..)
   ) where
 
 
@@ -26,7 +25,7 @@ import Control.Exception (assert)
 import Control.Monad (when)
 import Control.Tracer (Tracer, traceWith)
 import Data.Foldable qualified as Foldable
-import Data.List.NonEmpty (NonEmpty (..))
+import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -35,40 +34,6 @@ import Data.Sequence.Strict qualified as Seq
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Word (Word16)
-
--- | This helper typeclass allows the inbound and outbound tests implementation
--- to finish the protocol gracefully when all the desired objects have been sent.
---
--- | Normally, the outbound side should always respond with a non-empty list of
--- object IDs to a blocking request, but instead it can respond with the
--- 'caughtUpSentinel' (still inhabiting 'NonEmpty objectId') to indicate that
--- there are no more objects to send, and the inbound side can use 'ifCaughtUp'
--- to detect this and terminate the protocol gracefully.
---
--- | This suggests that the concrete type used for 'objectId' has some special
--- values that are not actually valid object IDs, but are used to signal this
--- condition. This is a bit hacky, but it allows us to keep the example
--- implementations simple and focused on the pipelining aspect, without having
--- to introduce additional protocol messages or state to handle termination.
-class Eq objectId => WithCaughtUpDetection objectId where
-  -- | This is a special value that the outbound implementation can use to
-  -- signal to the inbound implementation that there are no more objects to send.
-  -- This ought to be a value that uses non-normal object IDs, but still
-  -- inhabits 'NonEmpty objectId'.
-  caughtUpSentinel :: NonEmpty objectId
-
-  -- | This is a helper function used in the inbound implementation to terminate
-  -- the protocol gracefully when all objects that the outbound peer wanted to
-  -- send have actually been sent.
-  ifCaughtUp
-    :: InboundStIdle 'Z objectId object m a
-    -> (NonEmpty objectId -> InboundStIdle 'Z objectId object m a)
-    -> NonEmpty objectId
-    -> InboundStIdle 'Z objectId object m a
-  ifCaughtUp fCaughtUp fElse objectIds =
-    if objectIds == caughtUpSentinel
-       then fCaughtUp
-       else fElse objectIds
 
 --
 -- Outbound implementation
@@ -91,7 +56,7 @@ data TraceObjectDiffusionTestImplem objectId object =
 
 testObjectDiffusionOutbound
   :: forall objectId object m.
-     (Ord objectId, Show objectId, Monad m, WithCaughtUpDetection objectId)
+     (Ord objectId, Show objectId, Monad m)
   => Tracer m (TraceObjectDiffusionTestImplem objectId object)
   -> (object -> objectId)
   -> Word16  -- ^ Maximum number of unacknowledged object IDs allowed
@@ -162,15 +127,7 @@ testObjectDiffusionOutbound tracer objectId maxUnacked =
 
             return $! case (blocking, unackedExtra) of
               (SingBlocking, []) ->
-                -- | In the production-ready implementation that lives in
-                -- `ouroboros-consensus`, we would block on waiting new objects
-                -- from the ObjectPool here.
-                -- But in this test implementation, we use 'caughtUpSentinel'
-                -- to signal that there are no more objects to send, so the
-                -- inbound side knows it is caught-up and can terminate the
-                -- protocol gracefully.
-                SendMsgReplyObjectIds
-                  (BlockingReply caughtUpSentinel)
+                SendMsgServerIdle
                   (outboundIdle unackedSeq'' unackedMap'' remainingObjects')
 
               (SingBlocking, obj : objs) ->
@@ -225,7 +182,7 @@ initialInboundState = InboundState 0 Seq.empty Set.empty Map.empty 0
 
 testObjectDiffusionInbound
   :: forall objectId object m.
-     (Ord objectId, WithCaughtUpDetection objectId)
+     (Ord objectId)
   => Tracer m (TraceObjectDiffusionTestImplem objectId object)
   -> (object -> objectId)
   -> Word16  -- ^ Maximum number of unacknowledged object IDs allowed
@@ -264,18 +221,13 @@ testObjectDiffusionInbound
         SendMsgRequestObjectIdsBlocking
           (numObjectsToAcknowledge st)
           numObjectIdsToRequest
-          -- We use 'ifCaughtUp' here to detect if the outbound side ha
-          -- signaled that there are no more objects to send, in which case we
-          -- terminate the protocol gracefully using 'SendMsgDone'.
-          (ifCaughtUp
-            (SendMsgDone accum)
-            (handleReply accum Zero st {
+          (handleReply accum Zero st {
                     numObjectsToAcknowledge    = 0,
                     requestedObjectIdsInFlight = numObjectIdsToRequest
                   }
                   . CollectObjectIds numObjectIdsToRequest
                   . NonEmpty.toList)
-          )
+          (SendMsgDone accum)
 
     inboundIdle accum (Succ n) st
         -- We have replies in flight and we should eagerly collect them if

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Examples.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Examples.hs
@@ -18,8 +18,9 @@ import Network.TypedProtocol.Core
 
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
 import Ouroboros.Network.Protocol.ObjectDiffusion.Outbound
-import Ouroboros.Network.Protocol.ObjectDiffusion.Type (BlockingReplyList (..),
-           NumObjectIdsAck (..), NumObjectIdsReq (..), SingBlockingStyle (..))
+import Ouroboros.Network.Protocol.ObjectDiffusion.Type (NumObjectIdsAck (..),
+           NumObjectIdsReq (..), ObjectIdsReplyList (..),
+           ObjectIdsRequestKind (..))
 
 import Control.Exception (assert)
 import Control.Monad (when)
@@ -83,12 +84,12 @@ testObjectDiffusionOutbound tracer objectId maxUnacked =
               unackedMap
               (Map.fromList [ (x, ()) | x <- Foldable.toList unackedSeq ])
 
-          recvMsgRequestObjectIds :: forall blocking.
-                                     SingBlockingStyle blocking
+          recvMsgRequestObjectIds :: forall kind.
+                                     ObjectIdsRequestKind kind
                                   -> NumObjectIdsAck
                                   -> NumObjectIdsReq
-                                  -> m (OutboundStObjectIds blocking objectId object m ())
-          recvMsgRequestObjectIds blocking ackNo reqNo = do
+                                  -> m (OutboundStObjectIds kind objectId object m ())
+          recvMsgRequestObjectIds requestKind ackNo reqNo = do
             traceWith tracer $
               EventRecvMsgRequestObjectIds
                 unackedSeq unackedMap remainingObjects ackNo reqNo
@@ -108,8 +109,8 @@ testObjectDiffusionOutbound tracer objectId maxUnacked =
                 unackedMap' = Foldable.foldl' (flip Map.delete) unackedMap
                                 (Seq.take (fromIntegral ackNo) unackedSeq)
 
-            case blocking of
-              SingBlocking | not (Seq.null unackedSeq')
+            case requestKind of
+              RequestObjectIdsBlocking | not (Seq.null unackedSeq')
                 -> error $ "testObjectDiffusionOutbound.recvMsgRequestObjectIds: "
                         <> "peer made a blocking request for more object IDs when "
                         <> "there are still unacknowledged object IDs."
@@ -125,17 +126,18 @@ testObjectDiffusionOutbound tracer objectId maxUnacked =
                                                  | obj <- unackedExtra ]
                 remainingObjects' = drop (fromIntegral reqNo) remainingObjects
 
-            return $! case (blocking, unackedExtra) of
-              (SingBlocking, []) ->
-                SendMsgServerIdle
-                  (outboundIdle unackedSeq'' unackedMap'' remainingObjects')
+            return $! case (requestKind, unackedExtra) of
+              (RequestObjectIdsBlocking, []) ->
+                SendMsgAwaitReply $ pure $
+                  SendMsgServerIdle
+                    (outboundIdle unackedSeq'' unackedMap'' remainingObjects')
 
-              (SingBlocking, obj : objs) ->
+              (RequestObjectIdsBlocking, obj : objs) ->
                 SendMsgReplyObjectIds
                   (BlockingReply (fmap objectId (obj :| objs)))
                   (outboundIdle unackedSeq'' unackedMap'' remainingObjects')
 
-              (SingNonBlocking, objs) ->
+              (RequestObjectIdsNonBlocking, objs) ->
                 SendMsgReplyObjectIds
                   (NonBlockingReply (fmap objectId objs))
                   (outboundIdle unackedSeq'' unackedMap'' remainingObjects')
@@ -182,7 +184,7 @@ initialInboundState = InboundState 0 Seq.empty Set.empty Map.empty 0
 
 testObjectDiffusionInbound
   :: forall objectId object m.
-     (Ord objectId)
+     (Ord objectId, Applicative m)
   => Tracer m (TraceObjectDiffusionTestImplem objectId object)
   -> (object -> objectId)
   -> Word16  -- ^ Maximum number of unacknowledged object IDs allowed
@@ -221,6 +223,7 @@ testObjectDiffusionInbound
         SendMsgRequestObjectIdsBlocking
           (numObjectsToAcknowledge st)
           numObjectIdsToRequest
+          (pure ())
           (handleReply accum Zero st {
                     numObjectsToAcknowledge    = 0,
                     requestedObjectIdsInFlight = numObjectIdsToRequest

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Test.hs
@@ -111,11 +111,8 @@ newtype Object = Object { getObjectId :: ObjectId }
 instance ShowProxy Object where
     showProxy _ = "Object"
 
-newtype ObjectId = ObjectId (Maybe Word64)
-  deriving (Eq, Ord, Show, Serialise, Generic, NFData)
-
-instance Arbitrary ObjectId where
-  arbitrary = ObjectId <$> arbitrary
+newtype ObjectId = ObjectId Word64
+  deriving (Eq, Ord, Show, Arbitrary, Serialise, Generic, NFData)
 
 instance ShowProxy ObjectId where
     showProxy _ = "ObjectId"
@@ -128,31 +125,53 @@ instance (Arbitrary objectId, Arbitrary object)
   arbitrary = oneof
     [ pure $ AnyMessage MsgInit
     , AnyMessage
-        <$> ( MsgRequestObjectIds SingBlocking
+        <$> ( MsgRequestObjectIds RequestObjectIdsBlocking
             <$> arbitrary
             <*> arbitrary
             )
 
     , AnyMessage
-        <$> ( MsgRequestObjectIds SingNonBlocking
+        <$> ( MsgRequestObjectIds RequestObjectIdsNonBlocking
             <$> arbitrary
             <*> arbitrary
             )
 
-    , AnyMessage
-        <$> MsgReplyObjectIds
-        <$> ( BlockingReply
-            . NonEmpty.fromList
-            . QC.getNonEmpty
+    , ( \objectIds ->
+          AnyMessage
+            ( MsgReplyObjectIds (BlockingReply objectIds)
+                :: Message
+                    (ObjectDiffusion objectId object)
+                    (StObjectIds ('StObjectIdsBlocking 'StCanAwait))
+                    StIdle
             )
-        <$> arbitrary
+      )
+        <$> (NonEmpty.fromList . QC.getNonEmpty <$> arbitrary)
 
-    , AnyMessage
-        <$> MsgReplyObjectIds
-        <$> NonBlockingReply
+    , ( \objectIds ->
+          AnyMessage
+            ( MsgReplyObjectIds (BlockingReply objectIds)
+                :: Message
+                    (ObjectDiffusion objectId object)
+                    (StObjectIds ('StObjectIdsBlocking 'StMustReply))
+                    StIdle
+            )
+      )
+        <$> (NonEmpty.fromList . QC.getNonEmpty <$> arbitrary)
+
+    , ( \objectIds ->
+          AnyMessage
+            ( MsgReplyObjectIds (NonBlockingReply objectIds)
+                :: Message
+                    (ObjectDiffusion objectId object)
+                    (StObjectIds 'StObjectIdsNonBlocking)
+                    StIdle
+            )
+      )
         <$> arbitrary
 
     , pure $ AnyMessage MsgServerIdle
+
+    , pure $ AnyMessage MsgAwaitReply
 
     , AnyMessage
         <$> MsgRequestObjects
@@ -172,12 +191,12 @@ instance (Eq objectId, Eq object)
   (==) (AnyMessage MsgInit)
        (AnyMessage MsgInit) = True
 
-  (==) (AnyMessage (MsgRequestObjectIds SingBlocking ackNo  reqNo))
-       (AnyMessage (MsgRequestObjectIds SingBlocking ackNo' reqNo')) =
+  (==) (AnyMessage (MsgRequestObjectIds RequestObjectIdsBlocking ackNo  reqNo))
+       (AnyMessage (MsgRequestObjectIds RequestObjectIdsBlocking ackNo' reqNo')) =
     (ackNo, reqNo) == (ackNo', reqNo')
 
-  (==) (AnyMessage (MsgRequestObjectIds SingNonBlocking ackNo  reqNo))
-       (AnyMessage (MsgRequestObjectIds SingNonBlocking ackNo' reqNo')) =
+  (==) (AnyMessage (MsgRequestObjectIds RequestObjectIdsNonBlocking ackNo  reqNo))
+       (AnyMessage (MsgRequestObjectIds RequestObjectIdsNonBlocking ackNo' reqNo')) =
     (ackNo, reqNo) == (ackNo', reqNo')
 
   (==) (AnyMessage (MsgReplyObjectIds (BlockingReply objectIds)))
@@ -190,6 +209,9 @@ instance (Eq objectId, Eq object)
 
   (==) (AnyMessage MsgServerIdle)
        (AnyMessage MsgServerIdle) = True
+
+  (==) (AnyMessage MsgAwaitReply)
+       (AnyMessage MsgAwaitReply) = True
 
   (==) (AnyMessage (MsgRequestObjects objectIds))
        (AnyMessage (MsgRequestObjects objectIds')) = objectIds == objectIds'
@@ -266,6 +288,7 @@ labelMsg (AnyMessage msg) =
            MsgInit                -> "MsgInit"
            MsgRequestObjectIds {} -> "MsgRequestObjectIds"
            MsgReplyObjectIds as   -> "MsgReplyObjectIds " ++ renderRanges 3 (length as)
+           MsgAwaitReply          -> "MsgAwaitReply"
            MsgServerIdle          -> "MsgServerIdle"
            MsgRequestObjects as   -> "MsgRequestObjects " ++ renderRanges 3 (length as)
            MsgReplyObjects as     -> "MsgReplyObjects "   ++ renderRanges 3 (length as)
@@ -302,7 +325,8 @@ positiveWord16ToNat :: ChannelSize -> Natural
 positiveWord16ToNat (Positive (Small n)) = fromIntegral n
 
 testInboundPipelined
-  :: Tracer m (TraceObjectDiffusionTestImplem ObjectId Object)
+  :: Applicative m
+  => Tracer m (TraceObjectDiffusionTestImplem ObjectId Object)
   -> ObjectDiffusionTestParams
   -> ObjectDiffusionInboundPipelined ObjectId Object m [Object]
 testInboundPipelined

--- a/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Test.hs
+++ b/ouroboros-network/protocols/tests-lib/Ouroboros/Network/Protocol/ObjectDiffusion/Test.hs
@@ -23,7 +23,6 @@ module Ouroboros.Network.Protocol.ObjectDiffusion.Test
 
 import Control.Monad (void)
 import Data.ByteString.Lazy (ByteString)
-import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.List.NonEmpty qualified as NonEmpty
 
 import Control.Monad.Class.MonadAsync (MonadAsync)
@@ -61,8 +60,8 @@ import GHC.Generics
 import GHC.Natural (Natural)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Direct (directPipelined)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Examples
-           (TraceObjectDiffusionTestImplem, WithCaughtUpDetection (..),
-           testObjectDiffusionInbound, testObjectDiffusionOutbound)
+           (TraceObjectDiffusionTestImplem, testObjectDiffusionInbound,
+           testObjectDiffusionOutbound)
 import Ouroboros.Network.Protocol.ObjectDiffusion.Inbound
            (ObjectDiffusionInboundPipelined,
            objectDiffusionInboundPeerPipelined)
@@ -116,11 +115,7 @@ newtype ObjectId = ObjectId (Maybe Word64)
   deriving (Eq, Ord, Show, Serialise, Generic, NFData)
 
 instance Arbitrary ObjectId where
-  -- | We never generate the `Nothing` variant, since it is reserved for the sentinel value used to detect that the peer is caught up.
-  arbitrary = ObjectId . Just <$> arbitrary
-
-instance WithCaughtUpDetection ObjectId where
-  caughtUpSentinel = ObjectId Nothing :| []
+  arbitrary = ObjectId <$> arbitrary
 
 instance ShowProxy ObjectId where
     showProxy _ = "ObjectId"
@@ -157,6 +152,8 @@ instance (Arbitrary objectId, Arbitrary object)
         <$> NonBlockingReply
         <$> arbitrary
 
+    , pure $ AnyMessage MsgServerIdle
+
     , AnyMessage
         <$> MsgRequestObjects
         <$> arbitrary
@@ -190,6 +187,9 @@ instance (Eq objectId, Eq object)
   (==) (AnyMessage (MsgReplyObjectIds (NonBlockingReply objectIds)))
        (AnyMessage (MsgReplyObjectIds (NonBlockingReply objectIds'))) =
     objectIds == objectIds'
+
+  (==) (AnyMessage MsgServerIdle)
+       (AnyMessage MsgServerIdle) = True
 
   (==) (AnyMessage (MsgRequestObjects objectIds))
        (AnyMessage (MsgRequestObjects objectIds')) = objectIds == objectIds'
@@ -266,6 +266,7 @@ labelMsg (AnyMessage msg) =
            MsgInit                -> "MsgInit"
            MsgRequestObjectIds {} -> "MsgRequestObjectIds"
            MsgReplyObjectIds as   -> "MsgReplyObjectIds " ++ renderRanges 3 (length as)
+           MsgServerIdle          -> "MsgServerIdle"
            MsgRequestObjects as   -> "MsgRequestObjects " ++ renderRanges 3 (length as)
            MsgReplyObjects as     -> "MsgReplyObjects "   ++ renderRanges 3 (length as)
            MsgDone                -> "MsgDone"


### PR DESCRIPTION
# Description

Supports https://github.com/IntersectMBO/ouroboros-consensus/pull/2286.

## 1. Support graceful Object Diffusion termination

introduce `MsgServerIdle` to regularly return agency to the client from an idle server so the client can gracefully terminate the protocol as needed for https://github.com/tweag/cardano-peras/issues/187<table style="table-layout: fixed;"><tr><td><img src="https://github.com/user-attachments/assets/437b975b-b76e-45ae-a521-399faf2adc11"></td><td><img src="https://github.com/user-attachments/assets/30a307df-a54c-4b18-ad4e-844fa1011bd7"></td></tr><tr><td>before</td><td>after</td></tr></table>

## 2. Make Object Diffusion server idleness explicit

split `StObjectIds Blocking` into 2 states to make idleness of the server explicit so the client can decide if it has caught up or not as needed for https://github.com/tweag/cardano-peras/issues/144<table style="table-layout: fixed;"><tr><td><img src="https://github.com/user-attachments/assets/30a307df-a54c-4b18-ad4e-844fa1011bd7"></td><td><img src="https://github.com/user-attachments/assets/f9087e09-44e1-484c-806c-43be53274584"></td></tr><tr><td>before</td><td>after</td></tr></table>

## 3. default `NoThunks` instance for `Ouroboros.Network.PerasSupport.PerasSupport`



# Checklist

### Quality
* [x] Commit sequence makes sense and have useful messages, see [ref][contrib#git-history].
* [x] New tests are added and existing tests are updated.
* [x] Self-reviewed the PR.

### Maintenance
* [x] Linked an [issue][link-issue] or added the PR to the current sprint of [`ouroboros-network`][project] project.
* [ ] Added labels.
* [ ] Updated changelog files.
* [ ] The documentation has been properly updated, see [ref][contrib#documentation].

[project]: https://github.com/orgs/IntersectMBO/projects/5/views/1
[link-issue]: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=
[contrib#git-history]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#git-history
[contrib#documentation]: https://github.com/IntersectMBO/ouroboros-network/blob/master/CONTRIBUTING.md#documentation
